### PR TITLE
feat: add strict policy option for enforcing base URL

### DIFF
--- a/lib/tesla/middleware/base_url.ex
+++ b/lib/tesla/middleware/base_url.ex
@@ -2,8 +2,23 @@ defmodule Tesla.Middleware.BaseUrl do
   @moduledoc """
   Set base URL for all requests.
 
-  The base URL will be prepended to request path/URL only
-  if it does not include http(s).
+  By default, the base URL will be prepended to request path/URL only
+  if it does not include http(s). Use the `policy: :strict` option to
+  enforce base URL prepending regardless of scheme presence.
+
+  ## Options
+
+  The options can be passed as a keyword list or a string representing the base URL.
+
+  - `:base_url` - The base URL to use for all requests.
+  - `:policy` - Can be set to `:strict` to enforce base URL prepending even when
+    the request URL already includes a scheme. Useful for security when the URL is
+    controlled by user input. Defaults to `:insecure`.
+
+  > ### Security Considerations {: .warning}
+  > When URLs are controlled by user input, always use `policy: :strict` to prevent
+  > URL redirection attacks. The default `:insecure` policy allows users to bypass
+  > the base URL by providing fully qualified URLs.
 
   ## Examples
 
@@ -11,7 +26,10 @@ defmodule Tesla.Middleware.BaseUrl do
   defmodule MyClient do
     def client do
       Tesla.client([
-        {Tesla.Middleware.BaseUrl, "https://example.com/foo"}
+        # Using keyword format (recommended)
+        {Tesla.Middleware.BaseUrl, base_url: "https://example.com/foo"}
+        # or alternatively, using string
+        # {Tesla.Middleware.BaseUrl, "https://example.com/foo"}
       ])
     end
   end
@@ -28,25 +46,77 @@ defmodule Tesla.Middleware.BaseUrl do
   # equals to GET https://example.com/foo
 
   Tesla.get(client, "http://example.com/bar")
-  # equals to GET http://example.com/bar
+  # equals to GET http://example.com/bar (scheme detected, base URL not prepended)
+
+  # Using strict policy for user-controlled URLs (security)
+  defmodule MySecureClient do
+    def client do
+      Tesla.client([
+        {Tesla.Middleware.BaseUrl, base_url: "https://example.com/foo", policy: :strict}
+      ])
+    end
+  end
+
+  secure_client = MySecureClient.client()
+
+  Tesla.get(secure_client, "http://example.com/bar")
+  # equals to GET https://example.com/foo/http://example.com/bar (base URL always prepended)
+
+  Tesla.get(secure_client, "/safe/path")
+  # equals to GET https://example.com/foo/safe/path
   ```
   """
 
   @behaviour Tesla.Middleware
 
+  @type policy :: :strict | :insecure
+  @type opts :: [base_url: String.t(), policy: policy] | String.t()
+
   @impl Tesla.Middleware
-  def call(env, next, base) do
+  @spec call(Tesla.Env.t(), Tesla.Env.stack(), opts()) :: Tesla.Env.result()
+  def call(env, next, opts) do
+    {base_url, opts} = parse_opts!(opts)
+
     env
-    |> apply_base(base)
+    |> apply_base(base_url, opts)
     |> Tesla.run(next)
   end
 
