### PR TITLE
middleware example: print out both headers and options

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -94,10 +94,10 @@ defmodule Tesla.Middleware do
 
       @impl true
       def call(env, next, options) do
-        IO.inspect(env.headers, options)
+        IO.inspect(headers: env.headers, options: options)
 
         with {:ok, env} <- Tesla.run(env, next) do
-          IO.inspect(env.headers, options)
+          IO.inspect(headers: env.headers, options: options)
           {:ok, env}
         end
       end


### PR DESCRIPTION
I was looking at https://hexdocs.pm/tesla/Tesla.Middleware.html docs that were for 1.4.4 and noticed that the middleware example doesn't work. I wanted to fix it, but noticed that here on GitHub this code is already updated, but it still has some issues. I can imagine that originally it was indeed intended to use middleware options as options for `IO.inspect/2` but I am more inclined to believe that options were passed to IO.inspect just so the compiler wouldn't complain about the unused variable :) so I think it would be better to either print the options out or just remove them completely and replace them with `_options`.

p.s. the first time I'm contributing to this project. So I will use this opportunity to say that your library is very cool and I'm happy using it :)