### PR TITLE
feat(client): add put_middleware/2, replace_middleware!/3, update_middleware!/3, and insert_middleware!/4

### DIFF
--- a/lib/tesla/client.ex
+++ b/lib/tesla/client.ex
@@ -44,8 +44,23 @@ defmodule Tesla.Client do
   end
 
   @doc ~S"""
+  Returns a new client with the given middleware list, preserving the rest of the original client.
+
+  ## Examples
+
+      iex> client = Tesla.client([Tesla.Middleware.JSON])
+      iex> new_client = Tesla.Client.put_middleware(client, [Tesla.Middleware.Logger])
+      iex> Tesla.Client.middleware(new_client)
+      [Tesla.Middleware.Logger]
+  """
+  @spec put_middleware(t(), [middleware]) :: t()
+  def put_middleware(client, new_middleware) when is_list(new_middleware) do
+    %{client | pre: Tesla.client(new_middleware).pre}
+  end
+
+  @doc ~S"""
   Returns a new client by applying a function to the existing middleware list,
-  preserving the original adapter.
+  preserving the rest of the original client.
 
   ## Examples
 
@@ -57,12 +72,85 @@ defmodule Tesla.Client do
   """
   @spec update_middleware(t(), ([middleware] -> [middleware])) :: t()
   def update_middleware(client, fun) do
-    client
-    |> middleware()
-    |> fun.()
-    |> Tesla.client()
-    |> Map.put(:adapter, client.adapter)
+    put_middleware(client, fun.(middleware(client)))
   end
+
+  @doc ~S"""
+  Returns a new client by applying a function to the first occurrence of the target middleware,
+  preserving the rest of the original client. Raises if the target middleware is not found.
+
+  The function receives the current middleware entry (`module` or `{module, opts}`) and must
+  return the new entry. Only the first occurrence is updated if the same middleware appears
+  multiple times.
+
+  ## Examples
+
+      iex> client = Tesla.client([{Tesla.Middleware.BaseUrl, "https://old.api.com"}])
+      iex> new_client = Tesla.Client.update_middleware!(client, Tesla.Middleware.BaseUrl, fn {m, _} -> {m, "https://new.api.com"} end)
+      iex> Tesla.Client.middleware(new_client)
+      [{Tesla.Middleware.BaseUrl, "https://new.api.com"}]
+  """
+  @spec update_middleware!(t(), module, (middleware -> middleware)) :: t()
+  def update_middleware!(client, target, fun) when is_atom(target) and is_function(fun, 1) do
+    pre = middleware(client)
+    put_middleware(client, List.update_at(pre, find_middleware_index!(pre, target), fun))
+  end
+
+  @doc ~S"""
+  Returns a new client with the target middleware replaced by a new one,
+  preserving the rest of the original client. Raises if the target middleware is not found.
+
+  ## Examples
+
+      iex> client = Tesla.client([Tesla.Middleware.JSON, Tesla.Middleware.Logger])
+      iex> new_client = Tesla.Client.replace_middleware!(client, Tesla.Middleware.JSON, Tesla.Middleware.Retry)
+      iex> Tesla.Client.middleware(new_client)
+      [Tesla.Middleware.Retry, Tesla.Middleware.Logger]
+  """
+  @spec replace_middleware!(t(), module, middleware) :: t()
+  def replace_middleware!(client, target, new) when is_atom(target) do
+    pre = middleware(client)
+    put_middleware(client, List.replace_at(pre, find_middleware_index!(pre, target), new))
+  end
+
+  @doc ~S"""
+  Inserts a new middleware before or after a target middleware, preserving the rest of the original client.
+  Raises if the target middleware is not found.
+
+  ## Examples
+
+      iex> client = Tesla.client([Tesla.Middleware.JSON])
+      iex> new_client = Tesla.Client.insert_middleware!(client, Tesla.Middleware.Logger, :before, Tesla.Middleware.JSON)
+      iex> Tesla.Client.middleware(new_client)
+      [Tesla.Middleware.Logger, Tesla.Middleware.JSON]
+
+      iex> client = Tesla.client([Tesla.Middleware.JSON])
+      iex> new_client = Tesla.Client.insert_middleware!(client, Tesla.Middleware.Logger, :after, Tesla.Middleware.JSON)
+      iex> Tesla.Client.middleware(new_client)
+      [Tesla.Middleware.JSON, Tesla.Middleware.Logger]
+  """
+  @spec insert_middleware!(t(), middleware, :before, module) :: t()
+  @spec insert_middleware!(t(), middleware, :after, module) :: t()
+  def insert_middleware!(client, new, :before, target) when is_atom(target) do
+    pre = middleware(client)
+    put_middleware(client, List.insert_at(pre, find_middleware_index!(pre, target), new))
+  end
+
+  def insert_middleware!(client, new, :after, target) when is_atom(target) do
+    pre = middleware(client)
+    put_middleware(client, List.insert_at(pre, find_middleware_index!(pre, target) + 1, new))
+  end
+
+  defp find_middleware_index!(middleware, target) do
+    case Enum.find_index(middleware, &matches_target?(&1, target)) do
+      nil -> raise ArgumentError, "Middleware #{inspect(target)} not found"
+      index -> index
+    end
+  end
+
+  defp matches_target?({mw_mod, _}, target) when mw_mod == target, do: true
+  defp matches_target?(target, target), do: true
+  defp matches_target?(_, _), do: false
 
   defp unruntime(list) when is_list(list), do: Enum.map(list, &unruntime/1)
   defp unruntime({module, :call, [[]]}) when is_atom(module), do: module

