### PR TITLE
fix: ensure adapter is set

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -105,8 +105,9 @@ defmodule Tesla do
   end
 
   defp prepare(module, %{pre: pre, post: post} = client, options) do
-    env = struct(Env, options ++ [__module__: module, __client__: client])
-    stack = pre ++ module.__middleware__() ++ post ++ [effective_adapter(module, client)]
+    adapter = effective_adapter(module, client)
+    env = struct(Env, options ++ [__module__: module, __client__: %{client | adapter: adapter}])
+    stack = pre ++ module.__middleware__() ++ post ++ [adapter]
     {env, stack}
   end
 

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -49,7 +49,7 @@ defmodule TeslaTest do
       :ok
     end
 
-    test "defauilt adapter" do
+    test "default adapter" do
       assert Tesla.effective_adapter(EmptyClient) == {Tesla.Adapter.Httpc, :call, [[]]}
     end
 
@@ -61,6 +61,11 @@ defmodule TeslaTest do
     test "prefer config over module setting" do
       Application.put_env(:tesla, ModuleAdapterClient, adapter: Tesla.Mock)
       assert Tesla.effective_adapter(ModuleAdapterClient) == {Tesla.Mock, :call, [[]]}
+    end
+
+    test "ensure adapter is set" do
+      assert {:ok, response} = ModuleAdapterClient.request(url: "test")
+      assert response.__client__.adapter
     end
 
     test "execute module adapter" do


### PR DESCRIPTION
## Context

This ensures that the returned `Tesla.Env` includes the adapter used to make the call. This will help debug which adapter was used and also reflect what truly happened at runtime.

## Extra

Before

```elixir
iex(1)> Tesla.get("https://httpbin.org/get")
{:ok,
 %Tesla.Env{
   __client__: %Tesla.Client{
     adapter: nil
   }
 }}
 ```
After
```elixir
iex(1)> Tesla.get("https://httpbin.org/get")
{:ok,
 %Tesla.Env{
   __client__: %Tesla.Client{
     adapter: {Tesla.Adapter.Httpc, :call, [[]]}
   }
 }}
```