### PR TITLE
remove seemingly unnecessary step

### DIFF
--- a/lib/tesla/adapter/finch.ex
+++ b/lib/tesla/adapter/finch.ex
@@ -79,7 +79,7 @@ if Code.ensure_loaded?(Finch) do
 
     defp build(method, url, headers, %Multipart{} = mp) do
       headers = headers ++ Multipart.headers(mp)
-      body = Multipart.body(mp) |> Enum.to_list()
+      body = Multipart.body(mp)
 
       build(method, url, headers, body)
     end


### PR DESCRIPTION
This will bring a stream into memory, which can take a lot of memory unnecessarily

Admittedly there is a lot of intermediate code that I can't attach here, but replacing the finch adapter with the httpc adapter looks like this with a 10G multipart request body:

Finch adapter:

![finch](https://github.com/elixir-tesla/tesla/assets/378721/2d557131-bd9c-493e-a25a-093e8e630769)

httpc adapter:

![httpc](https://github.com/elixir-tesla/tesla/assets/378721/a033653c-92cb-4e76-b597-f3a39742e470)

(Notice that the units are different between the two screenshots, one is in MB and the other in GB)


I can try to characterize the memory issue I am seeing with a test if you would like to see, but uploading a big file to see a memory spike in a test seems like a test you wouldn't want in the long term.