### PR TITLE
Update missing encodeJson middleware in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,11 @@ use Tesla, except: [:delete, :options]
 ```elixir
 use Tesla, docs: false
 ```
+### Encode only JSON request (do not decode response)
+
+```elixir
+plug Tesla.Middleware.EncodeJson
+```
 
 ### Decode only JSON response (do not encode request)
 


### PR DESCRIPTION
Looking at the code I found the middleware but was also confused why it existed. The decode was documented, not the encode. so clearing the confusion