### PR TITLE
Use rescue to avoid dependency inversion

### DIFF
--- a/lib/tesla/adapter/finch.ex
+++ b/lib/tesla/adapter/finch.ex
@@ -65,15 +65,20 @@ if Code.ensure_loaded?(Finch) do
       req_opts = Keyword.take(opts, [:pool_timeout, :receive_timeout])
       req = build(env.method, url, env.headers, env.body)
 
-      case request(req, name, req_opts, opts) do
-        {:ok, %Finch.Response{status: status, headers: headers, body: body}} ->
-          {:ok, %Tesla.Env{env | status: status, headers: headers, body: body}}
+      try do
+        case request(req, name, req_opts, opts) do
+          {:ok, %Finch.Response{status: status, headers: headers, body: body}} ->
+            {:ok, %Tesla.Env{env | status: status, headers: headers, body: body}}
 
         {:error, %Mint.TransportError{reason: reason}} ->
           {:error, reason}
 
-        {:error, reason} ->
-          {:error, reason}
+          {:error, reason} ->
+            {:error, reason}
+        end
+      rescue
+        e in RuntimeError ->
+          {:error, {:runtime_error, e}}
       end
     end
 

--- a/lib/tesla/adapter/finch.ex
+++ b/lib/tesla/adapter/finch.ex
@@ -70,8 +70,8 @@ if Code.ensure_loaded?(Finch) do
           {:ok, %Finch.Response{status: status, headers: headers, body: body}} ->
             {:ok, %Tesla.Env{env | status: status, headers: headers, body: body}}
 
-        {:error, %Mint.TransportError{reason: reason}} ->
-          {:error, reason}
+          {:error, %Mint.TransportError{reason: reason}} ->
+            {:error, reason}
 
           {:error, reason} ->
             {:error, reason}

--- a/test/tesla/adapter/finch_test.exs
+++ b/test/tesla/adapter/finch_test.exs
@@ -10,15 +10,14 @@ defmodule Tesla.Adapter.FinchTest do
   use Tesla.AdapterCase.StreamResponseBody
   use Tesla.AdapterCase.SSL
 
-  setup context do
+  setup do
     opts = [
       name: @finch_name,
       pools: %{
         @https => [
           conn_opts: [
             transport_opts: [cacertfile: "#{:code.priv_dir(:httparrot)}/ssl/server-ca.crt"]
-          ],
-          size: Map.get(context, :pool_size, 50)
+          ]
         ]
       }
     ]
@@ -45,7 +44,6 @@ defmodule Tesla.Adapter.FinchTest do
     assert {:error, :timeout} = call(request, receive_timeout: 100, response: :stream)
   end
 
-  @tag pool_size: 1
   test "Unavailable connection" do
     :sys.suspend(@finch_name)
 


### PR DESCRIPTION
## Problem

When using Finch is expected to receive a RuntimeError if the connection pool is exhausted, see https://github.com/sneako/finch/blob/main/test/finch_test.exs#L561

This is a problem because in a service that uses a lower tier API than the service itself, a dependency inversion of tiers can happen. For example, a tier 2 service calling a tier 3 service. 

The tier inversion happens because we are not rescuing the error and returning it into a tuple, so the operation can work without problems under this situation.

## Proposed solution

Encapsulate the error in the error tuple. I'm adding this solution here, but I want to know if you consider that it would be best suited in the Finch code itself. Changing `reraise` basically.

cc/ @yordis 