### PR TITLE
Update CI with current Elixir and Erlang/OTP versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.13'
-        otp-version: '24.3'
+        elixir-version: '1.15'
+        otp-version: '25.3'
     - name: Restore dependencies cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,11 @@ jobs:
           - otp: '25.3.2.12'
             elixir: '1.15.8'
             experimental: false
-            lint: true
+            lint: false
           - otp: '26.2.5'
             elixir: '1.16.3'
             experimental: true
-            lint: false
+            lint: true
           - otp: '27.0'
             elixir: '1.17.1'
             experimental: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,22 @@ jobs:
   Test:
     runs-on: ubuntu-latest
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        elixir:
-          - 1.14
-          - 1.13
-        otp:
-          - 25.3
-          - 24.3
+        include:
+          - otp: '25.3'
+            elixir: '1.15'
+            experimental: false
+          - otp: '26.2'
+            elixir: '1.16'
+            experimental: false
+          - otp: '26.2'
+            elixir: '1.17'
+            experimental: true
+          - otp: '27.0'
+            elixir: '1.17'
+            experimental: true
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
@@ -41,14 +49,22 @@ jobs:
   Test-gun1:
     runs-on: ubuntu-latest
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}} - Gun1
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        elixir:
-          - 1.14
-          - 1.13
-        otp:
-          - 25.3
-          - 24.3
+        include:
+          - otp: '25.3'
+            elixir: '1.15'
+            experimental: false
+          - otp: '26.2'
+            elixir: '1.16'
+            experimental: false
+          - otp: '26.2'
+            elixir: '1.17'
+            experimental: true
+          - otp: '27.0'
+            elixir: '1.17'
+            experimental: true
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
@@ -83,8 +99,8 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.13'
-        otp-version: '24.3'
+        elixir-version: '1.15'
+        otp-version: '25.3'
         version-type: strict
     - name: Restore dependencies cache
       uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,17 +10,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - otp: '25.3'
-            elixir: '1.15'
+          - otp: '25.3.2.12'
+            elixir: '1.15.8'
             experimental: false
-          - otp: '26.2'
-            elixir: '1.16'
+          - otp: '26.2.5'
+            elixir: '1.16.3'
             experimental: false
-          - otp: '26.2'
-            elixir: '1.17'
-            experimental: true
           - otp: '27.0'
-            elixir: '1.17'
+            elixir: '1.17.1'
             experimental: true
     steps:
     - uses: actions/checkout@v4
@@ -49,29 +46,13 @@ jobs:
   Test-gun1:
     runs-on: ubuntu-latest
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}} - Gun1
-    continue-on-error: ${{ matrix.experimental }}
-    strategy:
-      matrix:
-        include:
-          - otp: '25.3'
-            elixir: '1.15'
-            experimental: false
-          - otp: '26.2'
-            elixir: '1.16'
-            experimental: false
-          - otp: '26.2'
-            elixir: '1.17'
-            experimental: true
-          - otp: '27.0'
-            elixir: '1.17'
-            experimental: true
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: ${{ matrix.elixir }}
-        otp-version: ${{ matrix.otp }}
+        elixir-version: '1.15.8'
+        otp-version: '25.3.2.12'
         version-type: strict
     - name: Restore dependencies cache
       uses: actions/cache@v4
@@ -99,8 +80,8 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.15'
-        otp-version: '25.3'
+        elixir-version: '1.15.8'
+        otp-version: '25.3.2.12'
         version-type: strict
     - name: Restore dependencies cache
       uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
             experimental: false
           - otp: '26.2.5'
             elixir: '1.16.3'
-            experimental: false
+            experimental: true
           - otp: '27.0'
             elixir: '1.17.1'
             experimental: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,15 @@ jobs:
           - otp: '25.3.2.12'
             elixir: '1.15.8'
             experimental: false
+            lint: true
           - otp: '26.2.5'
             elixir: '1.16.3'
             experimental: true
+            lint: false
           - otp: '27.0'
             elixir: '1.17.1'
             experimental: true
+            lint: false
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
@@ -42,10 +45,14 @@ jobs:
         mix deps.get
     - name: Run Tests
       run: mix test --trace
+    - if: ${{ matrix.lint }}
+      name: Check Format
+      run: mix format --check-formatted
 
+  # This tests with Gun 1, where as the standard Test job tests Gun 2
   Test-gun1:
     runs-on: ubuntu-latest
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}} - Gun1
+    name: Gun 1
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
@@ -72,27 +79,3 @@ jobs:
       env:
         LOCKFILE: gun1
       run: mix test test/tesla/adapter/gun_test.exs --trace
-
-  Linting:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Elixir
-      uses: erlef/setup-beam@v1
-      with:
-        elixir-version: '1.15.8'
-        otp-version: '25.3.2.12'
-        version-type: strict
-    - name: Restore dependencies cache
-      uses: actions/cache@v4
-      with:
-        path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-mix-
-    - name: Install Dependencies
-      run: |
-        mix local.rebar --force
-        mix local.hex --force
-        mix deps.get
-    - name: Check Format
-      run: mix format --check-formatted

--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -72,7 +72,7 @@ if Code.ensure_loaded?(:hackney) do
     end
 
     defp request(method, url, headers, body, opts) do
-      handle(:hackney.request(method, url, headers, body || '', opts), opts)
+      handle(:hackney.request(method, url, headers, body || ~c"", opts), opts)
     end
 
     defp request_stream(method, url, headers, body, opts) do

--- a/test/tesla/middleware/timeout_test.exs
+++ b/test/tesla/middleware/timeout_test.exs
@@ -115,7 +115,7 @@ defmodule Tesla.Middleware.TimeoutTest do
           [{last_module, _, _, file_info} | _] = __STACKTRACE__
 
           assert Tesla.Middleware.TimeoutTest.Client == last_module
-          assert file_info[:file] == 'lib/tesla/builder.ex'
+          assert file_info[:file] == ~c"lib/tesla/builder.ex"
           assert file_info[:line] == 23
       else
         _ ->
@@ -131,7 +131,7 @@ defmodule Tesla.Middleware.TimeoutTest do
           [_, {timeout_module, _, _, module_file_info} | _] = __STACKTRACE__
 
           assert Tesla.Middleware.Timeout == timeout_module
-          assert module_file_info == [file: 'lib/tesla/middleware/timeout.ex', line: 59]
+          assert module_file_info == [file: ~c"lib/tesla/middleware/timeout.ex", line: 59]
       else
         _ ->
           flunk("Expected exception to be thrown")


### PR DESCRIPTION
> I am trying to maintain (in CI) the latest 2 major versions, so Elixir 15+ and OTP 25+; wait 2-3 months and it will be Elixir 16+ and OTP 26+

https://github.com/elixir-tesla/tesla/pull/623#issuecomment-2176886751

This approach runs fewer permutations, so we're not attempting an old version of Elixir on a new version of Erlang. We also can flag the latest version or release candidate as experimental, so that it doesn't block merging, but still reports the failures.