### PR TITLE
fix: json decoder middleware for uppercase content type

### DIFF
--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -129,8 +129,15 @@ defmodule Tesla.Middleware.JSON do
 
   defp decodable_content_type?(env, opts) do
     case Tesla.get_header(env, "content-type") do
-      nil -> false
-      content_type -> Enum.any?(content_types(opts), &String.starts_with?(content_type, &1))
+      nil ->
+        false
+
+      content_type ->
+        content_type = String.downcase(content_type)
+
+        opts
+        |> content_types()
+        |> Enum.any?(&String.starts_with?(content_type, &1))
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Tesla.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/teamon/tesla"
-  @version "1.10.1"
+  @version "1.10.2"
 
   def project do
     [

--- a/test/tesla/middleware/json_test.exs
+++ b/test/tesla/middleware/json_test.exs
@@ -10,6 +10,10 @@ defmodule Tesla.Middleware.JsonTest do
       adapter fn env ->
         {status, headers, body} =
           case env.url do
+            # GET https://testlajson.free.beeceptor.com/todos to see the response
+            "/uppercased-content-type" ->
+              {200, [{"content-type", "application/JSON"}], "{\"value\": 123}"}
+
             "/decode" ->
               {200, [{"content-type", "application/json"}], "{\"value\": 123}"}
 
@@ -46,6 +50,11 @@ defmodule Tesla.Middleware.JsonTest do
 
         {:ok, %{env | status: status, headers: headers, body: body}}
       end
+    end
+
+    test "decoding json with insensitive content type" do
+      assert {:ok, env} = Client.get("/uppercased-content-type")
+      assert env.body == %{"value" => 123}
     end
 
     test "decode JSON body" do


### PR DESCRIPTION
closes #680
