### PR TITLE
[Finch] Change error handling, fix for response stream

### DIFF
--- a/lib/tesla/adapter/finch.ex
+++ b/lib/tesla/adapter/finch.ex
@@ -69,8 +69,11 @@ if Code.ensure_loaded?(Finch) do
         {:ok, %Finch.Response{status: status, headers: headers, body: body}} ->
           {:ok, %Tesla.Env{env | status: status, headers: headers, body: body}}
 
-        {:error, mint_error} ->
-          {:error, Exception.message(mint_error)}
+        {:error, %Mint.TransportError{reason: reason}} ->
+          {:error, reason}
+
+        {:error, reason} ->
+          {:error, reason}
       end
     end
 

--- a/test/tesla/adapter/finch_test.exs
+++ b/test/tesla/adapter/finch_test.exs
@@ -25,4 +25,22 @@ defmodule Tesla.Adapter.FinchTest do
     start_supervised!({Finch, opts})
     :ok
   end
+
+  test "Delay request" do
+    request = %Env{
+      method: :head,
+      url: "#{@http}/delay/1"
+    }
+
+    assert {:error, :timeout} = call(request, receive_timeout: 100)
+  end
+
+  test "Delay request with stream" do
+    request = %Env{
+      method: :head,
+      url: "#{@http}/delay/1"
+    }
+
+    assert {:error, :timeout} = call(request, receive_timeout: 100, response: :stream)
+  end
 end


### PR DESCRIPTION
SSE introduced inconsistent error here: https://github.com/elixir-tesla/tesla/blob/tt/finch-stream/lib/tesla/adapter/finch.ex#L143
Finch adapter was always expecting Mint error.

I've looked at other adapters and seems like `{:error, :timeout}` is used consistently, previous error-handling implementation would respond with `{:error, "timeout"}` - thus the change not to use `Exception.message/1` anymore. This is potentially a breaking change for anyone using Finch adapter.