### PR TITLE
feat: add `assigns` and `private` fields to `Tesla.Env`

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -164,24 +164,24 @@ defmodule Tesla do
   end
 
   @doc """
-  Assigns multiple values to `Tesla.Env`.
+  Merges the given assigns into `Tesla.Env`.
 
   ## Examples
 
       iex> env = %Tesla.Env{}
-      iex> env = Tesla.put_assigns(env, user_id: 123, role: :admin)
+      iex> env = Tesla.put_assigns(env, %{user_id: 123, role: :admin})
       iex> env.assigns
       %{user_id: 123, role: :admin}
 
       iex> env = %Tesla.Env{assigns: %{user_id: 123}}
-      iex> env = Tesla.put_assigns(env, role: :admin)
+      iex> env = Tesla.put_assigns(env, %{role: :admin})
       iex> env.assigns
       %{user_id: 123, role: :admin}
 
   """
-  @spec put_assigns(Tesla.Env.t(), Enumerable.t()) :: Tesla.Env.t()
-  def put_assigns(%Tesla.Env{} = env, assigns) do
-    %{env | assigns: Enum.into(assigns, env.assigns)}
+  @spec put_assigns(Tesla.Env.t(), Tesla.Env.assigns()) :: Tesla.Env.t()
+  def put_assigns(%Tesla.Env{} = env, assigns) when is_map(assigns) do
+    %{env | assigns: Map.merge(env.assigns, assigns)}
   end
 
   @doc """

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -197,7 +197,7 @@ defmodule Tesla do
   """
   @spec put_assign(Tesla.Env.t(), atom, any) :: Tesla.Env.t()
   def put_assign(%Tesla.Env{} = env, key, value) when is_atom(key) do
-    put_in(env.assigns[key], value)
+    %{env | assigns: Map.put(env.assigns, key, value)}
   end
 
   @doc """

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -163,8 +163,6 @@ defmodule Tesla do
     Map.update!(env, :opts, &Keyword.put(&1, key, value))
   end
 
-  # -- Assigns --
-
   @doc """
   Assigns multiple values to `Tesla.Env`.
 

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -257,7 +257,8 @@ defmodule Tesla do
 
   """
   @spec update_assign(Tesla.Env.t(), atom, any, (any -> any)) :: Tesla.Env.t()
-  def update_assign(%Tesla.Env{} = env, key, default, fun) when is_atom(key) and is_function(fun, 1) do
+  def update_assign(%Tesla.Env{} = env, key, default, fun)
+      when is_atom(key) and is_function(fun, 1) do
     %{env | assigns: Map.update(env.assigns, key, default, fun)}
   end
 

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -227,13 +227,13 @@ defmodule Tesla do
   ## Examples
 
       iex> env = %Tesla.Env{assigns: %{counter: 1}}
-      iex> env = Tesla.update_assign(env, :counter, &(&1 + 1))
+      iex> env = Tesla.update_assign!(env, :counter, &(&1 + 1))
       iex> env.assigns
       %{counter: 2}
 
   """
-  @spec update_assign(Tesla.Env.t(), atom, (any -> any)) :: Tesla.Env.t()
-  def update_assign(%Tesla.Env{} = env, key, fun) when is_atom(key) and is_function(fun, 1) do
+  @spec update_assign!(Tesla.Env.t(), atom, (any -> any)) :: Tesla.Env.t()
+  def update_assign!(%Tesla.Env{} = env, key, fun) when is_atom(key) and is_function(fun, 1) do
     %{env | assigns: Map.update!(env.assigns, key, fun)}
   end
 
@@ -245,7 +245,7 @@ defmodule Tesla do
   `default` is inserted as the value of `key`. The `default` value will not be passed
   through the update function.
 
-  See also `update_assign/3`.
+  See also `update_assign!/3`.
 
   ## Examples
 

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -47,6 +47,17 @@ defmodule Tesla do
   ```elixir
   config :tesla, :adapter, Tesla.Adapter.Mint
   ```
