### PR TITLE
Tesla.Middleware.JSON: Add support for Elixir 1.18's JSON module

### DIFF
--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -12,6 +12,15 @@ defmodule Tesla.Middleware.JSON do
   mix deps.compile tesla
   ```
 
+  > #### Using built-in `JSON` from Elixir 1.18 {: .info}
+  >
+  > This middleware supports the built-in `JSON` module introduced in ELixir 1.18, but for historical
+  > reasons is it not the default. To use it, set it as the `:engine`:
+  >
+  >     {Tesla.Middleware.JSON, engine: JSON}
+  >
+  > For more advanced usage using custom encoders/decodes, provide the `:encode` and `:decode` anonymous functions instead.
+
   If you only need to encode the request body or decode the response body,
   you can use `Tesla.Middleware.EncodeJson` or `Tesla.Middleware.DecodeJson` directly instead.
 
@@ -23,6 +32,8 @@ defmodule Tesla.Middleware.JSON do
       Tesla.client([
         # use jason engine
         Tesla.Middleware.JSON,
+        # or
+        {Tesla.Middleware.JSON, engine: JSON}
         # or
         {Tesla.Middleware.JSON, engine: JSX, engine_opts: [strict: [:comments]]},
         # or
@@ -39,7 +50,7 @@ defmodule Tesla.Middleware.JSON do
   - `:decode` - decoding function
   - `:encode` - encoding function
   - `:encode_content_type` - content-type to be used in request header
-  - `:engine` - encode/decode engine, e.g `Jason`, `Poison` or `JSX`  (defaults to Jason)
+  - `:engine` - encode/decode engine, e.g `JSON`, `Jason`, `Poison` or `JSX`  (defaults to Jason)
   - `:engine_opts` - optional engine options
   - `:decode_content_types` - list of additional decodable content-types
   """

--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -172,7 +172,14 @@ defmodule Tesla.Middleware.JSON do
     if fun = opts[op] do
       fun.(data)
     else
-      engine = Keyword.get(opts, :engine, @default_engine)
+      engine =
+        case Keyword.fetch(opts, :engine) do
+          # Special case for JSON, which doesn't have encode/2 nor return {:ok, json}
+          {:ok, JSON} -> Tesla.Middleware.JSON.JSONAdapter
+          {:ok, engine} -> engine
+          :error -> @default_engine
+        end
+
       opts = Keyword.get(opts, :engine_opts, [])
 
       apply(engine, op, [data, opts])

--- a/lib/tesla/middleware/json/json_adapter.ex
+++ b/lib/tesla/middleware/json/json_adapter.ex
@@ -1,0 +1,16 @@
+defmodule Tesla.Middleware.JSON.JSONAdapter do
+  @moduledoc false
+  # An adapter for Elixir's built-in JSON module introduced in Elixir 1.18
+  # that adjusts for Tesla's assumptions about a JSON engine, which are not satisfied by
+  # Elixir's JSON module. The assumptions are:
+  # - the module provides encode/2 and decode/2 functions
+  # - the 2nd argument to the functions is opts
+  # - the functions return {:ok, json} or {:error, reason} - not the case for JSON.encode!/2
+  #
+  # We do not support custom encoders and decoders.
+  # The purpose of this adapter is to allow `engine: JSON` to be set easily. If more advanced
+  # customization is required, the `:encode` and `:decode` functions can be supplied to the
+  # middleware instead of the `:engine` option.
+  def encode(data, _opts), do: {:ok, JSON.encode!(data)}
+  def decode(binary, _opts), do: JSON.decode(binary)
+end

--- a/test/tesla/middleware/json/json_adapter_test.exs
+++ b/test/tesla/middleware/json/json_adapter_test.exs
@@ -1,0 +1,21 @@
+defmodule Tesla.Middleware.JSON.JSONAdapterTest do
+  use ExUnit.Case, async: true
+
+  alias Tesla.Middleware.JSON.JSONAdapter
+
+  describe "encode/2" do
+    test "encodes as expected with default encoder" do
+      assert {:ok, ~S({"hello":"world"})} == JSONAdapter.encode(%{hello: "world"}, [])
+    end
+  end
+
+  describe "decode/2" do
+    test "returns {:ok, term} on success" do
+      assert {:ok, %{"hello" => "world"}} = JSONAdapter.decode(~S({"hello":"world"}), [])
+    end
+
+    test "returns {:error, reason} on failure" do
+      assert {:error, {:invalid_byte, _, _}} = JSONAdapter.decode("invalid_json", [])
+    end
+  end
+end


### PR DESCRIPTION
This is a proposal for one way to add support to the built-in `JSON` module available in Elixir 1.18.

There were a few challenges with this, because Tesla makes assumptions about how an engine should behave that JSON doesn't conform to. To work around this I created a `JSONAdapter` module that conforms to Tesla's expectations, and allows users to simply specify

    engine: JSON

for common cases, which will give people an easy path to migrate away from `Jason`, for example.

Elixir's built-in JSON module also supports custom encoders and decoders, which could theoretically be supplied via this middlewear's `engine_opts` param. But considering that would require additional wrapper/adapter logic, and the same thing can be achieved using the `encoder:` and `decoder:` options, I decided that might be overkill.

Long term, I don't think the `:engine` option makes much sense, because there are too many assumptions involved without defining a proper behaviour. Perhaps deprecating it and focussing on the `:encoder` and `:decoder` options might make sense?

## Docs preview

<img width="844" alt="image" src="https://github.com/user-attachments/assets/f8a70b90-cbd1-46dc-af99-2812e5a6e5bb" />

## Related issues
* #743 