### PR TITLE
fix httpc bodyless methods

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,6 +18,4 @@ if Mix.env() == :test do
     sasl_error_logger: false
 
   config :tesla, MockClient, adapter: Tesla.Mock
-
-  config :tesla, Tesla.Adapter.Mint, cacert: ["./deps/httparrot/priv/ssl/server-ca.crt"]
 end

--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -69,6 +69,12 @@ defmodule Tesla.Adapter.Httpc do
     :httpc.request(method, {url, headers}, http_opts, opts)
   end
 
+  # These methods aren't able to contain a content_type and body
+  defp request(method, url, headers, _content_type, _body, {http_opts, opts})
+       when method in [:get, :options, :head, :trace] do
+    :httpc.request(method, {url, headers}, http_opts, opts)
+  end
+
   defp request(method, url, headers, _content_type, %Multipart{} = mp, opts) do
     headers = headers ++ Multipart.headers(mp)
     headers = for {key, value} <- headers, do: {to_charlist(key), to_charlist(value)}

--- a/lib/tesla/builder.ex
+++ b/lib/tesla/builder.ex
@@ -214,7 +214,7 @@ defmodule Tesla.Builder do
       for bang <- [:safe, :bang],
           client <- [:client, :noclient],
           opts <- [:opts, :noopts],
-          method in only && not (method in except) do
+          method in only && method not in except do
         gen(method, bang, client, opts, docs)
       end
     end

--- a/lib/tesla/middleware/follow_redirects.ex
+++ b/lib/tesla/middleware/follow_redirects.ex
@@ -31,7 +31,7 @@ defmodule Tesla.Middleware.FollowRedirects do
 
   defp redirect(env, next, left) when left == 0 do
     case Tesla.run(env, next) do
-      {:ok, %{status: status} = env} when not (status in @redirect_statuses) ->
+      {:ok, %{status: status} = env} when status not in @redirect_statuses ->
         {:ok, env}
 
       {:ok, _env} ->

--- a/lib/tesla/middleware/method_override.ex
+++ b/lib/tesla/middleware/method_override.ex
@@ -44,7 +44,7 @@ defmodule Tesla.Middleware.MethodOverride do
     if opts[:override] do
       env.method in opts[:override]
     else
-      not (env.method in [:get, :post])
+      env.method not in [:get, :post]
     end
   end
 end

--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -9,7 +9,7 @@ defmodule Tesla.Adapter.GunTest do
   use Tesla.AdapterCase.SSL,
     certificates_verification: true,
     transport_opts: [
-      cacertfile: "#{:code.priv_dir(:httparrot)}/ssl/server-ca.crt"
+      cacertfile: Path.join([to_string(:code.priv_dir(:httparrot)), "/ssl/server-ca.crt"])
     ]
 
   alias Tesla.Adapter.Gun

--- a/test/tesla/adapter/hackney_test.exs
+++ b/test/tesla/adapter/hackney_test.exs
@@ -9,7 +9,7 @@ defmodule Tesla.Adapter.HackneyTest do
   use Tesla.AdapterCase.SSL,
     ssl_options: [
       verify: :verify_peer,
-      cacertfile: "#{:code.priv_dir(:httparrot)}/ssl/server-ca.crt"
+      cacertfile: Path.join([to_string(:code.priv_dir(:httparrot)), "/ssl/server-ca.crt"])
     ]
 
   alias Tesla.Env

--- a/test/tesla/adapter/httpc_test.exs
+++ b/test/tesla/adapter/httpc_test.exs
@@ -9,7 +9,7 @@ defmodule Tesla.Adapter.HttpcTest do
   use Tesla.AdapterCase.SSL,
     ssl: [
       verify: :verify_peer,
-      cacertfile: "#{:code.priv_dir(:httparrot)}/ssl/server-ca.crt"
+      cacertfile: Path.join([to_string(:code.priv_dir(:httparrot)), "/ssl/server-ca.crt"])
     ]
 
   # see https://github.com/teamon/tesla/issues/147

--- a/test/tesla/adapter/httpc_test.exs
+++ b/test/tesla/adapter/httpc_test.exs
@@ -28,4 +28,21 @@ defmodule Tesla.Adapter.HttpcTest do
 
     assert data["headers"]["content-type"] == "text/plain"
   end
+
+  test "that get uses the correct request" do
+    env = %Env{
+      method: :get,
+      body: "",
+      url: "#{@http}/get"
+    }
+
+    env = Tesla.put_header(env, "content-type", "text/plain")
+
+    assert {:ok, %Env{} = response} = call(env)
+    assert response.status == 200
+
+    {:ok, data} = Jason.decode(response.body)
+
+    assert data["headers"]["content-type"] == "text/plain"
+  end
 end

--- a/test/tesla/adapter/ibrowse_test.exs
+++ b/test/tesla/adapter/ibrowse_test.exs
@@ -18,6 +18,6 @@ defmodule Tesla.Adapter.IbrowseTest do
   # use Tesla.AdapterCase.SSL,
   #   ssl_options: [
   #     verify: :verify_peer,
-  #     cacertfile: "#{:code.priv_dir(:httparrot)}/ssl/server-ca.crt"
+  #     cacertfile: Path.join([to_string(:code.priv_dir(:httparrot)), "/ssl/server-ca.crt"])
   #   ]
 end

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -7,7 +7,7 @@ defmodule Tesla.Adapter.MintTest do
   use Tesla.AdapterCase.StreamRequestBody
 
   use Tesla.AdapterCase.SSL,
-    transport_opts: [cacertfile: "./deps/httparrot/priv/ssl/server-ca.crt"]
+    transport_opts: [cacertfile: Path.join([to_string(:code.priv_dir(:httparrot)), "/ssl/server-ca.crt"])]
 
   test "Delay request" do
     request = %Env{

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -7,7 +7,9 @@ defmodule Tesla.Adapter.MintTest do
   use Tesla.AdapterCase.StreamRequestBody
 
   use Tesla.AdapterCase.SSL,
-    transport_opts: [cacertfile: Path.join([to_string(:code.priv_dir(:httparrot)), "/ssl/server-ca.crt"])]
+    transport_opts: [
+      cacertfile: Path.join([to_string(:code.priv_dir(:httparrot)), "/ssl/server-ca.crt"])
+    ]
 
   test "Delay request" do
     request = %Env{


### PR DESCRIPTION
Currently we are creating a request with body and content_type in many cases for methods that can't support it. Httpc doesn't know what to do an outputs a function match error.