+
+  ## Assigns and Private
+
+  `Tesla.Env` has two map fields for storing additional data: `:assigns` and `:private`.
+
+  `:assigns` is a place for user data. It can be used to carry application-specific metadata
+  through the middleware pipeline.
+
+  `:private` is a map reserved for libraries and middleware to use. The keys must be atoms.
+  Prefix the keys with the name of your project to avoid any future conflicts. The `tesla_`
+  prefix is reserved for Tesla.
   """
 
   use Tesla.Builder
@@ -150,6 +161,106 @@ defmodule Tesla do
   @spec put_opt(Tesla.Env.t(), atom, any) :: Tesla.Env.t()
   def put_opt(env, key, value) do
     Map.update!(env, :opts, &Keyword.put(&1, key, value))
+  end
+
+  # -- Assigns --
+
+  @doc """
+  Assigns multiple values to `Tesla.Env`.
+
+  ## Examples
+
+      iex> env = %Tesla.Env{}
+      iex> env = Tesla.put_assigns(env, user_id: 123, role: :admin)
+      iex> env.assigns
+      %{user_id: 123, role: :admin}
+
+      iex> env = %Tesla.Env{assigns: %{user_id: 123}}
+      iex> env = Tesla.put_assigns(env, role: :admin)
+      iex> env.assigns
+      %{user_id: 123, role: :admin}
+
+  """
+  @spec put_assigns(Tesla.Env.t(), Enumerable.t()) :: Tesla.Env.t()
+  def put_assigns(%Tesla.Env{} = env, assigns) do
+    %{env | assigns: Enum.into(assigns, env.assigns)}
+  end
+
+  @doc """
+  Assigns key/value to `Tesla.Env`.
+
+  ## Examples
+
+      iex> env = %Tesla.Env{}
+      iex> env = Tesla.put_assign(env, :user_id, 123)
+      iex> env.assigns
+      %{user_id: 123}
+
+  """
+  @spec put_assign(Tesla.Env.t(), atom, any) :: Tesla.Env.t()
+  def put_assign(%Tesla.Env{} = env, key, value) when is_atom(key) do
+    put_in(env.assigns[key], value)
+  end
+
+  @doc """
+  Assigns key/value to `Tesla.Env` unless the key is already set.
+
+  ## Examples
+
+      iex> env = %Tesla.Env{}
+      iex> env = Tesla.put_assign_new(env, :user_id, 123)
+      iex> env = Tesla.put_assign_new(env, :user_id, 456)
+      iex> env.assigns
+      %{user_id: 123}
+
+  """
+  @spec put_assign_new(Tesla.Env.t(), atom, any) :: Tesla.Env.t()
+  def put_assign_new(%Tesla.Env{} = env, key, value) when is_atom(key) do
+    %{env | assigns: Map.put_new(env.assigns, key, value)}
+  end
+
+  @doc """
+  Updates assign `key` in `Tesla.Env` with the given function.
+
+  Raises if the `key` is not set.
+
+  See also `update_assign/4`.
+
+  ## Examples
+
+      iex> env = %Tesla.Env{assigns: %{counter: 1}}
+      iex> env = Tesla.update_assign(env, :counter, &(&1 + 1))
+      iex> env.assigns
+      %{counter: 2}
+
+  """
+  @spec update_assign(Tesla.Env.t(), atom, (any -> any)) :: Tesla.Env.t()
+  def update_assign(%Tesla.Env{} = env, key, fun) when is_atom(key) and is_function(fun, 1) do
+    %{env | assigns: Map.update!(env.assigns, key, fun)}
+  end
+
+  @doc """
+  Updates assign `key` in `Tesla.Env` with the given function or `default`.
+
+  If `key` is present in assigns then the existing value is passed to `fun` and its
+  result is used as the updated value of `key`. If `key` is not present in assigns,
+  `default` is inserted as the value of `key`. The `default` value will not be passed
+  through the update function.
+
+  See also `update_assign/3`.
+
+  ## Examples
+
+      iex> env = %Tesla.Env{assigns: %{counter: 10}}
+      iex> env = Tesla.update_assign(env, :counter, 1, &(&1 + 1))
+      iex> env = Tesla.update_assign(env, :other, 1, &(&1 + 1))
+      iex> env.assigns
+      %{counter: 11, other: 1}
+
+  """
+  @spec update_assign(Tesla.Env.t(), atom, any, (any -> any)) :: Tesla.Env.t()
+  def update_assign(%Tesla.Env{} = env, key, default, fun) when is_atom(key) and is_function(fun, 1) do
+    %{env | assigns: Map.update(env.assigns, key, default, fun)}
   end
 
   @doc """

--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -52,8 +52,8 @@ defmodule Tesla.Env do
           opts: opts,
           assigns: assigns,
           private: private,
