### PR TITLE
feat(logger): emit url.template from KeepRequest preserved URL

### DIFF
--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -104,9 +104,7 @@ defmodule Tesla.Middleware.Logger do
   Tesla-specific notes:
 
   - `overrides` keyword list is merged last and wins on duplicate keys
-  - `url.full` redacts URL `userinfo` per the URL semantic conventions
-  - `http.client.request.duration` is emitted as log metadata in **milliseconds**; treat it as
-    log-only rather than an OTLP metric value
+  - `url.template` requires `Tesla.Middleware.KeepRequest` placed before `Tesla.Middleware.PathParams`
 
   ## Custom log format
 

--- a/lib/tesla/opentelemetry/sem_conv.ex
+++ b/lib/tesla/opentelemetry/sem_conv.ex
@@ -4,6 +4,7 @@ if Code.ensure_loaded?(OpenTelemetry.SemConv.HTTPAttributes) do
 
     alias OpenTelemetry.SemConv.ErrorAttributes
     alias OpenTelemetry.SemConv.HTTPAttributes
+    alias OpenTelemetry.SemConv.Incubating.URLAttributes, as: IncubatingURLAttributes
     alias OpenTelemetry.SemConv.Metrics.HTTPMetrics
     alias OpenTelemetry.SemConv.ServerAttributes
     alias OpenTelemetry.SemConv.URLAttributes
@@ -19,6 +20,7 @@ if Code.ensure_loaded?(OpenTelemetry.SemConv.HTTPAttributes) do
         HTTPMetrics.http_client_request_duration() => duration_ms
       }
       |> maybe_put_url(env)
+      |> maybe_put_url_template(env)
       |> maybe_put_resend_count(env)
       |> maybe_put_http_result(result)
     end
@@ -49,6 +51,15 @@ if Code.ensure_loaded?(OpenTelemetry.SemConv.HTTPAttributes) do
       end
     end
 
+    defp maybe_put_url_template(attrs, %Tesla.Env{opts: opts}) do
+      with req_url when is_binary(req_url) <- opts[:req_url],
+           path when is_binary(path) <- URI.parse(req_url).path do
+        Map.put(attrs, IncubatingURLAttributes.url_template(), path)
+      else
+        _ -> attrs
+      end
+    end
+
     defp maybe_put_resend_count(attrs, %Tesla.Env{opts: opts}) do
       case Keyword.get(opts, :retry_count) do
         count when is_integer(count) and count > 0 ->
@@ -58,8 +69,6 @@ if Code.ensure_loaded?(OpenTelemetry.SemConv.HTTPAttributes) do
           attrs
       end
     end
-
-    defp maybe_put_resend_count(attrs, _), do: attrs
 
     defp maybe_put_http_result(attrs, {:ok, %Tesla.Env{status: status}})
          when is_integer(status) do

--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -459,6 +459,43 @@ defmodule Tesla.Middleware.LoggerTest do
       assert log =~ "http.response.status_code=200"
     end
 
+    test "url.template is emitted when KeepRequest precedes PathParams" do
+      client =
+        Tesla.client(
+          [
+            Tesla.Middleware.KeepRequest,
+            Tesla.Middleware.PathParams,
+            {Tesla.Middleware.Logger, metadata: :otel}
+          ],
+          fn env -> {:ok, %{env | status: 200}} end
+        )
+
+      log =
+        capture_log([metadata: [:"url.template"]], fn ->
+          Tesla.get(client, "/users/:id", opts: [path_params: [id: "123"]])
+        end)
+
+      assert log =~ "url.template=/users/:id"
+    end
+
+    test "url.template is omitted without KeepRequest" do
+      client =
+        Tesla.client(
+          [
+            Tesla.Middleware.PathParams,
+            {Tesla.Middleware.Logger, metadata: :otel}
+          ],
+          fn env -> {:ok, %{env | status: 200}} end
+        )
+
+      log =
+        capture_log([metadata: [:"url.template"]], fn ->
+          Tesla.get(client, "/users/:id", opts: [path_params: [id: "123"]])
+        end)
+
+      refute log =~ "url.template="
+    end
+
     test "default metadata is keyword list passthrough" do
       client =
         Tesla.client(


### PR DESCRIPTION
- `url.full` has high cardinality per request (e.g. `/users/123`, `/users/456`), making log aggregation by route impossible without a low-cardinality template attribute
- `url.template` is the correct OTel client-side attribute per the HTTP semantic conventions spec — `http.route` is server-only and does not belong on client spans
- `url.template` is only available when `Tesla.Middleware.KeepRequest` is placed before `Tesla.Middleware.PathParams`, preserving the template before path params are resolved