### PR TITLE
Allow for dynamic options in some middleware configs

### DIFF
--- a/lib/tesla/middleware/basic_auth.ex
+++ b/lib/tesla/middleware/basic_auth.ex
@@ -24,8 +24,8 @@ defmodule Tesla.Middleware.BasicAuth do
 
   ## Options
 
-  - `:username` - username (defaults to `""`)
-  - `:password` - password (defaults to `""`)
+  - `:username` - the literal username or a zero-arity function that returns the username (defaults to `""`)
+  - `:password` - the literal password or a zero-arity function that returns the password (defaults to `""`)
   """
 
   @behaviour Tesla.Middleware
@@ -48,10 +48,13 @@ defmodule Tesla.Middleware.BasicAuth do
 
   defp authorization_vars(opts) do
     %{
-      username: opts[:username] || "",
-      password: opts[:password] || ""
+      username: resolve(opts[:username] || ""),
+      password: resolve(opts[:password] || "")
     }
   end
+
+  defp resolve(value) when is_function(value, 0), do: value.()
+  defp resolve(value), do: value
 
   defp create_header(auth) do
     [{"authorization", "Basic #{auth}"}]

--- a/lib/tesla/middleware/bearer_auth.ex
+++ b/lib/tesla/middleware/bearer_auth.ex
@@ -24,17 +24,20 @@ defmodule Tesla.Middleware.BearerAuth do
 
   ## Options
 
-  - `:token` - token (defaults to `""`)
+  - `:token` - the literal token or a zero-arity function that returns the token (defaults to `""`)
   """
 
   @behaviour Tesla.Middleware
 
   @impl Tesla.Middleware
   def call(env, next, opts \\ []) do
-    token = Keyword.get(opts, :token, "")
+    token = Keyword.get(opts, :token, "") |> resolve()
 
     env
     |> Tesla.put_headers([{"authorization", "Bearer #{token}"}])
     |> Tesla.run(next)
   end
+
+  defp resolve(value) when is_function(value, 0), do: value.()
+  defp resolve(value), do: value
 end

--- a/lib/tesla/middleware/core.ex
+++ b/lib/tesla/middleware/core.ex
@@ -71,9 +71,12 @@ defmodule Tesla.Middleware.Headers do
   @impl Tesla.Middleware
   def call(env, next, headers) do
     env
-    |> Tesla.put_headers(headers)
+    |> Tesla.put_headers(resolve(headers))
     |> Tesla.run(next)
   end
+
+  defp resolve(headers) when is_function(headers, 0), do: headers.()
+  defp resolve(headers), do: headers
 end
 
 defmodule Tesla.Middleware.Query do

--- a/test/tesla/middleware/basic_auth_test.exs
+++ b/test/tesla/middleware/basic_auth_test.exs
@@ -54,6 +54,19 @@ defmodule Tesla.Middleware.BasicAuthTest do
     assert auth_header == "Basic #{base_64_encoded}"
   end
 
+  test "sends request with proper authorization header when config values are functions" do
+    username = "Aladdin"
+    password = "OpenSesame"
+
+    base_64_encoded = Base.encode64("#{username}:#{password}")
+    assert base_64_encoded == "QWxhZGRpbjpPcGVuU2VzYW1l"
+
+    {:ok, request} = BasicClient.client(fn -> username end, fn -> password end) |> BasicClient.get("/basic-auth")
+    auth_header = Tesla.get_header(request, "authorization")
+
+    assert auth_header == "Basic #{base_64_encoded}"
+  end
+
   test "it correctly encodes a blank username and password" do
     base_64_encoded = Base.encode64(":")
     assert base_64_encoded == "Og=="

--- a/test/tesla/middleware/bearer_auth_test.exs
+++ b/test/tesla/middleware/bearer_auth_test.exs
@@ -10,5 +10,8 @@ defmodule Tesla.Middleware.BearerAuthTest do
 
     assert {:ok, env} = @middleware.call(%Env{}, [], token: "token")
     assert env.headers == [{"authorization", "Bearer token"}]
+
+    assert {:ok, env} = @middleware.call(%Env{}, [], token: fn -> "token" end)
+    assert env.headers == [{"authorization", "Bearer token"}]
   end
 end

--- a/test/tesla/middleware/header_test.exs
+++ b/test/tesla/middleware/header_test.exs
@@ -12,4 +12,11 @@ defmodule Tesla.Middleware.HeadersTest do
 
     assert env.headers == [{"authorization", "secret"}, {"content-type", "text/plain"}]
   end
+
+  test "headers from a function argument" do
+    assert {:ok, env} =
+             @middleware.call(%Env{}, [], fn -> [{"content-type", "text/plain"}] end)
+
+    assert env.headers == [{"authorization", "secret"}, {"content-type", "text/plain"}]
+  end
 end


### PR DESCRIPTION
Basic Auth, Bearer, and Headers middleware now also accept functions as their options. This allows for auth credentials and user agents to be fetched the app config, for example.