### PR TITLE
Update tesla.ex

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -115,7 +115,7 @@ defmodule Tesla do
 
   defp prepare(module, %{pre: pre, post: post} = client, options) do
     env = struct(Env, options ++ [__module__: module, __client__: client])
-    stack = pre ++ module.__middleware__ ++ post ++ [effective_adapter(module, client)]
+    stack = pre ++ module.__middleware__() ++ post ++ [effective_adapter(module, client)]
     {env, stack}
   end
 


### PR DESCRIPTION
warning: using map.field notation (without parentheses) to invoke function Tesla.__middleware__() is deprecated, you must add parentheses instead: remote.function()