### PR TITLE
Ensure connection errors return the expected error tuple

### DIFF
--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -176,8 +176,15 @@ if Code.ensure_loaded?(Mint.HTTP) do
       end
     end
 
-    defp make_request(conn, method, path, headers, body),
-      do: HTTP.request(conn, method, path, headers, body)
+    defp make_request(conn, method, path, headers, body) do
+      case HTTP.request(conn, method, path, headers, body) do
+        {:ok, conn, ref} ->
+          {:ok, conn, ref}
+
+        {:error, _conn, error} ->
+          {:error, error}
+      end
+    end
 
     defp stream_request(conn, ref, fun) do
       case next_chunk(fun) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Tesla.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/teamon/tesla"
-  @version "1.6.0"
+  @version "1.6.1"
 
   def project do
     [

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -11,7 +11,7 @@ defmodule Tesla.Adapter.MintTest do
       cacertfile: Path.join([to_string(:code.priv_dir(:httparrot)), "/ssl/server-ca.crt"])
     ]
 
-  test "Delay request" do
+  test "timeout request" do
     request = %Env{
       method: :head,
       url: "#{@http}/delay/1"
@@ -177,6 +177,26 @@ defmodule Tesla.Adapter.MintTest do
 
       assert {:ok, conn} = Tesla.Adapter.Mint.close(conn)
       assert conn.state == :closed
+    end
+
+    test "body_as :plain - returns error tuple matching the specification when connection is closed",
+         %{conn: conn, original: original} do
+      request = %Env{
+        method: :get,
+        url: "#{@http}/stream-bytes/10"
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request, conn: conn, original: original, close_conn: false)
+
+      assert response.status == 200
+      assert byte_size(response.body) == 16
+
+      {:ok, conn} = Tesla.Adapter.Mint.close(conn)
+      assert conn.state == :closed
+
+      assert {:error, %Mint.HTTPError{reason: :closed, module: Mint.HTTP1}} =
+               call(request, conn: conn, original: original, close_conn: false)
     end
 
     test "body_as :stream", %{conn: conn, original: original} do


### PR DESCRIPTION
## Bug

We encountered an in-the Mint adapter in Tesla. The error arises when we try to issue a new request but the connection was previously closed by the server. The response is a tuple of three elements, including the closed connection struct, but only two elements are expected in the behavior. In consequence, if we chain the Logger middleware this error happens: `FunctionClauseError: no function clause matching in Tesla.Middleware.Logger.log_level/2`

We can reproduce it by closing the connection before issuing the request, an example is:

Given this module

```elixir
defmodule A do
  use Tesla

  adapter Tesla.Adapter.Mint
  
  plug Tesla.Middleware.Logger
  
  def get(), do: get("http://localhost:5984/ping")
end
```

```elixir
iex(15)> A.get
** (FunctionClauseError) no function clause matching in Tesla.Middleware.Logger.log_level/2

    The following arguments were given to Tesla.Middleware.Logger.log_level/2:

        # 1
        {:error,
         %Mint.HTTP1{
           host: "localhost",
           port: 5984,
           request: nil,
           streaming_request: nil,
           socket: #Port<0.13>,
           transport: Mint.Core.Transport.TCP,
           mode: :active,
           scheme_as_string: "http",
           requests: {[], []},
           state: :closed,
           buffer: "",
           proxy_headers: [],
           private: %{},
           log: false
         }, %Mint.TransportError{reason: :closed}}

        # 2
        []

    Attempted function clauses (showing 2 out of 2):

        defp log_level({:error, _}, _)
        defp log_level({:ok, env}, config)

    (tesla 1.6.0) lib/tesla/middleware/logger.ex:213: Tesla.Middleware.Logger.log_level/2
    (tesla 1.6.0) lib/tesla/middleware/logger.ex:203: Tesla.Middleware.Logger.call/3
```

## Proposed solution

- Ensure we handle properly the connection errors. As example this should be logged:

```elixir
iex(16)> A.get

    09:33:28.750 [error] GET http://localhost:5984/ping -> error: %Mint.TransportError{reason: :closed} (2.600 ms)
    {:error, %Mint.TransportError{reason: :closed}}
    
    09:33:28.750 [debug]
    >>> REQUEST >>>
    (no query)
    (no headers)
    (no body)
    
    <<< RESPONSE ERROR <<<
    %Mint.TransportError{reason: :closed}
```

PTAL @yordis. Thanks!