### PR TITLE
Replace get_env with compile_env in module body

### DIFF
--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -182,9 +182,7 @@ defmodule Tesla.Middleware.Logger do
 
   alias Tesla.Middleware.Logger.Formatter
 
-  @config if function_exported?(Application, :compile_env, 3),
-    do: Application.compile_env(:tesla, __MODULE__, []), else:
-    Application.get_env(:tesla, __MODULE__, [])
+  @config Application.compile_env(:tesla, __MODULE__, [])
 
   @format Formatter.compile(@config[:format])
 

--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -182,7 +182,10 @@ defmodule Tesla.Middleware.Logger do
 
   alias Tesla.Middleware.Logger.Formatter
 
-  @config Application.get_env(:tesla, __MODULE__, [])
+  @config if function_exported?(Application, :compile_env, 3),
+    do: Application.compile_env(:tesla, __MODULE__, []), else:
+    Application.get_env(:tesla, __MODULE__, [])
+
   @format Formatter.compile(@config[:format])
 
   @type log_level :: :info | :warn | :error

--- a/lib/tesla/middleware/telemetry.ex
+++ b/lib/tesla/middleware/telemetry.ex
@@ -80,9 +80,10 @@ if Code.ensure_loaded?(:telemetry) do
     ```
     """
 
-    @disable_legacy_event Application.get_env(:tesla, Tesla.Middleware.Telemetry,
-                            disable_legacy_event: false
-                          )[:disable_legacy_event]
+    @disable_legacy_event (if function_exported?(Application, :compile_env, 3),
+    do: Application.compile_env(:tesla, __MODULE__), else:
+    Application.get_env(:tesla, __MODULE__, []))[:disable_legacy_event] || false
+
 
     @behaviour Tesla.Middleware
 

--- a/lib/tesla/middleware/telemetry.ex
+++ b/lib/tesla/middleware/telemetry.ex
@@ -143,7 +143,7 @@ if Code.ensure_loaded?(:telemetry) do
     end
 
     if @disable_legacy_event do
-      defp emit_legacy_event(duration, result) do
+      defp emit_legacy_event(_duration, _result) do
         :ok
       end
     else

--- a/lib/tesla/middleware/telemetry.ex
+++ b/lib/tesla/middleware/telemetry.ex
@@ -80,10 +80,8 @@ if Code.ensure_loaded?(:telemetry) do
     ```
     """
 
-    @disable_legacy_event (if function_exported?(Application, :compile_env, 3),
-    do: Application.compile_env(:tesla, __MODULE__), else:
-    Application.get_env(:tesla, __MODULE__, []))[:disable_legacy_event] || false
-
+    @disable_legacy_event Application.compile_env(:tesla, Tesla.Middleware.Telemetry,
+      disable_legacy_event: false)[:disable_legacy_event]
 
     @behaviour Tesla.Middleware
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Tesla.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/teamon/tesla"
-  @version "1.6.1"
+  @version "1.7.0"
 
   def project do
     [
@@ -10,7 +10,7 @@ defmodule Tesla.Mixfile do
       version: @version,
       description: description(),
       package: package(),
-      elixir: "~> 1.7",
+      elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       lockfile: lockfile(System.get_env("LOCKFILE")),


### PR DESCRIPTION
close #579 

Changes:

1. Replace Application.get_env with Application.compile_env in `Tesla.Middleware.Logger.Formatter` & `Tesla.Middleware.Telemetry` modules.
2. Put prefix with unused vars.