### PR TITLE
Fix quickstart typo

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -12,7 +12,7 @@ defmodule Tesla do
   defmodule ExampleApi do
     def client do
       Tesla.client([
-        Tesla.Middleware.BaseUrl, "http://api.example.com",
+        {Tesla.Middleware.BaseUrl, "http://api.example.com"},
         Tesla.Middleware.JSON
       ])
     end


### PR DESCRIPTION
Previous example gives error:

```
** (FunctionClauseError) no function clause matching in Tesla.Builder.runtime/1    
    
    The following arguments were given to Tesla.Builder.runtime/1:
    
        # 1
        "http://localhost:4001"
    
    Attempted function clauses (showing 4 out of 4):
    
        defp runtime(list) when is_list(list)
        defp runtime({module, opts}) when is_atom(module)
        defp runtime(fun) when is_function(fun)
        defp runtime(module) when is_atom(module)
    
    (tesla 1.13.2) lib/tesla/builder.ex:203: Tesla.Builder.runtime/1
    (elixir 1.16.1) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.16.1) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
    (tesla 1.13.2) lib/tesla/builder.ex:176: Tesla.Builder.client/3
    iex:1: (file)
```