### PR TITLE
Fix mocked calls failing when using Timeout middleware

### DIFF
--- a/lib/tesla/middleware/timeout.ex
+++ b/lib/tesla/middleware/timeout.ex
@@ -40,7 +40,11 @@ defmodule Tesla.Middleware.Timeout do
     timeout = Keyword.get(opts, :timeout, @default_timeout)
     task_module = Keyword.get(opts, :task_module, Task)
 
-    task = safe_async(task_module, fn -> Tesla.run(env, next) end)
+    mock = Tesla.Mock.pdict_get()
+    task = safe_async(task_module, fn ->
+      if mock, do: Tesla.Mock.pdict_set(mock)
+      Tesla.run(env, next)
+    end)
 
     try do
       task

--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -225,8 +225,11 @@ defmodule Tesla.Mock do
     end
   end
 
-  defp pdict_set(fun), do: Process.put(__MODULE__, fun)
-  defp pdict_get, do: Process.get(__MODULE__)
+  @doc false
+  def pdict_set(fun), do: Process.put(__MODULE__, fun)
+
+  @doc false
+  def pdict_get, do: Process.get(__MODULE__)
 
   defp agent_set(fun) do
     case Process.whereis(__MODULE__) do

--- a/test/tesla/middleware/timeout_test.exs
+++ b/test/tesla/middleware/timeout_test.exs
@@ -31,6 +31,14 @@ defmodule Tesla.Middleware.TimeoutTest do
     end
   end
 
+  defmodule MockClient do
+    use Tesla
+
+    plug Tesla.Middleware.Timeout, timeout: 100
+
+    adapter Tesla.Mock
+  end
+
   defmodule DefaultTimeoutClient do
     use Tesla
 
@@ -100,6 +108,14 @@ defmodule Tesla.Middleware.TimeoutTest do
     end
   end
 
+  describe "using Tesla.Mock" do
+    test "can return the response when not timeout" do
+      Tesla.Mock.mock(fn %Tesla.Env{} -> {200, [], ""} end)
+
+      assert {:ok, %Tesla.Env{status: 200}} = MockClient.get("/mock")
+    end
+  end
+
   describe "repassing errors and exit" do
     test "should repass rescued errors" do
       assert_raise RuntimeError, "custom_exception", fn ->
@@ -131,7 +147,7 @@ defmodule Tesla.Middleware.TimeoutTest do
           [_, {timeout_module, _, _, module_file_info} | _] = __STACKTRACE__
 
           assert Tesla.Middleware.Timeout == timeout_module
-          assert module_file_info == [file: 'lib/tesla/middleware/timeout.ex', line: 59]
+          assert module_file_info == [file: 'lib/tesla/middleware/timeout.ex', line: 63]
       else
         _ ->
           flunk("Expected exception to be thrown")


### PR DESCRIPTION
Since the Timeout middleware is creating a new process, the mock in the pdict is lost. Fortunately it's easy to copy the pdict over to the new process.