-  defp apply_base(env, base) do
-    if Regex.match?(~r/^https?:\/\//i, env.url) do
-      # skip if url is already with scheme
-      env
-    else
-      %{env | url: join(base, env.url)}
+  defp parse_opts!(opts) when is_binary(opts) do
+    {opts, []}
+  end
+
+  defp parse_opts!(opts) when is_list(opts) do
+    case Keyword.pop(opts, :base_url) do
+      {base_url, remaining_opts} when is_binary(base_url) ->
+        {base_url, remaining_opts}
+
+      {base_url, _remaining_opts} ->
+        raise ArgumentError, "base_url must be a string but got #{inspect(base_url)}"
+    end
+  end
+
+  defp apply_base(env, base_url, opts) do
+    case get_policy!(opts) do
+      :strict ->
+        %{env | url: join(base_url, env.url)}
+
+      :insecure ->
+        if Regex.match?(~r/^https?:\/\//i, env.url) do
+          env
+        else
+          %{env | url: join(base_url, env.url)}
+        end
+    end
+  end
+
+  defp get_policy!(opts) do
+    case Keyword.get(opts, :policy, :insecure) do
+      policy when policy in [:strict, :insecure] ->
+        policy
+
+      other ->
+        raise ArgumentError, "invalid policy #{inspect(other)}, expected :strict or :insecure"
     end
   end
 

--- a/test/tesla/middleware/base_url_test.exs
+++ b/test/tesla/middleware/base_url_test.exs
@@ -79,4 +79,197 @@ defmodule Tesla.Middleware.BaseUrlTest do
     assert {:ok, env} = @middleware.call(%Env{url: "HTTPS://other.foo"}, [], "http://example.com")
     assert env.url == "HTTPS://other.foo"
   end
+
+  test "strict policy: prepend base url even with http scheme" do
+    assert {:ok, env} =
+             @middleware.call(
+               %Env{url: "http://other.foo"},
+               [],
+               base_url: "http://example.com",
+               policy: :strict
+             )
+
+    assert env.url == "http://example.com/http://other.foo"
+  end
+
+  test "strict policy: prepend base url even with https scheme" do
+    assert {:ok, env} =
+             @middleware.call(
+               %Env{url: "https://other.foo"},
+               [],
+               base_url: "http://example.com",
+               policy: :strict
+             )
+
+    assert env.url == "http://example.com/https://other.foo"
+  end
+
+  test "strict policy: still works with relative paths" do
+    assert {:ok, env} =
+             @middleware.call(%Env{url: "/path"}, [],
+               base_url: "http://example.com",
+               policy: :strict
+             )
+
+    assert env.url == "http://example.com/path"
+  end
+
+  test "strict policy: case insensitive scheme detection" do
+    assert {:ok, env} =
+             @middleware.call(
+               %Env{url: "HTTP://other.foo"},
+               [],
+               base_url: "http://example.com",
+               policy: :strict
+             )
+
+    assert env.url == "http://example.com/HTTP://other.foo"
+
+    assert {:ok, env} =
+             @middleware.call(
+               %Env{url: "HTTPS://other.foo"},
+               [],
+               base_url: "http://example.com",
+               policy: :strict
+             )
+
+    assert env.url == "http://example.com/HTTPS://other.foo"
+  end
+
+  test "default policy (no policy): respects permissive behavior" do
+    assert {:ok, env} =
+             @middleware.call(%Env{url: "http://other.foo"}, [], base_url: "http://example.com")
+
+    assert env.url == "http://other.foo"
+  end
+
+  test "backward compatibility: string base url works with new implementation" do
+    assert {:ok, env} = @middleware.call(%Env{url: "http://other.foo"}, [], "http://example.com")
+    assert env.url == "http://other.foo"
+
+    assert {:ok, env} = @middleware.call(%Env{url: "/path"}, [], "http://example.com")
+    assert env.url == "http://example.com/path"
+  end
+
+  test "policy validation: accepts valid policy values" do
+    assert {:ok, env} =
+             @middleware.call(
+               %Env{url: "http://other.foo"},
+               [],
+               base_url: "http://example.com",
+               policy: :strict
+             )
+
+    assert env.url == "http://example.com/http://other.foo"
+
+    assert {:ok, env} =
+             @middleware.call(
+               %Env{url: "http://other.foo"},
+               [],
+               base_url: "http://example.com",
+               policy: :insecure
+             )
+
+    assert env.url == "http://other.foo"
+  end
+
+  test "policy validation: raises error for invalid policy values" do
+    assert_raise ArgumentError, "invalid policy :strikt, expected :strict or :insecure", fn ->
+      @middleware.call(
+        %Env{url: "http://other.foo"},
+        [],
+        base_url: "http://example.com",
+        policy: :strikt
+      )
+    end
+
+    assert_raise ArgumentError, "invalid policy :secure, expected :strict or :insecure", fn ->
+      @middleware.call(
+        %Env{url: "http://other.foo"},
+        [],
+        base_url: "http://example.com",
+        policy: :secure
+      )
+    end
+
+    assert_raise ArgumentError, "invalid policy \"strict\", expected :strict or :insecure", fn ->
+      @middleware.call(
+        %Env{url: "http://other.foo"},
+        [],
+        base_url: "http://example.com",
+        policy: "strict"
+      )
+    end
+
+    assert_raise ArgumentError, "invalid policy 123, expected :strict or :insecure", fn ->
+      @middleware.call(
+        %Env{url: "http://other.foo"},
+        [],
+        base_url: "http://example.com",
+        policy: 123
+      )
+    end
+  end
+
+  test "edge case: empty string base_url" do
+    assert {:ok, env} = @middleware.call(%Env{url: "/path"}, [], "")
+    assert env.url == "/path"
+
+    assert {:ok, env} = @middleware.call(%Env{url: "path"}, [], "")
+    assert env.url == "path"
+
+    assert {:ok, env} = @middleware.call(%Env{url: ""}, [], "")
+    assert env.url == ""
+
+    assert {:ok, env} = @middleware.call(%Env{url: "http://example.com"}, [], "")
+    assert env.url == "http://example.com"
+
+    assert {:ok, env} = @middleware.call(%Env{url: "/path"}, [], base_url: "")
+    assert env.url == "/path"
+  end
+
+  test "edge case: empty string base_url with strict policy" do
+    assert {:ok, env} =
+             @middleware.call(
+               %Env{url: "http://example.com"},
+               [],
+               base_url: "",
+               policy: :strict
+             )
+
+    assert env.url == "http://example.com"
+
+    assert {:ok, env} =
+             @middleware.call(
+               %Env{url: "/path"},
+               [],
+               base_url: "",
+               policy: :strict
+             )
+
+    assert env.url == "/path"
+  end
+
+  test "error handling: invalid base_url types" do
+    assert_raise ArgumentError, "base_url must be a string but got nil", fn ->
+      @middleware.call(%Env{url: "/path"}, [], base_url: nil)
+    end
+
+    assert_raise ArgumentError, "base_url must be a string but got :invalid", fn ->
+      @middleware.call(%Env{url: "/path"}, [], base_url: :invalid)
+    end
+
+    assert_raise ArgumentError, "base_url must be a string but got 123", fn ->
+      @middleware.call(%Env{url: "/path"}, [], base_url: 123)
+    end
+
+    # Missing :base_url key (same error as nil)
+    assert_raise ArgumentError, "base_url must be a string but got nil", fn ->
+      @middleware.call(%Env{url: "/path"}, [], policy: :strict)
+    end
+
+    assert_raise ArgumentError, "base_url must be a string but got nil", fn ->
+      @middleware.call(%Env{url: "/path"}, [], [])
+    end
+  end
 end


### PR DESCRIPTION
Add an opt-in `policy: :strict` option to the BaseUrl middleware that enforces
base URL prepending regardless of whether the request URL already includes a scheme.
This addresses security concerns when user input controls the URL parameter,
preventing potential URL redirection attacks.

Signed-off-by: Yordis Prieto <yordis.prieto@gmail.com>