### PR TITLE
fix(mint): avoid active-mode message races without breaking reused connections

### DIFF
--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -39,6 +39,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
       Processing of the chunks and checking body size must be done by yourself. Example of processing function is in `test/tesla/adapter/mint_test.exs` - `Tesla.Adapter.MintTest.read_body/4`. If you don't need connection later don't forget to close it with `Tesla.Adapter.Mint.close/1`.
     - `:max_body` - Max response body size in bytes. Works only with `body_as: :plain`, with other settings you need to check response body size by yourself.
     - `:conn` - Opened connection with mint. Is used for reusing mint connections.
+    - `:mode` - Mint receive mode. Defaults to `:passive` for connections opened by the adapter. When reusing a caller-supplied `:conn`, pass `:mode` explicitly if that connection is not `:active`.
     - `:original` - Original host with port, for which reused connection was open. Needed for `Tesla.Middleware.FollowRedirects`. Otherwise adapter will use connection for another open host.
     - `:close_conn` - Close connection or not after receiving full response body. Is used for reusing mint connections. Defaults to `true`.
     - `:proxy` - Proxy settings. E.g.: `{:http, "localhost", 8888, []}`, `{:http, "127.0.0.1", 8888, []}`
@@ -51,7 +52,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
     alias Tesla.Multipart
     alias Mint.HTTP
 
-    @default timeout: 2_000, body_as: :plain, close_conn: true, mode: :active
+    @default timeout: 2_000, body_as: :plain, close_conn: true
 
     @tags [:tcp_error, :ssl_error, :tcp_closed, :ssl_closed, :tcp, :ssl]
 
@@ -132,7 +133,11 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp check_original(_uri, opts), do: opts
 
     defp open_conn(_uri, %{conn: conn, original_matches: true} = opts) do
-      {:ok, conn, opts}
+      opts = Map.put_new(opts, :mode, :active)
+
+      with {:ok, conn} <- HTTP.set_mode(conn, opts[:mode]) do
+        {:ok, conn, opts}
+      end
     end
 
     defp open_conn(uri, %{conn: conn, original_matches: false} = opts) do
@@ -314,7 +319,11 @@ if Code.ensure_loaded?(Mint.HTTP) do
           if opts[:close_conn], do: {:ok, _conn} = close(conn)
           {:error, error}
 
-        {:error, _conn, error, _res} ->
+        {:error, conn, %Mint.TransportError{reason: :timeout}, _res} ->
+          if opts[:close_conn], do: {:ok, _conn} = close(conn)
+          {:error, :timeout}
+
+        {:error, conn, error, _res} ->
           if opts[:close_conn], do: {:ok, _conn} = close(conn)
           # TODO: (breaking change) fix typo in error message, "Encounter" => "Encountered"
           {:error, "Encounter Mint error #{inspect(error)}"}

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -51,6 +51,7 @@ defmodule Tesla.Adapter.MintTest do
     assert response.status == 200
     %{conn: conn, ref: ref, opts: opts, body: body} = response.body
     assert opts[:body_as] == :chunks
+    assert opts[:mode] == :passive
 
     {:ok, conn, received_body} = read_body(conn, ref, opts, body)
     assert byte_size(received_body) == 16
@@ -195,8 +196,11 @@ defmodule Tesla.Adapter.MintTest do
       {:ok, conn} = Tesla.Adapter.Mint.close(conn)
       assert conn.state == :closed
 
-      assert {:error, %Mint.HTTPError{reason: :closed, module: Mint.HTTP1}} =
+      assert {:error, error} =
                call(request, conn: conn, original: original, close_conn: false)
+
+      assert match?(%Mint.HTTPError{reason: :closed, module: Mint.HTTP1}, error) or
+               match?(%Mint.TransportError{reason: :einval}, error)
     end
 
     test "body_as :stream", %{conn: conn, original: original} do


### PR DESCRIPTION
this should fix #811 

Reading the issue #357 and the subsequent PR, it seems that the desired fix was to set the default mint mode to passive, however it was not really set because of the reasons outlined in #811

A related change is to avoid wrapping the timeout transport error in a string when passive mode is used: currently the `receive_message` function returns a `{:error, :timeout}` error when in active mode, a mint error when in passive, which is then wrapped in a `{:error, "Encounter Mint error %Mint.TransportError{reason: :timeout}"}` tuple. This was changed to avoid incoherent errors between the two modes.

Please let me know if this is an acceptable way to fix the timeout return value inconsistency or it is better to leave it as it is (and instead fix the test) because it would technically introduce a breaking change in the api