### PR TITLE
feat: add retry_count opt in the retry middleware

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Tesla.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/teamon/tesla"
-  @version "1.10.3"
+  @version "1.11.0"
 
   def project do
     [

--- a/test/tesla/middleware/retry_test.exs
+++ b/test/tesla/middleware/retry_test.exs
@@ -75,7 +75,15 @@ defmodule Tesla.Middleware.RetryTest do
   end
 
   test "finally pass on laggy request" do
-    assert {:ok, %Tesla.Env{url: "/maybe", method: :get}} = Client.get("/maybe")
+    assert {:ok, %Tesla.Env{url: "/maybe", method: :get}} = Client.get("/maybe") |> dbg()
+  end
+
+  test "pass retry_count opt" do
+    assert {:ok, env} = Client.get("/maybe")
+    assert env.opts[:retry_count] == 5
+
+    assert {:ok, env} = Client.get("/ok")
+    assert env.opts[:retry_count] == nil
   end
 
   test "raise if max_retries is exceeded" do


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-erlang-contrib/pull/334

It will allow us to set `Trace.http_retry_count()` telemetry