### PR TITLE
feat: override adapter at OTP app level

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -123,6 +123,7 @@ defmodule Tesla do
   def effective_adapter(module, client \\ %Tesla.Client{}) do
     with nil <- client.adapter,
          nil <- adapter_per_module_from_config(module),
+         nil <- adapter_per_otp_app_from_config(module),
          nil <- adapter_per_module(module),
          nil <- adapter_from_config() do
       adapter_default()
@@ -131,6 +132,14 @@ defmodule Tesla do
 
   defp adapter_per_module_from_config(module) do
     case Application.get_env(:tesla, module, [])[:adapter] do
+      nil -> nil
+      {adapter, opts} -> {adapter, :call, [opts]}
+      adapter -> {adapter, :call, [[]]}
+    end
+  end
+
+  defp adapter_per_otp_app_from_config(module) do
+    case Application.get_env(:tesla, module.__otp_app__, [])[:adapter] do
       nil -> nil
       {adapter, opts} -> {adapter, :call, [opts]}
       adapter -> {adapter, :call, [[]]}

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -17,6 +17,10 @@ defmodule TeslaTest do
       use Tesla
     end
 
+    defmodule EmptyClientInEmptyApp do
+      use Tesla, otp_app: :empty_app
+    end
+
     defmodule ModuleAdapterClient do
       use Tesla
 
@@ -44,6 +48,7 @@ defmodule TeslaTest do
 
     setup do
       # clean config
+      Application.delete_env(:tesla, :empty_app)
       Application.delete_env(:tesla, EmptyClient)
       Application.delete_env(:tesla, ModuleAdapterClient)
       :ok
@@ -53,9 +58,14 @@ defmodule TeslaTest do
       assert Tesla.effective_adapter(EmptyClient) == {Tesla.Adapter.Httpc, :call, [[]]}
     end
 
-    test "use adapter override from config" do
+    test "use adapter override from config for module" do
       Application.put_env(:tesla, EmptyClient, adapter: Tesla.Mock)
       assert Tesla.effective_adapter(EmptyClient) == {Tesla.Mock, :call, [[]]}
+    end
+
+    test "use adapter override from config for otp_app" do
+      Application.put_env(:tesla, :empty_app, adapter: Tesla.Mock)
+      assert Tesla.effective_adapter(EmptyClientInEmptyApp) == {Tesla.Mock, :call, [[]]}
     end
 
     test "prefer config over module setting" do


### PR DESCRIPTION
Thanks for all your hard works, Tesla already [has great support on choosing adapter at different levels](https://github.com/elixir-tesla/tesla/blob/189ffa5b0c26fcce1a6c88e4fe2fb17de772e578/lib/tesla.ex#L123).

But, it still have one case that tesla doesn't support - override adapter at OTP app level.

This PR adds that feature, which is useful when we want to use different adapter for different OTP apps.

---
An example - I installed two packages from Hex:
+ `foo`, whose OTP app name is `:foo`, the underlying HTTP client is **Tesla**
+ `bar`, whose OTP app name is `:bar`, the underlying HTTP client is **Tesla**, too.

I want to use `:finch` as the adapter for them all, but due to some reason, I have to set HTTP proxy for `bar`. But, `:finch` doesn't support proxy, for now. So I have to use `:hackney`, which supports proxy.

With this PR, I can do something like:

```
config :telsa, :adapter, {Tesla.Adapter.Finch, name: MyFinch}
config :tesla, :bar, adapter: Tesla.Adapter.Hackney # override adapter for :bar in an easy way.
```

---

Feel free to comment. I can make any modifications necessary to ensure this PR is mergeable. ;)

