### PR TITLE
Update dependency versions in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ Add `:tesla` as dependency in `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:tesla, "~> 1.4"},
+    {:tesla, "~> 1.9"},
 
     # optional, but recommended adapter
-    {:hackney, "~> 1.17"},
+    {:hackney, "~> 1.20"},
 
     # optional, required by JSON middleware
-    {:jason, ">= 1.0.0"}
+    {:jason, "~> 1.4"}
   ]
 end
 ```
@@ -199,7 +199,7 @@ When using adapter other than `:httpc` remember to add it to the dependencies li
 defp deps do
   [
     {:tesla, "~> 1.4.0"},
-    {:hackney, "~> 1.10"} # when using hackney adapter
+    {:hackney, "~> 1.20"} # when using hackney adapter
   ]
 end
 ```


### PR DESCRIPTION
The dependency versions listed were out of date, and are updated by this commit.

The syntax for installing Jason has been changed from the `>=` syntax to the `~>` syntax. (This is the format used in the Jason library documentation.)