--- a/test/tesla/client_test.exs
+++ b/test/tesla/client_test.exs
@@ -38,6 +38,162 @@ defmodule Tesla.ClientTest do
     assert Client.adapter(client) == nil
   end
 
+  describe "put_middleware/2" do
+    test "replaces middleware list" do
+      client = Tesla.client([FirstMiddleware])
+
+      new_client = Client.put_middleware(client, [SecondMiddleware])
+
+      assert Client.middleware(new_client) == [SecondMiddleware]
+    end
+
+    test "replaces with empty list" do
+      client = Tesla.client([FirstMiddleware])
+
+      new_client = Client.put_middleware(client, [])
+
+      assert Client.middleware(new_client) == []
+    end
+
+    test "preserves atom adapter" do
+      adapter = Tesla.Adapter.Httpc
+      client = Tesla.client([FirstMiddleware], adapter)
+
+      new_client = Client.put_middleware(client, [SecondMiddleware])
+
+      assert Client.adapter(new_client) == adapter
+    end
+
+    test "preserves tuple adapter" do
+      adapter = {Tesla.Adapter.Hackney, [recv_timeout: 30_000]}
+      client = Tesla.client([FirstMiddleware], adapter)
+
+      new_client = Client.put_middleware(client, [SecondMiddleware])
+
+      assert Client.adapter(new_client) == adapter
+    end
+
+    test "preserves function adapter" do
+      adapter = fn env -> {:ok, env} end
+      client = Tesla.client([FirstMiddleware], adapter)
+
+      new_client = Client.put_middleware(client, [SecondMiddleware])
+
+      assert Client.adapter(new_client) == adapter
+    end
+
+    test "preserves nil adapter" do
+      client = Tesla.client([FirstMiddleware])
+
+      new_client = Client.put_middleware(client, [SecondMiddleware])
+
+      assert Client.adapter(new_client) == nil
+    end
+
+    test "preserves post middleware stack" do
+      client = %Client{pre: [], post: [{SecondMiddleware, :call, [[]]}]}
+
+      new_client = Client.put_middleware(client, [ThirdMiddleware])
+
+      assert Client.middleware(new_client) == [ThirdMiddleware]
+      assert new_client.post == client.post
+    end
+  end
+
+  describe "replace_middleware!/3" do
+    test "replaces target atom middleware" do
+      client = Tesla.client([FirstMiddleware, SecondMiddleware])
+
+      new_client = Client.replace_middleware!(client, FirstMiddleware, ThirdMiddleware)
+
+      assert Client.middleware(new_client) == [ThirdMiddleware, SecondMiddleware]
+    end
+
+    test "replaces target tuple middleware" do
+      client = Tesla.client([{FirstMiddleware, [opt: true]}, SecondMiddleware])
+
+      new_client = Client.replace_middleware!(client, FirstMiddleware, ThirdMiddleware)
+
+      assert Client.middleware(new_client) == [ThirdMiddleware, SecondMiddleware]
+    end
+
+    test "raises when target not found" do
+      client = Tesla.client([FirstMiddleware])
+
+      assert_raise ArgumentError, ~r/not found/, fn ->
+        Client.replace_middleware!(client, SecondMiddleware, ThirdMiddleware)
+      end
+    end
+
+    test "preserves adapter" do
+      adapter = Tesla.Adapter.Httpc
+      client = Tesla.client([FirstMiddleware], adapter)
+
+      new_client = Client.replace_middleware!(client, FirstMiddleware, SecondMiddleware)
+
+      assert Client.adapter(new_client) == adapter
+    end
+  end
+
+  describe "insert_middleware!/4" do
+    test "inserts before target atom middleware" do
+      client = Tesla.client([FirstMiddleware, SecondMiddleware])
+
+      new_client = Client.insert_middleware!(client, ThirdMiddleware, :before, SecondMiddleware)
+
+      assert Client.middleware(new_client) == [FirstMiddleware, ThirdMiddleware, SecondMiddleware]
+    end
+
+    test "inserts after target atom middleware" do
+      client = Tesla.client([FirstMiddleware, SecondMiddleware])
+
+      new_client = Client.insert_middleware!(client, ThirdMiddleware, :after, FirstMiddleware)
+
+      assert Client.middleware(new_client) == [FirstMiddleware, ThirdMiddleware, SecondMiddleware]
+    end
+
+    test "inserts before target tuple middleware" do
+      client = Tesla.client([{FirstMiddleware, [opt: true]}, SecondMiddleware])
+
+      new_client = Client.insert_middleware!(client, ThirdMiddleware, :before, FirstMiddleware)
+
+      assert Client.middleware(new_client) == [
+               ThirdMiddleware,
+               {FirstMiddleware, [opt: true]},
+               SecondMiddleware
+             ]
+    end
+
+    test "inserts after target tuple middleware" do
+      client = Tesla.client([FirstMiddleware, {SecondMiddleware, [opt: true]}])
+
+      new_client = Client.insert_middleware!(client, ThirdMiddleware, :after, SecondMiddleware)
+
+      assert Client.middleware(new_client) == [
+               FirstMiddleware,
+               {SecondMiddleware, [opt: true]},
+               ThirdMiddleware
+             ]
+    end
+
+    test "raises when target not found" do
+      client = Tesla.client([FirstMiddleware])
+
+      assert_raise ArgumentError, ~r/not found/, fn ->
+        Client.insert_middleware!(client, ThirdMiddleware, :before, SecondMiddleware)
+      end
+    end
+
+    test "preserves adapter" do
+      adapter = Tesla.Adapter.Httpc
+      client = Tesla.client([FirstMiddleware], adapter)
+
+      new_client = Client.insert_middleware!(client, SecondMiddleware, :before, FirstMiddleware)
+
+      assert Client.adapter(new_client) == adapter
+    end
+  end
+
   describe "update_middleware/2" do
     test "prepends middleware" do
       client = Tesla.client([FirstMiddleware])
