### PR TITLE
feat: add support for should_retry with arity of 2 to Retry middleware

### DIFF
--- a/lib/tesla/middleware.ex
+++ b/lib/tesla/middleware.ex
@@ -14,13 +14,13 @@ defmodule Tesla.Middleware do
   or inside tuple in case of dynamic middleware (`Tesla.client/1`):
 
       Tesla.client([{Tesla.Middleware.BaseUrl, "https://example.com"}])
-      
+
   ## Ordering
-  
+
   The order in which middleware is defined matters. Note that the order when _sending_ the request
   matches the order the middleware was defined in, but the order when _receiving_ the response
   is reversed.
-  
+
   For example, `Tesla.Middleware.DecompressResponse` must come _after_ `Tesla.Middleware.JSON`,
   otherwise the response isn't decompressed before it reaches the JSON parser.
 


### PR DESCRIPTION
Closes https://github.com/elixir-tesla/tesla/issues/578

I also formatted the middleware.ex as it caused the lining test to fail aaaand made a typo in the branch name 🤦


~I am open to ideas on how to make this work with what is described in that issue... I needed a way to prevent Retry from repeating POST/PUT requests on timeouts, so I wrote it and at first glance thought it was the same issue, but now I see it isn't :)~

Edit: with the addition of the suggested changes by @yordis, this now does in fact close the aforementioned issue 🎊 