### PR TITLE
docs: fix typos again

### DIFF
--- a/lib/tesla/adapter/gun.ex
+++ b/lib/tesla/adapter/gun.ex
@@ -278,7 +278,7 @@ if Code.ensure_loaded?(:gun) do
     defp maybe_add_transport(%URI{scheme: "https"}, opts), do: Map.put(opts, :transport, :tls)
     defp maybe_add_transport(_, opts), do: opts
 
-    # Support for gun master branch where transport_opts, were splitted to tls_opts and tcp_opts
+    # Support for gun master branch where transport_opts, were split to tls_opts and tcp_opts
     # https://github.com/ninenines/gun/blob/491ddf58c0e14824a741852fdc522b390b306ae2/doc/src/manual/gun.asciidoc#changelog
     # TODO: remove after update to gun 2.0
     defp fetch_tls_opts(%{tls_opts: tls_opts}) when is_list(tls_opts), do: tls_opts

--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -222,7 +222,7 @@ defmodule Tesla.Middleware.LoggerTest do
       assert is_list(Formatter.compile(nil))
     end
 
-    test "compile with funtion" do
+    test "compile with function" do
       assert Formatter.compile(&CompileMod.format/3) == (&CompileMod.format/3)
     end
 
@@ -281,7 +281,7 @@ defmodule Tesla.Middleware.LoggerTest do
                "GET /get page=1&sort=desc&status%5B%5D=a&status%5B%5D=b&status%5B%5D=c&user%5Bname%5D=Jon&user%5Bage%5D=20 -> 201 | 200.000"
     end
 
-    test "format with funtion" do
+    test "format with function" do
       assert Formatter.format(nil, nil, nil, &CompileMod.format/3) == "message"
     end
 


### PR DESCRIPTION
Found via `typos --hidden --format brief`