### PR TITLE
fix: Handle named ancestors in Tesla.Mock

### DIFF
--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -237,7 +237,14 @@ defmodule Tesla.Mock do
     # we will check mocks *both* in $callers and $ancestors
     # We might want to remove checking in $ancestors in a major release
     ancestors = Process.get(:"$ancestors", [])
-    potential_mock_holder_pids = [self() | Enum.reverse(callers) ++ Enum.reverse(ancestors)]
+
+    potential_mock_holder_pids =
+      [self() | Enum.reverse(callers) ++ Enum.reverse(ancestors)]
+      |> Enum.map(fn
+        pid when is_pid(pid) -> pid
+        atom when is_atom(atom) -> Process.whereis(atom)
+      end)
+      |> Enum.filter(&is_pid/1)
 
     Enum.find_value(potential_mock_holder_pids, nil, fn pid ->
       {:dictionary, process_dictionary} = Process.info(pid, :dictionary)


### PR DESCRIPTION
The process `$ancestor` list can contain named processed as well as pids in certain supervision tree structures. This PR fixes a crash that happens with `Tesla.Mock` when a mocked module is called from within a spawned task within a named supervision tree, by looking up the pid of the named process if it exists.

Here is a trivial example showing the problematic `$ancestors` behaviour that causes the error
```elixir
iex(1)> Supervisor.start_link([{Task.Supervisor, name: MyTaskSup}], [name: MySup, strategy: :one_for_one])
{:ok, #PID<0.109.0>}
iex(2)> Task.Supervisor.async(MyTaskSup, fn -> :erlang.get(:"$ancestors") end) |> Task.await()
[#PID<0.110.0>, MySup, #PID<0.108.0>, #PID<0.98.0>]
```