@@ -97,6 +253,54 @@ defmodule Tesla.ClientTest do
       new_client = Client.update_middleware(client, &(&1 ++ [SecondMiddleware]))
 
       assert Client.adapter(new_client) == nil
+    end
+  end
+
+  describe "update_middleware!/3" do
+    test "updates atom middleware" do
+      client = Tesla.client([FirstMiddleware])
+
+      new_client =
+        Client.update_middleware!(client, FirstMiddleware, fn _ -> SecondMiddleware end)
+
+      assert Client.middleware(new_client) == [SecondMiddleware]
+    end
+
+    test "updates tuple middleware opts" do
+      client = Tesla.client([{FirstMiddleware, [opt: 1]}])
+
+      new_client =
+        Client.update_middleware!(client, FirstMiddleware, fn {m, opts} ->
+          {m, Keyword.put(opts, :opt, 2)}
+        end)
+
+      assert Client.middleware(new_client) == [{FirstMiddleware, [opt: 2]}]
+    end
+
+    test "updates only first occurrence" do
+      client = Tesla.client([FirstMiddleware, SecondMiddleware, FirstMiddleware])
+
+      new_client = Client.update_middleware!(client, FirstMiddleware, fn _ -> ThirdMiddleware end)
+
+      assert Client.middleware(new_client) == [ThirdMiddleware, SecondMiddleware, FirstMiddleware]
+    end
+
+    test "raises when target not found" do
+      client = Tesla.client([FirstMiddleware])
+
+      assert_raise ArgumentError, ~r/not found/, fn ->
+        Client.update_middleware!(client, SecondMiddleware, fn m -> m end)
+      end
+    end
+
+    test "preserves adapter" do
+      adapter = Tesla.Adapter.Httpc
+      client = Tesla.client([FirstMiddleware], adapter)
+
+      new_client =
+        Client.update_middleware!(client, FirstMiddleware, fn _ -> SecondMiddleware end)
+
+      assert Client.adapter(new_client) == adapter
     end
   end
 


### PR DESCRIPTION
- Extends `Tesla.Client` with targeted middleware manipulation functions that follow `Map` API conventions, building on `update_middleware/2` merged in #839
- `put_middleware/2` replaces the entire middleware list while preserving all original client fields, serving as the internal primitive for the other functions
- `update_middleware/3` applies a function to the first occurrence of a target middleware, allowing in-place modification of options
- `replace_middleware/3` finds a target middleware by module and swaps it for a new one
- `insert_middleware/4` inserts a new middleware `:before` or `:after` a target middleware
- All functions raise `ArgumentError` with a descriptive message when the target is not found or arguments are invalid