### PR TITLE
fix: Support registered names in mock

### DIFF
--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -233,6 +233,11 @@ defmodule Tesla.Mock do
       Enum.find(Process.get(:"$ancestors", []), self(), fn ancestor ->
         !is_nil(Process.get(ancestor, __MODULE__))
       end)
+      |> case do
+        nil -> raise "Unknown pid_holder in mock"
+        pid when is_pid(pid) -> pid
+        name when is_atom(name) -> Process.whereis(name)
+      end
 
     pid_holder |> Process.info() |> Keyword.get(:dictionary) |> Keyword.get(__MODULE__)
   end


### PR DESCRIPTION
In some situations, the pid_holder is a registered process (e.g, MyApp.Supervisor). Process.info/1 does not support this, so we have to use Process.whereis/1 to resolve the actual pid.

This small issue was introduced between 1.9 and 1.10.