### PR TITLE
fix: handle HTTP response trailers when use Finch + stream

### DIFF
--- a/lib/tesla/adapter/finch.ex
+++ b/lib/tesla/adapter/finch.ex
@@ -112,6 +112,7 @@ if Code.ensure_loaded?(Finch) do
         {:status, status}, _acc -> status
         {:headers, headers}, status -> send(owner, {ref, {:status, status, headers}})
         {:data, data}, _acc -> send(owner, {ref, {:data, data}})
+        {:trailers, trailers}, _acc -> trailers
       end
 
       task =


### PR DESCRIPTION
I found an error using Finch adapter in conjunction with streamed responses. The adapter doesn't take into account the `{:trailers, trailers}` command and raises an error.