### PR TITLE
Adds docs to the Mint adapter on 'transport_opts'

### DIFF
--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -41,6 +41,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
     - `:original` - Original host with port, for which reused connection was open. Needed for `Tesla.Middleware.FollowRedirects`. Otherwise adapter will use connection for another open host.
     - `:close_conn` - Close connection or not after receiving full response body. Is used for reusing mint connections. Defaults to `true`.
     - `:proxy` - Proxy settings. E.g.: `{:http, "localhost", 8888, []}`, `{:http, "127.0.0.1", 8888, []}`
+    - `:transport_opts` - Keyword list of HTTP or HTTPS options passed into `:gen_tcp` or `:ssl` respectively by mint. See [mint's docs on `transport_opts`](https://hexdocs.pm/mint/Mint.HTTP.html#connect/4-transport-options).
     """
 
     @behaviour Tesla.Adapter


### PR DESCRIPTION
While looking into an API that required using special options passed into `transport_opts`, I noticed that Mint supports it but that Tesla had no docs on whether `transport_opts` was a valid option for this adapter. Looking at the code, Tesla does support passing `transport_opts` into Mint. I think this would be a useful addition to the docs.