### PR TITLE
fix: Handle non-list term being emitted from Stream.chunk_while in SSE

### DIFF
--- a/lib/tesla/middleware/sse.ex
+++ b/lib/tesla/middleware/sse.ex
@@ -55,7 +55,7 @@ defmodule Tesla.Middleware.SSE do
       end,
       fn
         "" -> {:cont, ""}
-        acc -> {:cont, acc, ""}
+        acc -> {:cont, [acc], ""}
       end
     )
     |> Stream.flat_map(& &1)


### PR DESCRIPTION
The `Stream.chunk_while/3` in `SSE.decode_body/2` has a bug where if there is any data left in the accumulator at the end of the stream, it will be emit a binary rather than the expected value of a list of binaries. This PR wraps that value so as to not crash the stream.