### PR TITLE
Update Tesla.Middleware documentation with functioning example code

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -89,32 +89,19 @@ defmodule Tesla.Middleware do
 
   ### Examples
 
-      defmodule MyProject.InspectHeadersMiddleware do
-        @behaviour Tesla.Middleware
+    defmodule MyProject.InspectHeadersMiddleware do
+      @behaviour Tesla.Middleware
 
-        @impl Tesla.Middleware
-        def call(env, next, options) do
-          env
-          |> pre_inspect_headers(options)
-          |> Tesla.run(next)
-          |> post_inspect_headers(options)
-        end
+      @impl true
+      def call(env, next, options) do
+        IO.inspect(env.headers, options)
 
-        # Prior to Tesla.run you must return the Tesla.Env arg
-        defp pre_inspect_headers(env, options) do
+        with {:ok, env} <- Tesla.run(env, next) do
           IO.inspect(env.headers, options)
-
-          env
-        end
-
-        # Post Tesla.run function must match the :ok/:error tuple
-        # and return the same
-        defp post_inspect_headers({_, env} = result, options) do
-          IO.inspect(env.headers, options)
-
-          result
+          {:ok, env}
         end
       end
+    end
 
   """
 

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -95,13 +95,24 @@ defmodule Tesla.Middleware do
         @impl Tesla.Middleware
         def call(env, next, options) do
           env
-          |> inspect_headers(options)
+          |> pre_inspect_headers(options)
           |> Tesla.run(next)
-          |> inspect_headers(options)
+          |> post_inspect_headers(options)
         end
 
-        defp inspect_headers(env, options) do
+        # Prior to Tesla.run you must return the Tesla.Env arg
+        defp pre_inspect_headers(env, options) do
           IO.inspect(env.headers, options)
+
+          env
+        end
+
+        # Post Tesla.run function must match the :ok/:error tuple
+        # and return the same
+        defp post_inspect_headers({_, env} = result, options) do
+          IO.inspect(env.headers, options)
+
+          result
         end
       end
 


### PR DESCRIPTION
The current [example code](https://hexdocs.pm/tesla/Tesla.Middleware.html#module-examples) in the Tesla.Middleware documentation will not work as it is. The `inspect_headers` function does not return the `env` arg, which is what `Tesla.run` expects as the first arg. This results in this confusing error:

```** (ArgumentError) you attempted to apply a function named :opts on []. If you are using Kernel.apply/3, make sure the module is an atom. If you are using the dot syntax, such as map.field or module.function(), make sure the left side of the dot is an atom or a map```

In addition, the result of running the HTTP request will be an :ok/:error tuple, not the bare `Tesla.env` struct, so you need a different function (or different args) to handle that case.

Happy to tweak the approach here if desired but it seems like it would be ideal for example code to work correctly.