### PR TITLE
TLS & httpc: suggested higher limit of max intermediate certs

### DIFF
--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -34,7 +34,7 @@ defmodule Tesla.Adapter.Httpc do
         ssl: [
           verify: :verify_peer,
           cacerts: :public_key.cacerts_get(),
-          depth: 3,
+          depth: 100,
           customize_hostname_check: [
             match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
           ],


### PR DESCRIPTION
OpenSSL sets this to 100 by default, which prevents validation errors for endpoints presenting a longer certificate chain.

Reference:
* https://docs.openssl.org/3.3/man3/SSL_CTX_set_verify/#notes