### PR TITLE
feat: allow to specify encoding strategy for query params

### DIFF
--- a/guides/explanations/3.adapter.md
+++ b/guides/explanations/3.adapter.md
@@ -16,7 +16,7 @@ defmodule Tesla.Adapter.Req do
   @impl Tesla.Adapter
   def run(env, _opts) do
     req = Req.new(
-      url: Tesla.build_url(env.url, env.query),
+      url: Tesla.build_url(env),
       method: env.method,
       headers: env.headers,
       body: env.body

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -346,7 +346,7 @@ defmodule Tesla do
   @spec build_url(Tesla.Env.t()) :: String.t()
   def build_url(%Tesla.Env{} = env) do
     query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
-    Tesla.build_url(url, query, encoding)
+    Tesla.build_url(env.url, env.query, encoding)
   end
 
   def encode_query(query, encoding \\ :www_form) do

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -318,7 +318,9 @@ defmodule Tesla do
       iex> Tesla.build_url("http://api.example.com", [user_name: "John Smith"], :rfc3986)
       "http://api.example.com?user_name=John%20Smith"
   """
-  @spec build_url(Tesla.Env.url(), Tesla.Env.query(), :rfc3986 | :www_form) :: binary
+  @type encoding_strategy :: :rfc3986 | :www_form
+
+  @spec build_url(Tesla.Env.url(), Tesla.Env.query(), encoding_strategy) :: binary
   def build_url(url, query, encoding \\ :www_form)
 
   def build_url(url, [], _encoding), do: url

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -281,7 +281,7 @@ defmodule Tesla do
   MyApi.get_something(client, 42)
   ```
   """
-  if Version.match?(System.version(), "~> 1.7"), do: @doc(since: "1.2.0")
+  @doc since: "1.2.0"
   @spec client([Tesla.Client.middleware()], Tesla.Client.adapter()) :: Tesla.Client.t()
   def client(middleware, adapter \\ nil), do: Tesla.Builder.client(middleware, [], adapter)
 
@@ -302,21 +302,21 @@ defmodule Tesla do
 
   ## Examples
 
-      iex> Tesla.build_url("http://api.example.com", [user: 3, page: 2])
-      "http://api.example.com?user=3&page=2"
+      iex> Tesla.build_url("https://api.example.com", [user: 3, page: 2])
+      "https://api.example.com?user=3&page=2"
 
       # URL that already contains query params
-      iex> url = "http://api.example.com?user=3"
+      iex> url = "https://api.example.com?user=3"
       iex> Tesla.build_url(url, [page: 2, status: true])
-      "http://api.example.com?user=3&page=2&status=true"
+      "https://api.example.com?user=3&page=2&status=true"
 
       # default encoding `:www_form`
-      iex> Tesla.build_url("http://api.example.com", [user_name: "John Smith"])
-      "http://api.example.com?user_name=John+Smith"
+      iex> Tesla.build_url("https://api.example.com", [user_name: "John Smith"])
+      "https://api.example.com?user_name=John+Smith"
 
       # specified encoding strategy :rfc3986
-      iex> Tesla.build_url("http://api.example.com", [user_name: "John Smith"], :rfc3986)
-      "http://api.example.com?user_name=John%20Smith"
+      iex> Tesla.build_url("https://api.example.com", [user_name: "John Smith"], :rfc3986)
+      "https://api.example.com?user_name=John%20Smith"
   """
   @type encoding_strategy :: :rfc3986 | :www_form
 
@@ -328,6 +328,18 @@ defmodule Tesla do
   def build_url(url, query, encoding) do
     join = if String.contains?(url, "?"), do: "&", else: "?"
     url <> join <> encode_query(query, encoding)
+  end
+
+  @doc """
+  Builds a URL from the given `t:Tesla.Env.t/0` struct.
+
+  Combines the `url` and `query` fields, and allows specifying the `encoding`
+  strategy before calling `build_url/3`.
+  """
+  @spec build_url(Tesla.Env.t()) :: String.t()
+  def build_url(%Tesla.Env{} = env) do
+    query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
+    Tesla.build_url(url, query, encoding)
   end
 
   def encode_query(query, encoding \\ :www_form) do

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -333,13 +333,7 @@ defmodule Tesla do
   def encode_query(query, encoding \\ :www_form) do
     query
     |> Enum.flat_map(&encode_pair/1)
-    |> uri_encode_query(encoding)
-  end
-
-  if Version.match?(System.version(), "~> 1.12") do
-    defp uri_encode_query(enum, encoding), do: URI.encode_query(enum, encoding)
-  else
-    defp uri_encode_query(enum, _encoding), do: URI.encode_query(enum)
+    |> URI.encode_query(encoding)
   end
 
   @doc false

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -346,7 +346,7 @@ defmodule Tesla do
   @spec build_url(Tesla.Env.t()) :: String.t()
   def build_url(%Tesla.Env{} = env) do
     query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
-    Tesla.build_url(env.url, env.query, encoding)
+    Tesla.build_url(env.url, env.query, query_encoding)
   end
 
   def encode_query(query, encoding \\ :www_form) do

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -291,35 +291,42 @@ defmodule Tesla do
   @deprecated "Use client/1 or client/2 instead"
   def build_adapter(fun), do: Tesla.Builder.client([], [], fun)
 
+  @type encoding_strategy :: :rfc3986 | :www_form
+
   @doc """
-  Builds URL with the given query params.
+  Builds URL with the given URL and query params.
 
-  Useful when you need to create an URL with dynamic query params from a Keyword list
+  Useful when you need to create a URL with dynamic query params from a Keyword
+  list
 
-  Allows to specify the `encoding` strategy to be one either `:www_form` or `:rfc3986`
-  Read more about options in [`URI.encode_query/2`](https://hexdocs.pm/elixir/1.14.3/URI.html#encode_query/2)
-  Defaults to `:www_form`, ignored when compiled with elixir version older than 1.12.
+  Allows to specify the `encoding` strategy to be one either `:www_form` or
+  `:rfc3986`. Read more about encoding at `URI.encode_query/2`.
+
+  - `url` - the base URL to which the query params will be appended.
+  - `query` - a list of key-value pairs to be encoded as query params.
+  - `encoding` - the encoding strategy to use. Defaults to `:www_form`
 
   ## Examples
 
       iex> Tesla.build_url("https://api.example.com", [user: 3, page: 2])
       "https://api.example.com?user=3&page=2"
 
-      # URL that already contains query params
+  URL that already contains query params:
+
       iex> url = "https://api.example.com?user=3"
       iex> Tesla.build_url(url, [page: 2, status: true])
       "https://api.example.com?user=3&page=2&status=true"
 
-      # default encoding `:www_form`
+  Default encoding `:www_form`:
+
       iex> Tesla.build_url("https://api.example.com", [user_name: "John Smith"])
       "https://api.example.com?user_name=John+Smith"
 
-      # specified encoding strategy :rfc3986
+  Specified encoding strategy `:rfc3986`:
+
       iex> Tesla.build_url("https://api.example.com", [user_name: "John Smith"], :rfc3986)
       "https://api.example.com?user_name=John%20Smith"
   """
-  @type encoding_strategy :: :rfc3986 | :www_form
-
   @spec build_url(Tesla.Env.url(), Tesla.Env.query(), encoding_strategy) :: binary
   def build_url(url, query, encoding \\ :www_form)
 

--- a/lib/tesla/adapter/finch.ex
+++ b/lib/tesla/adapter/finch.ex
@@ -58,10 +58,11 @@ if Code.ensure_loaded?(Finch) do
 
     @impl Tesla.Adapter
     def call(%Tesla.Env{} = env, opts) do
+      query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
       opts = Tesla.Adapter.opts(@defaults, env, opts)
 
       name = Keyword.fetch!(opts, :name)
-      url = Tesla.build_url(env.url, env.query)
+      url = Tesla.build_url(env.url, env.query, query_encoding)
       req_opts = Keyword.take(opts, [:pool_timeout, :receive_timeout])
       req = build(env.method, url, env.headers, env.body)
 

--- a/lib/tesla/adapter/finch.ex
+++ b/lib/tesla/adapter/finch.ex
@@ -58,11 +58,10 @@ if Code.ensure_loaded?(Finch) do
 
     @impl Tesla.Adapter
     def call(%Tesla.Env{} = env, opts) do
-      query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
       opts = Tesla.Adapter.opts(@defaults, env, opts)
 
       name = Keyword.fetch!(opts, :name)
-      url = Tesla.build_url(env.url, env.query, query_encoding)
+      url = Tesla.build_url(env)
       req_opts = Keyword.take(opts, [:pool_timeout, :receive_timeout])
       req = build(env.method, url, env.headers, env.body)
 

--- a/lib/tesla/adapter/gun.ex
+++ b/lib/tesla/adapter/gun.ex
@@ -176,9 +176,11 @@ if Code.ensure_loaded?(:gun) do
     end
 
     defp request(env, opts) do
+      query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
+
       request(
         Tesla.Adapter.Shared.format_method(env.method),
-        Tesla.build_url(env.url, env.query),
+        Tesla.build_url(env.url, env.query, query_encoding),
         format_headers(env.headers),
         env.body || "",
         Tesla.Adapter.opts(

--- a/lib/tesla/adapter/gun.ex
+++ b/lib/tesla/adapter/gun.ex
@@ -176,11 +176,9 @@ if Code.ensure_loaded?(:gun) do
     end
 
     defp request(env, opts) do
-      query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
-
       request(
         Tesla.Adapter.Shared.format_method(env.method),
-        Tesla.build_url(env.url, env.query, query_encoding),
+        Tesla.build_url(env),
         format_headers(env.headers),
         env.body || "",
         Tesla.Adapter.opts(

--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -49,9 +49,11 @@ if Code.ensure_loaded?(:hackney) do
     defp format_body(data) when is_binary(data) or is_reference(data), do: data
 
     defp request(env, opts) do
+      query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
+
       request(
         env.method,
-        Tesla.build_url(env.url, env.query),
+        Tesla.build_url(env.url, env.query, query_encoding),
         env.headers,
         env.body,
         Tesla.Adapter.opts(env, opts)

--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -49,11 +49,9 @@ if Code.ensure_loaded?(:hackney) do
     defp format_body(data) when is_binary(data) or is_reference(data), do: data
 
     defp request(env, opts) do
-      query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
-
       request(
         env.method,
-        Tesla.build_url(env.url, env.query, query_encoding),
+        Tesla.build_url(env),
         env.headers,
         env.body,
         Tesla.Adapter.opts(env, opts)

--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -51,7 +51,7 @@ defmodule Tesla.Adapter.Httpc do
     handle(
       request(
         env.method,
-        Tesla.build_url(env.url) |> to_charlist(),
+        Tesla.build_url(env) |> to_charlist(),
         Enum.map(env.headers, fn {k, v} -> {to_charlist(k), to_charlist(v)} end),
         content_type,
         env.body,

--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -47,11 +47,12 @@ defmodule Tesla.Adapter.Httpc do
 
   defp request(env, opts) do
     content_type = to_charlist(Tesla.get_header(env, "content-type") || "")
+    query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
 
     handle(
       request(
         env.method,
-        Tesla.build_url(env.url, env.query) |> to_charlist,
+        Tesla.build_url(env.url, env.query, query_encoding) |> to_charlist(),
         Enum.map(env.headers, fn {k, v} -> {to_charlist(k), to_charlist(v)} end),
         content_type,
         env.body,

--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -47,12 +47,11 @@ defmodule Tesla.Adapter.Httpc do
 
   defp request(env, opts) do
     content_type = to_charlist(Tesla.get_header(env, "content-type") || "")
-    query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
 
     handle(
       request(
         env.method,
-        Tesla.build_url(env.url, env.query, query_encoding) |> to_charlist(),
+        Tesla.build_url(env.url) |> to_charlist(),
         Enum.map(env.headers, fn {k, v} -> {to_charlist(k), to_charlist(v)} end),
         content_type,
         env.body,

--- a/lib/tesla/adapter/ibrowse.ex
+++ b/lib/tesla/adapter/ibrowse.ex
@@ -61,7 +61,7 @@ if Code.ensure_loaded?(:ibrowse) do
 
       handle(
         request(
-          Tesla.build_url(env.url) |> to_charlist(),
+          Tesla.build_url(env) |> to_charlist(),
           env.headers,
           env.method,
           body,

--- a/lib/tesla/adapter/ibrowse.ex
+++ b/lib/tesla/adapter/ibrowse.ex
@@ -57,11 +57,12 @@ if Code.ensure_loaded?(:ibrowse) do
     defp format_body(data) when is_binary(data), do: data
 
     defp request(env, opts) do
+      query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
       body = env.body || []
 
       handle(
         request(
-          Tesla.build_url(env.url, env.query) |> to_charlist,
+          Tesla.build_url(env.url, env.query, query_encoding) |> to_charlist(),
           env.headers,
           env.method,
           body,

--- a/lib/tesla/adapter/ibrowse.ex
+++ b/lib/tesla/adapter/ibrowse.ex
@@ -57,12 +57,11 @@ if Code.ensure_loaded?(:ibrowse) do
     defp format_body(data) when is_binary(data), do: data
 
     defp request(env, opts) do
-      query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
       body = env.body || []
 
       handle(
         request(
-          Tesla.build_url(env.url, env.query, query_encoding) |> to_charlist(),
+          Tesla.build_url(env.url) |> to_charlist(),
           env.headers,
           env.method,
           body,

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -91,9 +91,11 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defdelegate close(conn), to: HTTP
 
     defp request(env, opts) do
+      query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
+
       request(
         format_method(env.method),
-        Tesla.build_url(env.url, env.query),
+        Tesla.build_url(env.url, env.query, query_encoding),
         env.headers,
         env.body,
         Enum.into(opts, %{})

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -93,7 +93,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp request(env, opts) do
       request(
         format_method(env.method),
-        Tesla.build_url(env.url),
+        Tesla.build_url(env),
         env.headers,
         env.body,
         Enum.into(opts, %{})

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -91,11 +91,9 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defdelegate close(conn), to: HTTP
 
     defp request(env, opts) do
-      query_encoding = Keyword.get(env.opts, :query_encoding, :www_form)
-
       request(
         format_method(env.method),
-        Tesla.build_url(env.url, env.query, query_encoding),
+        Tesla.build_url(env.url),
         env.headers,
         env.body,
         Enum.into(opts, %{})

--- a/lib/tesla/error.ex
+++ b/lib/tesla/error.ex
@@ -2,6 +2,6 @@ defmodule Tesla.Error do
   defexception env: nil, stack: [], reason: nil
 
   def message(%Tesla.Error{env: %{url: url, method: method}, reason: reason}) do
-    "#{inspect(reason)} (#{method |> to_string |> String.upcase()} #{url})"
+    "#{inspect(reason)} (#{method |> to_string() |> String.upcase()} #{url})"
   end
 end

--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -43,7 +43,12 @@ defmodule Tesla.Middleware.Logger.Formatter do
     Enum.map(format, &output(&1, request, response, time))
   end
 
-  defp output(:query, env, _, _), do: env.query |> Tesla.encode_query()
+  defp output(:query, env, _, _) do
+    encoding = Keyword.get(env.opts, :query_encoding, :www_form)
+
+    Tesla.encode_query(env.query, encoding)
+  end
+
   defp output(:method, env, _, _), do: env.method |> to_string() |> String.upcase()
   defp output(:url, env, _, _), do: env.url
   defp output(:status, _, {:ok, env}, _), do: to_string(env.status)

--- a/test/support/adapter_case/basic.ex
+++ b/test/support/adapter_case/basic.ex
@@ -91,20 +91,18 @@ defmodule Tesla.AdapterCase.Basic do
           assert response.body["url"] == "#{@http}/get?user_name=John+Smith"
         end
 
-        if Version.match?(System.version(), "~> 1.12") do
-          test "encoding query params with rfc3986 optionally" do
-            request = %Env{
-              method: :get,
-              url: "#{@http}/get",
-              query: [user_name: "John Smith"],
-              opts: [query_encoding: :rfc3986]
-            }
+        test "encoding query params with rfc3986 optionally" do
+          request = %Env{
+            method: :get,
+            url: "#{@http}/get",
+            query: [user_name: "John Smith"],
+            opts: [query_encoding: :rfc3986]
+          }
 
-            assert {:ok, %Env{} = response} = call(request)
-            assert {:ok, %Env{} = response} = Tesla.Middleware.JSON.decode(response, [])
+          assert {:ok, %Env{} = response} = call(request)
+          assert {:ok, %Env{} = response} = Tesla.Middleware.JSON.decode(response, [])
 
-            assert response.body["url"] == "#{@http}/get?user_name=John%20Smith"
-          end
+          assert response.body["url"] == "#{@http}/get?user_name=John%20Smith"
         end
 
         test "autoredirects disabled by default" do

--- a/test/support/adapter_case/basic.ex
+++ b/test/support/adapter_case/basic.ex
@@ -78,6 +78,35 @@ defmodule Tesla.AdapterCase.Basic do
           assert args["user[age]"] == "20"
         end
 
+        test "encoding query params with www_form by default" do
+          request = %Env{
+            method: :get,
+            url: "#{@http}/get",
+            query: [user_name: "John Smith"]
+          }
+
+          assert {:ok, %Env{} = response} = call(request)
+          assert {:ok, %Env{} = response} = Tesla.Middleware.JSON.decode(response, [])
+
+          assert response.body["url"] == "#{@http}/get?user_name=John+Smith"
+        end
+
+        if Version.match?(System.version(), "~> 1.12") do
+          test "encoding query params with rfc3986 optionally" do
+            request = %Env{
+              method: :get,
+              url: "#{@http}/get",
+              query: [user_name: "John Smith"],
+              opts: [query_encoding: :rfc3986]
+            }
+
+            assert {:ok, %Env{} = response} = call(request)
+            assert {:ok, %Env{} = response} = Tesla.Middleware.JSON.decode(response, [])
+
+            assert response.body["url"] == "#{@http}/get?user_name=John%20Smith"
+          end
+        end
+
         test "autoredirects disabled by default" do
           request = %Env{
             method: :get,

--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -4,7 +4,7 @@ defmodule Tesla.Middleware.LoggerTest do
   defmodule Client do
     use Tesla
 
-    plug Tesla.Middleware.Logger
+    plug Tesla.Middleware.Logger, format: "$query $url -> $status"
 
     adapter fn env ->
       env = Tesla.put_header(env, "content-type", "text/plain")
@@ -60,6 +60,22 @@ defmodule Tesla.Middleware.LoggerTest do
     test "ok" do
       log = capture_log(fn -> Client.get("/ok") end)
       assert log =~ "/ok -> 200"
+    end
+
+    test "default encoding strategy www_form" do
+      log = capture_log(fn -> Client.get("/ok", query: [test: "foo bar"]) end)
+      assert log =~ "test=foo+bar"
+    end
+
+    if Version.match?(System.version(), "~> 1.12") do
+      test "encodes with specified strategy" do
+        log =
+          capture_log(fn ->
+            Client.get("/ok", query: %{"test" => "foo bar"}, opts: [query_encoding: :rfc3986])
+          end)
+
+        assert log =~ "test=foo%20bar"
+      end
     end
   end
 

--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -67,15 +67,13 @@ defmodule Tesla.Middleware.LoggerTest do
       assert log =~ "test=foo+bar"
     end
 
-    if Version.match?(System.version(), "~> 1.12") do
-      test "encodes with specified strategy" do
-        log =
-          capture_log(fn ->
-            Client.get("/ok", query: %{"test" => "foo bar"}, opts: [query_encoding: :rfc3986])
-          end)
+    test "encodes with specified strategy" do
+      log =
+        capture_log(fn ->
+          Client.get("/ok", query: %{"test" => "foo bar"}, opts: [query_encoding: :rfc3986])
+        end)
 
-        assert log =~ "test=foo%20bar"
-      end
+      assert log =~ "test=foo%20bar"
     end
   end
 

--- a/test/tesla/middleware/retry_test.exs
+++ b/test/tesla/middleware/retry_test.exs
@@ -75,7 +75,7 @@ defmodule Tesla.Middleware.RetryTest do
   end
 
   test "finally pass on laggy request" do
-    assert {:ok, %Tesla.Env{url: "/maybe", method: :get}} = Client.get("/maybe") |> dbg()
+    assert {:ok, %Tesla.Env{url: "/maybe", method: :get}} = Client.get("/maybe")
   end
 
   test "pass retry_count opt" do

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -335,11 +335,9 @@ defmodule TeslaTest do
       assert build_url(url, query_params, :www_form) === build_url(url, query_params)
     end
 
-    if Version.match?(System.version(), "~> 1.12") do
-      test "encoding rfc3986", %{url: url} do
-        query_params = [name: "foo bar", page: 2]
-        assert build_url(url, query_params, :rfc3986) === url <> "?name=foo%20bar&page=2"
-      end
+    test "encoding rfc3986", %{url: url} do
+      query_params = [name: "foo bar", page: 2]
+      assert build_url(url, query_params, :rfc3986) === url <> "?name=foo%20bar&page=2"
     end
 
     test "default encoding www_form", %{url: url} do

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -323,4 +323,28 @@ defmodule TeslaTest do
       end
     end
   end
+
+  describe "build_url/3" do
+    setup do
+      {:ok, url: "http://api.example.com"}
+    end
+
+    test "encoding www_form", %{url: url} do
+      query_params = [name: "foo bar", page: 2]
+      assert build_url(url, query_params, :www_form) === url <> "?name=foo+bar&page=2"
+      assert build_url(url, query_params, :www_form) === build_url(url, query_params)
+    end
+
+    if Version.match?(System.version(), "~> 1.12") do
+      test "encoding rfc3986", %{url: url} do
+        query_params = [name: "foo bar", page: 2]
+        assert build_url(url, query_params, :rfc3986) === url <> "?name=foo%20bar&page=2"
+      end
+    end
+
+    test "default encoding www_form", %{url: url} do
+      query_params = [name: "foo bar", page: 2]
+      assert build_url(url, query_params, :www_form) === build_url(url, query_params)
+    end
+  end
 end


### PR DESCRIPTION
I was adapting Tesla in a project when we encode query params with `:rfc3986` and I noticed that, while Tesla provides conveniences to build url encoding query params for us, it doesn't allow to specify the encoding strategy.

### TL;DR

This PR allows specifying option `query_encoding: :rfc3986` so that whitespaces in query params will be encoded as "%20".

```elixir
Tesla.get("http://example.com", query: [username: "John Smith"], opts: [query_encoding: :rfc3986])
```
will build the following url
```
http://example.com?username=John%20Smith
```

Also adds optional argument to `Tesla.build_url` and `Tesla.encode_query`.

----
Tesla uses [URI.encode_query/2](https://hexdocs.pm/elixir/1.14.3/URI.html#encode_query/2) to encode query params. Since Elixir 1.12 that function allows to specify the encoding strategy.

> You can specify one of the following encoding strategies:
>
>  - `:www_form` - (default, since v1.12.0) keys and values are URL encoded as per [encode_www_form/1](https://hexdocs.pm/elixir/1.14.3/URI.html#encode_www_form/1). This is the format typically used by browsers on query strings and form data. It encodes " " as "+".
>
>  - `:rfc3986` - (since v1.12.0) the same as `:www_form` except it encodes " " as "%20" according [RFC 3986](https://tools.ietf.org/html/rfc3986). This is the best option if you are encoding in a non-browser situation, since encoding spaces as "+" can be ambiguous to URI parsers. This can inadvertently lead to spaces being interpreted as literal plus signs.
>
> Encoding defaults to `:www_form` for backward compatibility.