### PR TITLE
refactor: `import Bitwise` instead of `use Bitwise`

### DIFF
--- a/lib/tesla/middleware/retry.ex
+++ b/lib/tesla/middleware/retry.ex
@@ -47,8 +47,8 @@ defmodule Tesla.Middleware.Retry do
       (float between 0 and 1, defaults to 0.2)
   """
 
-  # Not necessary in Elixir 1.10+
-  use Bitwise, skip_operators: true
+  # Not necessary in Elixir 1.14+
+  import Bitwise
 
   @behaviour Tesla.Middleware
 


### PR DESCRIPTION
Fixes deprecation warning in elixir 1.14.0

```
warning: use Bitwise is deprecated. import Bitwise instead
  lib/tesla/middleware/retry.ex:51: Tesla.Middleware.Retry
```