### PR TITLE
add source_ref to mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,12 +1,15 @@
 defmodule Tesla.Mixfile do
   use Mix.Project
 
+  @version "1.2.0"
+
   def project do
     [
       app: :tesla,
-      version: "1.2.0",
+      version: @version,
       description: description(),
       package: package(),
+      source_ref: "v#{@version}",
       source_url: "https://github.com/teamon/tesla",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
At the moment every "view source" link in hexdocs leads to master branch. After this change these links will refer to specific tag in github.