### PR TITLE
docs: add Finch adapter specific stream option

### DIFF
--- a/lib/tesla/adapter/finch.ex
+++ b/lib/tesla/adapter/finch.ex
@@ -39,6 +39,12 @@ if Code.ensure_loaded?(Finch) do
     ## Adapter specific options
 
       * `:name` - The `:name` provided to Finch (**required**).
+      * `:response` - Expected response type. Defines the Finch request type
+        to use. Supported values:
+        + `:stream` - Streams the response using `Finch.stream/5` for the
+          request.
+        + `nil` or not specified - Responds without streaming using
+          `Finch.request/3`.
 
     ## [Finch options](https://hexdocs.pm/finch/Finch.html#request/3)
 


### PR DESCRIPTION
The docs are missing one specific option for the Finch adapter: `:response`. It is mentioned in the [cheat sheet docs](https://hexdocs.pm/tesla/general.html#streaming-response-body) but not in the Finch Adapter.