### PR TITLE
Upgrade verify_ssl_fun to 1.1.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       matrix:
         elixir:
+          - 1.15
           - 1.14
-          - 1.13
         otp:
           - 25.3
-          - 24.3
+          - 26.0
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir

--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -72,7 +72,7 @@ if Code.ensure_loaded?(:hackney) do
     end
 
     defp request(method, url, headers, body, opts) do
-      handle(:hackney.request(method, url, headers, body || '', opts), opts)
+      handle(:hackney.request(method, url, headers, body || ~c"", opts), opts)
     end
 
     defp request_stream(method, url, headers, body, opts) do

--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -80,8 +80,8 @@ defmodule Tesla.Adapter.Httpc do
     headers = for {key, value} <- headers, do: {to_charlist(key), to_charlist(value)}
 
     {content_type, headers} =
-      case List.keytake(headers, 'content-type', 0) do
-        nil -> {'text/plain', headers}
+      case List.keytake(headers, ~c"content-type", 0) do
+        nil -> {~c"text/plain", headers}
         {{_, ct}, headers} -> {ct, headers}
       end
 

--- a/lib/tesla/middleware.ex
+++ b/lib/tesla/middleware.ex
@@ -16,11 +16,11 @@ defmodule Tesla.Middleware do
       Tesla.client([{Tesla.Middleware.BaseUrl, "https://example.com"}])
       
   ## Ordering
-  
+
   The order in which middleware is defined matters. Note that the order when _sending_ the request
   matches the order the middleware was defined in, but the order when _receiving_ the response
   is reversed.
-  
+
   For example, `Tesla.Middleware.DecompressResponse` must come _after_ `Tesla.Middleware.JSON`,
   otherwise the response isn't decompressed before it reaches the JSON parser.
 

