### PR TITLE
Make headers addition idempotent

### DIFF
--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -71,6 +71,7 @@ defmodule Tesla.Middleware.JSON do
       {:ok,
        env
        |> Tesla.put_body(body)
+       |> Tesla.delete_header("content-type")
        |> Tesla.put_headers([{"content-type", encode_content_type(opts)}])}
     else
       false -> {:ok, env}

--- a/test/tesla/middleware/json_test.exs
+++ b/test/tesla/middleware/json_test.exs
@@ -140,6 +140,7 @@ defmodule Tesla.Middleware.JsonTest do
           case {env.url, env.headers} do
             {"/encode", [{"content-type", "application/json"}]} ->
               {200, [{"content-type", "application/json"}], "{\"value\": 123}"}
+
             {"/encode", _} ->
               {400, [], "Invalid content type"}
           end
@@ -149,8 +150,10 @@ defmodule Tesla.Middleware.JsonTest do
     end
 
     test "does not repeat the Content-Type if it has been already added by another middleware" do
-      assert {:ok, env} = IdempotentContentTypeClient.post("/encode", %{"foo" => "bar"})
-      assert env.headers == [{"content-type", "application/json"}]
+      assert {:ok, %{status: 200, headers: headers}} =
+               IdempotentContentTypeClient.post("/encode", %{"foo" => "bar"})
+
+      assert headers == [{"content-type", "application/json"}]
     end
   end
 


### PR DESCRIPTION
## Problem

When used with the `Headers` middleware, `JSON` is sometimes able to add the `content-type` header twice if the former already added it. This prevents the usage of endpoints that have no body (no encodable) but that return JSON. This is not a problem with `hackney`, but if we use `Mint`, the duplicity is not handled and, in consequence, the header is duplicated.

## Proposed solution

Make idempotent the header addition so we allow our middleware to be isolated no matter how it is used. This could be opinionated, since we could rely on clients to design APIs that accept a non nil body, but let's see if you consider this as a good thing to have.

cc/ @yordis 