### PR TITLE
fix: add basic Hackney 1.22 support: {:connect_error, _}

### DIFF
--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -95,6 +95,7 @@ if Code.ensure_loaded?(:hackney) do
       end)
     end
 
+    defp handle({:connect_error, {:error, reason}}, _opts), do: {:error, reason}
     defp handle({:error, _} = error, _opts), do: error
     defp handle({:ok, status, headers}, _opts), do: {:ok, status, headers, []}
 


### PR DESCRIPTION
Fixes: #753