--- a/mix.lock
+++ b/mix.lock
@@ -42,7 +42,7 @@
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "poison": {:hex, :poison, "5.0.0", "d2b54589ab4157bbb82ec2050757779bfed724463a544b6e20d79855a9e43b24", [:mix], [{:decimal, "~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "11dc6117c501b80c62a7594f941d043982a1bd05a1184280c0d9166eb4d8d3fc"},
   "ranch": {:hex, :ranch, "2.1.0", "2261f9ed9574dcfcc444106b9f6da155e6e540b2f82ba3d42b339b93673b72a3", [:make, :rebar3], [], "hexpm", "244ee3fa2a6175270d8e1fc59024fd9dbc76294a321057de8f803b1479e76916"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -197,7 +197,7 @@ defmodule Tesla.Adapter.GunTest do
     }
 
     assert {:error, "socks protocol is not supported"} ==
-             call(request, proxy: {:socks5, 'localhost', 1234})
+             call(request, proxy: {:socks5, ~c"localhost", 1234})
   end
 
   test "receive gun_up message when receive is false" do

--- a/test/tesla/middleware/timeout_test.exs
+++ b/test/tesla/middleware/timeout_test.exs
@@ -115,7 +115,7 @@ defmodule Tesla.Middleware.TimeoutTest do
           [{last_module, _, _, file_info} | _] = __STACKTRACE__
 
           assert Tesla.Middleware.TimeoutTest.Client == last_module
-          assert file_info[:file] == 'lib/tesla/builder.ex'
+          assert file_info[:file] == ~c"lib/tesla/builder.ex"
           assert file_info[:line] == 23
       else
         _ ->
@@ -131,7 +131,7 @@ defmodule Tesla.Middleware.TimeoutTest do
           [_, {timeout_module, _, _, module_file_info} | _] = __STACKTRACE__
 
           assert Tesla.Middleware.Timeout == timeout_module
-          assert module_file_info == [file: 'lib/tesla/middleware/timeout.ex', line: 59]
+          assert module_file_info == [file: ~c"lib/tesla/middleware/timeout.ex", line: 59]
       else
         _ ->
           flunk("Expected exception to be thrown")


### PR DESCRIPTION
Running `mix test` results in the following error

```
➜  tesla git:(master) mix test
==> ssl_verify_fun
Compiling 7 files (.erl)
src/ssl_verify_pk.erl:14:14: can't find include lib "public_key/include/public_key.hrl"
%   14| -include_lib("public_key/include/public_key.hrl").
%     |              ^

src/ssl_verify_pk.erl:26:26: record 'OTPCertificate' undefined
%   26| -spec verify_fun(Cert :: #'OTPCertificate'{},
%     |                          ^

src/ssl_verify_fingerprint.erl:15:14: can't find include lib "public_key/include/public_key.hrl"
%   15| -include_lib("public_key/include/public_key.hrl").
%     |              ^

src/ssl_verify_fun_cert_helpers.erl:13:14: can't find include lib "public_key/include/public_key.hrl"
%   13| -include_lib("public_key/include/public_key.hrl").
%     |              ^

src/ssl_verify_pk.erl:28:39: record 'Extension' undefined
%   28|                           {extension, #'Extension'{}}, InitialUserState :: term()) ->
%     |                                       ^

src/ssl_verify_hostname.erl:16:14: can't find include lib "public_key/include/public_key.hrl"
%   16| -include_lib("public_key/include/public_key.hrl").
%     |              ^

src/ssl_verify_fingerprint.erl:27:26: record 'OTPCertificate' undefined
%   27| -spec verify_fun(Cert :: #'OTPCertificate'{},
%     |                          ^

src/ssl_verify_fun_cert_helpers.erl:23:34: undefined macro 'id-ce-subjectAltName'
%   23|   AltSubject = select_extension(?'id-ce-subjectAltName', Extensions),
%     |                                  ^

src/ssl_verify_pk.erl:51:30: record 'OTPCertificate' undefined
%   51| -spec verify_cert_pk(Cert :: #'OTPCertificate'{}, Pk :: pk()) ->
%     |                              ^

src/ssl_verify_hostname.erl:28:26: record 'OTPCertificate' undefined
%   28| -spec verify_fun(Cert :: #'OTPCertificate'{},
%     |                          ^

src/ssl_verify_fingerprint.erl:29:39: record 'Extension' undefined
%   29|                           {extension, #'Extension'{}}, InitialUserState :: term()) ->
%     |                                       ^

src/ssl_verify_fun_cert_helpers.erl:9:2: function extract_dns_names/1 undefined
%    9| -export([extract_dns_names/1,
%     |  ^

src/ssl_verify_hostname.erl:30:39: record 'Extension' undefined
%   30|                           {extension, #'Extension'{}}, InitialUserState :: term()) ->
%     |                                       ^

src/ssl_verify_fingerprint.erl:52:39: record 'OTPCertificate' undefined
%   52| -spec verify_cert_fingerprint(Cert :: #'OTPCertificate'{}, Fingerprint :: fingerprint()) ->
%     |                                       ^

src/ssl_verify_fun_cert_helpers.erl:19:2: spec for undefined function extract_dns_names/1
%   19| -spec extract_dns_names(Cert :: #'OTPCertificate'{}) -> [] | [string()].
%     |  ^

src/ssl_verify_hostname.erl:46:36: record 'OTPCertificate' undefined
%   46| -spec verify_cert_hostname(Cert :: #'OTPCertificate'{}, Hostname :: hostname()) ->
%     |                                    ^

src/ssl_verify_fun_cert_helpers.erl:19:33: record 'OTPCertificate' undefined
%   19| -spec extract_dns_names(Cert :: #'OTPCertificate'{}) -> [] | [string()].
%     |                                 ^

src/ssl_verify_hostname.erl:76:38: record 'OTPCertificate' undefined
%   76|                              Cert :: #'OTPCertificate'{},
%     |                                      ^

src/ssl_verify_fun_cert_helpers.erl:32:26: record 'OTPCertificate' undefined
%   32| -spec extract_cn(Cert :: #'OTPCertificate'{}) -> {error, no_common_name} | {ok, string()} | {error, invalid}.
%     |                          ^

src/ssl_verify_fun_cert_helpers.erl:34:17: record 'OTPCertificate' undefined
%   34|   TBSCert = Cert#'OTPCertificate'.tbsCertificate,
%     |                 ^

src/ssl_verify_fun_cert_helpers.erl:35:32: record 'OTPTBSCertificate' undefined
%   35|   {rdnSequence, List} = TBSCert#'OTPTBSCertificate'.subject,
%     |                                ^

src/ssl_verify_fun_cert_helpers.erl:38:26: record 'OTPCertificate' undefined
%   38| -spec extract_pk(Cert :: #'OTPCertificate'{}) -> {error, no_common_name} | #'SubjectPublicKeyInfo'{}.
%     |                          ^

src/ssl_verify_fun_cert_helpers.erl:38:76: record 'SubjectPublicKeyInfo' undefined
%   38| -spec extract_pk(Cert :: #'OTPCertificate'{}) -> {error, no_common_name} | #'SubjectPublicKeyInfo'{}.
%     |                                                                            ^

src/ssl_verify_fun_cert_helpers.erl:40:17: record 'OTPCertificate' undefined
%   40|   TBSCert = Cert#'OTPCertificate'.tbsCertificate,
%     |                 ^

src/ssl_verify_fun_cert_helpers.erl:41:26: record 'OTPTBSCertificate' undefined
%   41|   PublicKeyInfo = TBSCert#'OTPTBSCertificate'.subjectPublicKeyInfo,
%     |                          ^

src/ssl_verify_fun_cert_helpers.erl:42:16: record 'OTPSubjectPublicKeyInfo' undefined
%   42|   PublicKeyInfo#'OTPSubjectPublicKeyInfo'.subjectPublicKey.
%     |                ^

src/ssl_verify_fun_cert_helpers.erl:48:24: record 'Extension' undefined
%   48| -spec extensions_list([#'Extension'{}] | asn1_NOVALUE) -> [] | [#'Extension'{}].
%     |                        ^

src/ssl_verify_fun_cert_helpers.erl:48:65: record 'Extension' undefined
%   48| -spec extensions_list([#'Extension'{}] | asn1_NOVALUE) -> [] | [#'Extension'{}].
%     |                                                                 ^

src/ssl_verify_fun_cert_helpers.erl:55:39: record 'Extension' undefined
%   55| -spec select_extension(Id :: term(), [#'Extension'{}]) -> undefined | #'Extension'{}.
%     |                                       ^

src/ssl_verify_fun_cert_helpers.erl:55:71: record 'Extension' undefined
%   55| -spec select_extension(Id :: term(), [#'Extension'{}]) -> undefined | #'Extension'{}.
%     |                                                                       ^

src/ssl_verify_fun_cert_helpers.erl:57:28: record 'Extension' undefined
%   57|   Matching = [Extension || #'Extension'{extnID = ExtId} = Extension <- Extensions, ExtId =:= Id],
%     |                            ^

src/ssl_verify_fun_cert_helpers.erl:57:84: variable 'ExtId' is unbound
%   57|   Matching = [Extension || #'Extension'{extnID = ExtId} = Extension <- Extensions, ExtId =:= Id],
%     |                                                                                    ^

src/ssl_verify_fun_cert_helpers.erl:75:15: record 'AttributeTypeAndValue' undefined
%   75| extract_cn2([[#'AttributeTypeAndValue'{type={2, 5, 4, 3},
%     |               ^

src/ssl_verify_fun_cert_helpers.erl:77:39: variable 'CN' is unbound
%   77|   ssl_verify_fun_encodings:get_string(CN);
%     |                                       ^

src/ssl_verify_fun_cert_helpers.erl:49:1: Warning: function extensions_list/1 is unused
%   49| extensions_list(E) ->
%     | ^

src/ssl_verify_fun_cert_helpers.erl:56:1: Warning: function select_extension/2 is unused
%   56| select_extension(Id, Extensions) ->
%     | ^

src/ssl_verify_fun_cert_helpers.erl:64:1: Warning: function extract_dns_names_from_alt_names/2 is unused
%   64| extract_dns_names_from_alt_names([ExtValue | Rest], Acc) ->
%     | ^

could not compile dependency :ssl_verify_fun, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile ssl_verify_fun --force", update it with "mix deps.update ssl_verify_fun" or clean it with "mix deps.clean ssl_verify_fun"
```

Upgrading `ssl_verify_fun` to `1.1.7` fixe the above errors and allows tests to run.