### PR TITLE
Document the plug behavior of runtime function evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ client |> GitHub.user_repos("teamon")
 client |> GitHub.get("/me")
 ```
 
+However, if insted of a pure String you use a function call that is evaluated at run time and works: `plug Tesla.Middleware.Headers, [{"authorization", get_api_key()}]`
+
 ## Adapters
 
 Tesla supports multiple HTTP adapter that do the actual HTTP request processing.

--- a/lib/tesla/builder.ex
+++ b/lib/tesla/builder.ex
@@ -84,6 +84,11 @@ defmodule Tesla.Builder do
   @doc """
   Attach middleware to your API client.
 
+  Notice that this has one important difference to Plug's plug that you might be used to.
+  Here `opts` aren't passed by value but as the AST and evaluated at run time.
+  This means, while you can't pass a secret string directly, you can call a function that
+  retrieves the secret and it will be called at run time.
+
   ```
   defmodule ExampleApi do
     use Tesla
@@ -96,6 +101,9 @@ defmodule Tesla.Builder do
 
     # or a custom middleware
     plug MyProject.CustomMiddleware
+
+    # or pass a function to get the token
+    plug Tesla.Middleware.Headers, [{"authorization", get_api_key()}]
   end
   """
 


### PR DESCRIPTION
First of all, thanks a lot for Tesla - it's a joy to work with! 💚 

This confused us a lot when working with Tesla. The docs don't
seem to mention but it does work (we are using it and tried
out it's behavior, the function are definitely called at run
time and well the implementation uses `Macro.escape`).

As some feedback, as mentioned this behavior was irritating to us. I do this here vs. a separate issue as I believe it's intended and as we at version 1.x+ breaking compatibility would of course be bad. However, this design is confusing imo because:

* it works differently from the known `plug` usage
* looking at the code, it looks like it'd be run at compile time and hence be wrong, "magic" makes it not be wrong
* if this is intended behvaior, I feel like passing in the reference to a function (`&get_api_key/0`) would be a better way to accomplish this vs. calling the function but not really now `get_api_key()`


Anyhow, thanks a lot for all of your work, you're really helping the elixir community 💚 🎉 🙌 

![IMG_20180518_161925_01](https://user-images.githubusercontent.com/606517/125597133-4c37d347-4ea1-4be9-bafd-fa3bda6963e3.jpg)
