### PR TITLE
Unify configuration

### DIFF
--- a/lib/tesla/middleware/config.ex
+++ b/lib/tesla/middleware/config.ex
@@ -1,0 +1,58 @@
+defmodule Tesla.Middleware.Config do
+  @moduledoc false
+
+  def build!(middleware, schema, opts) do
+    global_keys =
+      schema
+      |> Enum.filter(fn {_k, v} -> v[:global] == true end)
+      |> Enum.map(fn {k, _v} -> k end)
+
+    :tesla
+    |> Application.get_env(middleware, [])
+    |> Keyword.take(global_keys)
+    |> Keyword.merge(opts)
+    |> NimbleOptions.validate(to_nimble(schema))
+    |> handle_validate(middleware)
+  end
+
+  def docs(schema) do
+    schema
+    |> to_nimble()
+    |> NimbleOptions.docs()
+  end
+
+  defp to_nimble(schema) do
+    Enum.map(schema, fn {k, v} ->
+      {global, value} = Keyword.pop(v, :global, false)
+
+      if global == true do
+        {k,
+         Keyword.update(value, :doc, "", fn doc ->
+           doc <> " Configurable via application configuration."
+         end)}
+      else
+        {k, value}
+      end
+    end)
+  end
+
+  defp handle_validate({:ok, opts}, _middleware), do: opts
+
+  defp handle_validate({:error, error}, middleware) do
+    raise ArgumentError, format_error(error, middleware)
+  end
+
+  defp format_error(%NimbleOptions.ValidationError{keys_path: [], message: message}, middleware) do
+    "invalid configuration given to middleware #{inspect(middleware)}, " <> message
+  end
+
+  defp format_error(
+         %NimbleOptions.ValidationError{keys_path: keys_path, message: message},
+         middleware
+       ) do
+    "invalid configuration given to to middleware #{inspect(middleware)} for key #{
+      inspect(keys_path)
+    }, " <>
+      message
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -52,6 +52,7 @@ defmodule Tesla.Mixfile do
   defp deps do
     [
       {:mime, "~> 1.0"},
+      {:nimble_options, "~> 0.3.0"},
 
       # http clients
       {:ibrowse, "~> 4.4.0", optional: true},


### PR DESCRIPTION
Implementation of  #234

This is a draft of the implementation, I'm opening to check if the approach makes sense. cc: @teamon 

## Proposed solution

Use [nimble_options](https://hex.pm/packages/nimble_options) to validate the opts given to a middleware. For a option to be fetched from Application Configuration, it needs to set `global: true` in the `config_schema` of the middleware.

It follows a clear precedence of first fetching from application and then overriding with the configuration given directly as options to the middleware. It also always fetches the configuration in runtime.

Based on the schema a documentation for the options is generated:

![Screenshot_2021-05-17 Tesla Middleware Logger — tesla v1 4 1](https://user-images.githubusercontent.com/13632762/118561800-f40a3900-b741-11eb-934c-11b5984eb25a.png)

## TODO

- [ ] Documentation
- [ ] Unit Tests
- [ ] Use in all middlewares