-          __module__: atom(),
-          __client__: client()
+          __module__: atom() | nil,
+          __client__: client() | nil
         }
 
   defstruct method: nil,

--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -40,6 +40,7 @@ defmodule Tesla.Env do
   @type result :: {:ok, t()} | {:error, any}
 
   @type assigns :: %{optional(atom) => any}
+  @type private :: %{optional(atom) => any}
 
   @type t :: %__MODULE__{
           method: method,
@@ -50,7 +51,7 @@ defmodule Tesla.Env do
           status: status,
           opts: opts,
           assigns: assigns,
-          private: assigns,
+          private: private,
           __module__: atom(),
           __client__: client()
         }

--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -16,6 +16,12 @@ defmodule Tesla.Env do
     Note: request body is overridden by response body when adapter is called.
   - `:status` - response status. Example: `200`
   - `:opts` - list of options. Example: `[adapter: [recv_timeout: 30_000]]`
+  - `:assigns` - a place for user data as a map. It can be used to carry application-specific
+    metadata through the middleware pipeline.
+
+  - `:private` - a map reserved for libraries and middleware to use. The keys must be atoms.
+    Prefix the keys with the name of your project to avoid any future conflicts. The `tesla_`
+    prefix is reserved for Tesla.
   """
 
   @type client :: Tesla.Client.t()
@@ -33,6 +39,8 @@ defmodule Tesla.Env do
   @type stack :: [runtime]
   @type result :: {:ok, t()} | {:error, any}
 
+  @type assigns :: %{optional(atom) => any}
+
   @type t :: %__MODULE__{
           method: method,
           query: query,
@@ -41,8 +49,10 @@ defmodule Tesla.Env do
           body: body,
           status: status,
           opts: opts,
-          __module__: atom,
-          __client__: client
+          assigns: assigns,
+          private: assigns,
+          __module__: atom(),
+          __client__: client()
         }
 
   defstruct method: nil,
@@ -52,6 +62,8 @@ defmodule Tesla.Env do
             body: nil,
             status: nil,
             opts: [],
+            assigns: %{},
+            private: %{},
             __module__: nil,
             __client__: nil
 end

--- a/mix.exs
+++ b/mix.exs
@@ -20,9 +20,12 @@ defmodule Tesla.Mixfile do
         plt_add_apps: [:mix, :inets, :idna, :ssl_verify_fun, :ex_unit],
         plt_add_deps: :apps_direct
       ],
-      docs: docs(),
-      preferred_cli_env: [coveralls: :test, "coveralls.html": :test]
+      docs: docs()
     ]
+  end
+
+  def cli do
+    [preferred_envs: [coveralls: :test, "coveralls.html": :test]]
   end
 
   def application do

--- a/mix.exs
+++ b/mix.exs
@@ -20,12 +20,9 @@ defmodule Tesla.Mixfile do
         plt_add_apps: [:mix, :inets, :idna, :ssl_verify_fun, :ex_unit],
         plt_add_deps: :apps_direct
       ],
-      docs: docs()
+      docs: docs(),
+      preferred_cli_env: [coveralls: :test, "coveralls.html": :test]
     ]
-  end
-
-  def cli do
-    [preferred_envs: [coveralls: :test, "coveralls.html": :test]]
   end
 
   def application do


### PR DESCRIPTION
## Summary

- Adds `assigns` field (`%{}`) to `Tesla.Env` for user data that needs to travel through the middleware pipeline
- Adds `private` field (`%{}`) to `Tesla.Env` reserved for libraries and middleware, with the `tesla_` prefix reserved for Tesla itself
- Adds helper functions on `Tesla`: `put_assigns/2`, `put_assign/3`, `put_assign_new/3`, `update_assign/3`, `update_assign/4`

## Motivation

Currently `opts` serves triple duty: per-request configuration, middleware-to-middleware communication, and user data. This introduces dedicated fields to separate those concerns, following the well-established `assigns`/`private` convention from the Elixir ecosystem (Plug, Phoenix LiveView).

- **`opts`** remains for per-request configuration (adapter options, path_params, etc.)
- **`assigns`** is a place for user data carried through the pipeline
- **`private`** is reserved for libraries and middleware internal state (keys must be prefixed with the library name to avoid collisions)

## Test plan

- [x] All existing tests pass (480 tests, 0 failures)
- [x] New doctests cover all helper functions
- [x] Backward compatible — no changes to existing fields or behavior