### PR TITLE
fix(mint): avoid failing large HTTP/2 uploads

### DIFF
--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -193,8 +193,11 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
     defp make_request(conn, method, path, headers, body, opts)
          when is_binary(body) or is_list(body) do
-      if HTTP.protocol(conn) == :http2 and IO.iodata_length(body) > 0 do
-        make_request(conn, method, path, headers, stream_to_fun([body]), opts)
+      body_length = IO.iodata_length(body)
+
+      if HTTP.protocol(conn) == :http2 and body_length > 0 do
+        headers = put_default_content_length_header(headers, body_length)
+        make_request(conn, method, path, headers, stream_to_fun(iodata_stream(body)), opts)
       else
         case HTTP.request(conn, method, path, headers, body) do
           {:ok, conn, ref} ->
@@ -218,11 +221,6 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
     defp stream_request(conn, ref, fun, opts, acc \\ %{}) do
       case next_chunk(fun) do
-        {:ok, item, fun} when is_list(item) ->
-          with {:ok, conn, acc} <- stream_request_body(conn, ref, List.to_string(item), opts, acc) do
-            stream_request(conn, ref, fun, opts, acc)
-          end
-
         {:ok, item, fun} ->
           with {:ok, conn, acc} <- stream_request_body(conn, ref, item, opts, acc) do
             stream_request(conn, ref, fun, opts, acc)
@@ -379,8 +377,84 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp raise_stream_error(error) when is_binary(error), do: raise(RuntimeError, message: error)
     defp raise_stream_error(error), do: raise(RuntimeError, message: inspect(error))
 
+    defp put_default_content_length_header(headers, body_length) do
+      if Enum.any?(headers, fn {name, _value} -> String.downcase(name) == "content-length" end) do
+        headers
+      else
+        [{"content-length", Integer.to_string(body_length)} | headers]
+      end
+    end
+
+    defp iodata_stream(body) do
+      Stream.resource(
+        fn -> {[body], [], 0} end,
+        &next_iodata_chunk/1,
+        fn _ -> :ok end
+      )
+    end
+
+    defp next_iodata_chunk({[], [], 0}), do: {:halt, {[], [], 0}}
+
+    defp next_iodata_chunk({[], buffer, _buffer_size}) do
+      {[IO.iodata_to_binary(Enum.reverse(buffer))], {[], [], 0}}
+    end
+
+    defp next_iodata_chunk({[chunk | rest], buffer, buffer_size}) when is_binary(chunk) do
+      chunk_size = byte_size(chunk)
+
+      cond do
+        buffer_size == 0 and chunk_size > @http2_request_chunk_size ->
+          <<head::binary-size(@http2_request_chunk_size), tail::binary>> = chunk
+          {[head], {[tail | rest], [], 0}}
+
+        buffer_size + chunk_size < @http2_request_chunk_size ->
+          next_iodata_chunk({rest, [chunk | buffer], buffer_size + chunk_size})
+
+        true ->
+          take_size = @http2_request_chunk_size - buffer_size
+          <<head::binary-size(take_size), tail::binary>> = chunk
+          chunk = IO.iodata_to_binary(Enum.reverse([head | buffer]))
+          {[chunk], {[tail | rest], [], 0}}
+      end
+    end
+
+    defp next_iodata_chunk({[chunk | rest], buffer, buffer_size})
+         when is_integer(chunk) and chunk >= 0 and chunk <= 255 do
+      if buffer_size + 1 < @http2_request_chunk_size do
+        next_iodata_chunk({rest, [chunk | buffer], buffer_size + 1})
+      else
+        chunk = IO.iodata_to_binary(Enum.reverse([chunk | buffer]))
+        {[chunk], {rest, [], 0}}
+      end
+    end
+
+    defp next_iodata_chunk({[chunk | rest], buffer, buffer_size}) when is_list(chunk) do
+      next_iodata_chunk({prepend_iodata(chunk, rest), buffer, buffer_size})
+    end
+
+    defp next_iodata_chunk({[chunk | _rest], _buffer, _buffer_size}) do
+      IO.iodata_to_binary([chunk])
+    end
+
+    defp prepend_iodata([], rest), do: rest
+    defp prepend_iodata([head | tail], rest), do: [head | prepend_iodata(tail, rest)]
+
     defp stream_request_body(conn, ref, chunk, opts, acc) when is_binary(chunk) do
       stream_request_body_chunk(conn, ref, chunk, opts, acc)
+    end
+
+    defp stream_request_body(conn, ref, chunk, opts, acc)
+         when is_integer(chunk) and chunk >= 0 and chunk <= 255 do
+      stream_request_body_chunk(conn, ref, <<chunk>>, opts, acc)
+    end
+
+    defp stream_request_body(conn, ref, chunk, opts, acc) when is_list(chunk) do
+      Enum.reduce_while(iodata_stream(chunk), {:ok, conn, acc}, fn item, {:ok, conn, acc} ->
+        case stream_request_body(conn, ref, item, opts, acc) do
+          {:ok, conn, acc} -> {:cont, {:ok, conn, acc}}
+          {:error, error} -> {:halt, {:error, error}}
+        end
+      end)
     end
 
     defp stream_request_body(conn, ref, chunk, opts, acc) do

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -386,13 +386,17 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp raise_stream_error(error), do: raise(RuntimeError, message: inspect(error))
 
     defp put_default_content_length_header(headers, body_length) do
-      if Enum.any?(headers, fn {name, _value} ->
-           String.downcase(to_string(name)) == "content-length"
-         end) do
+      if has_header?(headers, "content-length") do
         headers
       else
         [{"content-length", Integer.to_string(body_length)} | headers]
       end
+    end
+
+    defp has_header?(headers, expected_name) do
+      Enum.any?(headers, fn {name, _value} ->
+        String.downcase(name) == expected_name
+      end)
     end
 
     defp stream_request_body(conn, ref, chunk, opts, acc) when is_binary(chunk) do

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -219,7 +219,11 @@ if Code.ensure_loaded?(Mint.HTTP) do
       end
     end
 
-    defp stream_request(conn, ref, fun, opts, acc \\ %{}) do
+    defp stream_request(conn, ref, fun, opts, acc \\ %{})
+
+    defp stream_request(conn, _ref, _fun, _opts, %{done: true} = acc), do: {:ok, conn, acc}
+
+    defp stream_request(conn, ref, fun, opts, acc) do
       case next_chunk(fun) do
         {:ok, item, fun} ->
           with {:ok, conn, acc} <- stream_request_body(conn, ref, item, opts, acc) do
@@ -299,13 +303,14 @@ if Code.ensure_loaded?(Mint.HTTP) do
     end
 
     defp receive_responses(conn, ref, opts, acc) do
-      with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc),
-           :ok <- check_data_size(acc, conn, opts) do
+      with :ok <- check_data_size(acc, conn, opts) do
         if acc[:done] do
           if opts[:close_conn], do: {:ok, _conn} = close(conn)
           {:ok, acc}
         else
-          receive_responses(conn, ref, opts, acc)
+          with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc) do
+            receive_responses(conn, ref, opts, acc)
+          end
         end
       end
     end
@@ -323,12 +328,14 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp check_data_size(_, _, _), do: :ok
 
     defp receive_headers_and_status(conn, ref, opts, acc) do
-      with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc) do
-        case acc do
-          %{status: _status, headers: _headers} -> {:ok, conn, acc}
-          # if we don't have status or headers we try to get them in next packet
-          _ -> receive_headers_and_status(conn, ref, opts, acc)
-        end
+      case acc do
+        %{status: _status, headers: _headers} ->
+          {:ok, conn, acc}
+
+        _ ->
+          with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc) do
+            receive_headers_and_status(conn, ref, opts, acc)
+          end
       end
     end
 
@@ -515,7 +522,11 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
     defp await_request_window(conn, ref, chunk, opts, acc, chunk_size) do
       with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc) do
-        stream_http2_body_chunk(conn, ref, chunk, opts, acc, chunk_size)
+        if acc[:done] do
+          {:ok, conn, acc}
+        else
+          stream_http2_body_chunk(conn, ref, chunk, opts, acc, chunk_size)
+        end
       end
     end
 

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -191,14 +191,22 @@ if Code.ensure_loaded?(Mint.HTTP) do
       end
     end
 
-    defp make_request(conn, method, path, headers, body, _opts)
+    defp make_request(conn, method, path, headers, body, opts)
          when is_binary(body) or is_list(body) do
-      case HTTP.request(conn, method, path, headers, body) do
-        {:ok, conn, ref} ->
-          {:ok, conn, ref, %{}}
+      body_length = IO.iodata_length(body)
 
-        {:error, _conn, error} ->
-          {:error, error}
+      if HTTP.protocol(conn) == :http2 and body_length > 0 do
+        headers = put_default_content_length_header(headers, body_length)
+        body = IO.iodata_to_binary(body)
+        make_request(conn, method, path, headers, stream_to_fun([body]), opts)
+      else
+        case HTTP.request(conn, method, path, headers, body) do
+          {:ok, conn, ref} ->
+            {:ok, conn, ref, %{}}
+
+          {:error, _conn, error} ->
+            {:error, error}
+        end
       end
     end
 
@@ -376,6 +384,16 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp raise_stream_error(error) when Kernel.is_exception(error), do: raise(error)
     defp raise_stream_error(error) when is_binary(error), do: raise(RuntimeError, message: error)
     defp raise_stream_error(error), do: raise(RuntimeError, message: inspect(error))
+
+    defp put_default_content_length_header(headers, body_length) do
+      if Enum.any?(headers, fn {name, _value} ->
+           String.downcase(to_string(name)) == "content-length"
+         end) do
+        headers
+      else
+        [{"content-length", Integer.to_string(body_length)} | headers]
+      end
+    end
 
     defp stream_request_body(conn, ref, chunk, opts, acc) when is_binary(chunk) do
       stream_request_body_chunk(conn, ref, chunk, opts, acc)

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -53,6 +53,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
     alias Mint.HTTP
 
     @default timeout: 2_000, body_as: :plain, close_conn: true
+    @http2_request_chunk_size 16_384
 
     @tags [:tcp_error, :ssl_error, :tcp_closed, :ssl_closed, :tcp, :ssl]
 
@@ -393,16 +394,14 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp stream_request_body_chunk(conn, ref, chunk, opts, acc) do
       case HTTP.protocol(conn) do
         :http2 ->
-          with {:ok, conn, acc} <- await_request_window(conn, ref, opts, acc) do
-            window_size = request_window_size(conn, ref)
-            chunk_size = min(byte_size(chunk), window_size)
-            <<body_chunk::binary-size(chunk_size), rest::binary>> = chunk
-
-            case HTTP.stream_request_body(conn, ref, body_chunk) do
-              {:ok, conn} -> stream_request_body_chunk(conn, ref, rest, opts, acc)
-              {:error, _conn, error} -> {:error, error}
-            end
-          end
+          stream_http2_body_chunk(
+            conn,
+            ref,
+            chunk,
+            opts,
+            acc,
+            min(byte_size(chunk), @http2_request_chunk_size)
+          )
 
         _ ->
           case HTTP.stream_request_body(conn, ref, chunk) do
@@ -412,21 +411,38 @@ if Code.ensure_loaded?(Mint.HTTP) do
       end
     end
 
-    defp await_request_window(conn, ref, opts, acc) do
-      if request_window_size(conn, ref) > 0 do
-        {:ok, conn, acc}
-      else
-        with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc) do
-          await_request_window(conn, ref, opts, acc)
-        end
+    defp stream_http2_body_chunk(conn, _ref, "", _opts, acc, _chunk_size), do: {:ok, conn, acc}
+
+    defp stream_http2_body_chunk(conn, ref, chunk, opts, acc, chunk_size) do
+      chunk_size = min(byte_size(chunk), chunk_size)
+      <<body_chunk::binary-size(chunk_size), rest::binary>> = chunk
+
+      case HTTP.stream_request_body(conn, ref, body_chunk) do
+        {:ok, conn} ->
+          stream_http2_body_chunk(
+            conn,
+            ref,
+            rest,
+            opts,
+            acc,
+            min(byte_size(rest), @http2_request_chunk_size)
+          )
+
+        {:error, conn, %Mint.HTTPError{reason: {:exceeds_window_size, _, 0}}} ->
+          await_request_window(conn, ref, chunk, opts, acc, chunk_size)
+
+        {:error, conn, %Mint.HTTPError{reason: {:exceeds_window_size, _, window_size}}} ->
+          stream_http2_body_chunk(conn, ref, chunk, opts, acc, window_size)
+
+        {:error, _conn, error} ->
+          {:error, error}
       end
     end
 
-    defp request_window_size(conn, ref) do
-      min(
-        Mint.HTTP2.get_window_size(conn, :connection),
-        Mint.HTTP2.get_window_size(conn, {:request, ref})
-      )
+    defp await_request_window(conn, ref, chunk, opts, acc, chunk_size) do
+      with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc) do
+        stream_http2_body_chunk(conn, ref, chunk, opts, acc, chunk_size)
+      end
     end
 
     defp reduce_responses(responses, ref, acc) do

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -191,21 +191,14 @@ if Code.ensure_loaded?(Mint.HTTP) do
       end
     end
 
-    defp make_request(conn, method, path, headers, body, opts)
+    defp make_request(conn, method, path, headers, body, _opts)
          when is_binary(body) or is_list(body) do
-      body_length = IO.iodata_length(body)
+      case HTTP.request(conn, method, path, headers, body) do
+        {:ok, conn, ref} ->
+          {:ok, conn, ref, %{}}
 
-      if HTTP.protocol(conn) == :http2 and body_length > 0 do
-        headers = put_default_content_length_header(headers, body_length)
-        make_request(conn, method, path, headers, stream_to_fun(iodata_stream(body)), opts)
-      else
-        case HTTP.request(conn, method, path, headers, body) do
-          {:ok, conn, ref} ->
-            {:ok, conn, ref, %{}}
-
-          {:error, _conn, error} ->
-            {:error, error}
-        end
+        {:error, _conn, error} ->
+          {:error, error}
       end
     end
 
@@ -384,68 +377,6 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp raise_stream_error(error) when is_binary(error), do: raise(RuntimeError, message: error)
     defp raise_stream_error(error), do: raise(RuntimeError, message: inspect(error))
 
-    defp put_default_content_length_header(headers, body_length) do
-      if Enum.any?(headers, fn {name, _value} -> String.downcase(name) == "content-length" end) do
-        headers
-      else
-        [{"content-length", Integer.to_string(body_length)} | headers]
-      end
-    end
-
-    defp iodata_stream(body) do
-      Stream.resource(
-        fn -> {[body], [], 0} end,
-        &next_iodata_chunk/1,
-        fn _ -> :ok end
-      )
-    end
-
-    defp next_iodata_chunk({[], [], 0}), do: {:halt, {[], [], 0}}
-
-    defp next_iodata_chunk({[], buffer, _buffer_size}) do
-      {[IO.iodata_to_binary(Enum.reverse(buffer))], {[], [], 0}}
-    end
-
-    defp next_iodata_chunk({[chunk | rest], buffer, buffer_size}) when is_binary(chunk) do
-      chunk_size = byte_size(chunk)
-
-      cond do
-        buffer_size == 0 and chunk_size > @http2_request_chunk_size ->
-          <<head::binary-size(@http2_request_chunk_size), tail::binary>> = chunk
-          {[head], {[tail | rest], [], 0}}
-
-        buffer_size + chunk_size < @http2_request_chunk_size ->
-          next_iodata_chunk({rest, [chunk | buffer], buffer_size + chunk_size})
-
-        true ->
-          take_size = @http2_request_chunk_size - buffer_size
-          <<head::binary-size(take_size), tail::binary>> = chunk
-          chunk = IO.iodata_to_binary(Enum.reverse([head | buffer]))
-          {[chunk], {[tail | rest], [], 0}}
-      end
-    end
-
-    defp next_iodata_chunk({[chunk | rest], buffer, buffer_size})
-         when is_integer(chunk) and chunk >= 0 and chunk <= 255 do
-      if buffer_size + 1 < @http2_request_chunk_size do
-        next_iodata_chunk({rest, [chunk | buffer], buffer_size + 1})
-      else
-        chunk = IO.iodata_to_binary(Enum.reverse([chunk | buffer]))
-        {[chunk], {rest, [], 0}}
-      end
-    end
-
-    defp next_iodata_chunk({[chunk | rest], buffer, buffer_size}) when is_list(chunk) do
-      next_iodata_chunk({prepend_iodata(chunk, rest), buffer, buffer_size})
-    end
-
-    defp next_iodata_chunk({[chunk | _rest], _buffer, _buffer_size}) do
-      raise ArgumentError, "invalid iodata element in request body: #{inspect(chunk)}"
-    end
-
-    defp prepend_iodata([], rest), do: rest
-    defp prepend_iodata([head | tail], rest), do: [head | prepend_iodata(tail, rest)]
-
     defp stream_request_body(conn, ref, chunk, opts, acc) when is_binary(chunk) do
       stream_request_body_chunk(conn, ref, chunk, opts, acc)
     end
@@ -456,18 +387,24 @@ if Code.ensure_loaded?(Mint.HTTP) do
     end
 
     defp stream_request_body(conn, ref, chunk, opts, acc) when is_list(chunk) do
-      Enum.reduce_while(iodata_stream(chunk), {:ok, conn, acc}, fn item, {:ok, conn, acc} ->
-        case stream_request_body(conn, ref, item, opts, acc) do
-          {:ok, conn, acc} -> {:cont, {:ok, conn, acc}}
-          {:error, error} -> {:halt, {:error, error}}
-        end
-      end)
-    end
-
-    defp stream_request_body(conn, ref, chunk, opts, acc) do
       chunk
       |> IO.iodata_to_binary()
       |> then(&stream_request_body_chunk(conn, ref, &1, opts, acc))
+    end
+
+    defp stream_request_body(conn, ref, chunk, opts, acc) do
+      case HTTP.protocol(conn) do
+        :http2 ->
+          chunk
+          |> IO.iodata_to_binary()
+          |> then(&stream_request_body_chunk(conn, ref, &1, opts, acc))
+
+        _ ->
+          case HTTP.stream_request_body(conn, ref, chunk) do
+            {:ok, conn} -> {:ok, conn, acc}
+            {:error, _conn, error} -> {:error, error}
+          end
+      end
     end
 
     defp stream_request_body_chunk(conn, _ref, "", _opts, acc), do: {:ok, conn, acc}

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -121,8 +121,8 @@ if Code.ensure_loaded?(Mint.HTTP) do
            path <- prepare_path(uri.path, uri.query),
            opts <- check_original(uri, opts),
            {:ok, conn, opts} <- open_conn(uri, opts),
-           {:ok, conn, ref} <- make_request(conn, method, path, headers, body) do
-        format_response(conn, ref, opts)
+           {:ok, conn, ref, response} <- make_request(conn, method, path, headers, body, opts) do
+        format_response(conn, ref, opts, response)
       end
     end
 
@@ -176,7 +176,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp parse_scheme("https"), do: {:ok, :https}
     defp parse_scheme(_), do: {:error, :unsupported_scheme}
 
-    defp make_request(conn, method, path, headers, body) when is_function(body) do
+    defp make_request(conn, method, path, headers, body, opts) when is_function(body) do
       with {:ok, conn, ref} <-
              HTTP.request(
                conn,
@@ -185,46 +185,65 @@ if Code.ensure_loaded?(Mint.HTTP) do
                headers,
                :stream
              ),
-           {:ok, conn} <- stream_request(conn, ref, body) do
-        {:ok, conn, ref}
+           {:ok, conn, response} <- stream_request(conn, ref, body, opts) do
+        {:ok, conn, ref, response}
       end
     end
 
-    defp make_request(conn, method, path, headers, body) do
+    defp make_request(conn, method, path, headers, body, opts)
+         when is_binary(body) or is_list(body) do
+      if HTTP.protocol(conn) == :http2 and IO.iodata_length(body) > 0 do
+        make_request(conn, method, path, headers, stream_to_fun([body]), opts)
+      else
+        case HTTP.request(conn, method, path, headers, body) do
+          {:ok, conn, ref} ->
+            {:ok, conn, ref, %{}}
+
+          {:error, _conn, error} ->
+            {:error, error}
+        end
+      end
+    end
+
+    defp make_request(conn, method, path, headers, body, _opts) do
       case HTTP.request(conn, method, path, headers, body) do
         {:ok, conn, ref} ->
-          {:ok, conn, ref}
+          {:ok, conn, ref, %{}}
 
         {:error, _conn, error} ->
           {:error, error}
       end
     end
 
-    defp stream_request(conn, ref, fun) do
+    defp stream_request(conn, ref, fun, opts, acc \\ %{}) do
       case next_chunk(fun) do
         {:ok, item, fun} when is_list(item) ->
-          chunk = List.to_string(item)
-          {:ok, conn} = HTTP.stream_request_body(conn, ref, chunk)
-          stream_request(conn, ref, fun)
+          with {:ok, conn, acc} <- stream_request_body(conn, ref, List.to_string(item), opts, acc) do
+            stream_request(conn, ref, fun, opts, acc)
+          end
 
         {:ok, item, fun} ->
-          {:ok, conn} = HTTP.stream_request_body(conn, ref, item)
-          stream_request(conn, ref, fun)
+          with {:ok, conn, acc} <- stream_request_body(conn, ref, item, opts, acc) do
+            stream_request(conn, ref, fun, opts, acc)
+          end
 
         :eof ->
-          HTTP.stream_request_body(conn, ref, :eof)
+          case HTTP.stream_request_body(conn, ref, :eof) do
+            {:ok, conn} -> {:ok, conn, acc}
+            {:error, _conn, error} -> {:error, error}
+          end
       end
     end
 
-    defp format_response(conn, ref, %{body_as: :plain} = opts) do
-      with {:ok, response} <- receive_responses(conn, ref, opts) do
+    defp format_response(conn, ref, %{body_as: :plain} = opts, response) do
+      with {:ok, response} <- receive_responses(conn, ref, opts, response) do
         {:ok, response[:status], response[:headers], response[:data]}
       end
     end
 
-    defp format_response(conn, ref, %{body_as: :chunks} = opts) do
+    defp format_response(conn, ref, %{body_as: :chunks} = opts, response) do
       with {:ok, conn, %{status: status, headers: headers} = acc} <-
-             receive_headers_and_status(conn, ref, opts),
+             receive_headers_and_status(conn, ref, opts, response),
            {state, data} <-
              response_state(acc) do
         {:ok, conn} =
@@ -238,10 +257,10 @@ if Code.ensure_loaded?(Mint.HTTP) do
       end
     end
 
-    defp format_response(conn, ref, %{body_as: :stream} = opts) do
+    defp format_response(conn, ref, %{body_as: :stream} = opts, response) do
       # there can be some data already
       with {:ok, conn, %{status: status, headers: headers} = acc} <-
-             receive_headers_and_status(conn, ref, opts) do
+             receive_headers_and_status(conn, ref, opts, response) do
         body_as_stream =
           Stream.resource(
             fn -> %{conn: conn, data: acc[:data], done: acc[:done]} end,
@@ -280,7 +299,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
       end
     end
 
-    defp receive_responses(conn, ref, opts, acc \\ %{}) do
+    defp receive_responses(conn, ref, opts, acc) do
       with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc),
            :ok <- check_data_size(acc, conn, opts) do
         if acc[:done] do
@@ -304,7 +323,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
     defp check_data_size(_, _, _), do: :ok
 
-    defp receive_headers_and_status(conn, ref, opts, acc \\ %{}) do
+    defp receive_headers_and_status(conn, ref, opts, acc) do
       with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc) do
         case acc do
           %{status: _status, headers: _headers} -> {:ok, conn, acc}
@@ -358,6 +377,57 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp raise_stream_error(error) when Kernel.is_exception(error), do: raise(error)
     defp raise_stream_error(error) when is_binary(error), do: raise(RuntimeError, message: error)
     defp raise_stream_error(error), do: raise(RuntimeError, message: inspect(error))
+
+    defp stream_request_body(conn, ref, chunk, opts, acc) when is_binary(chunk) do
+      stream_request_body_chunk(conn, ref, chunk, opts, acc)
+    end
+
+    defp stream_request_body(conn, ref, chunk, opts, acc) do
+      chunk
+      |> IO.iodata_to_binary()
+      |> then(&stream_request_body_chunk(conn, ref, &1, opts, acc))
+    end
+
+    defp stream_request_body_chunk(conn, _ref, "", _opts, acc), do: {:ok, conn, acc}
+
+    defp stream_request_body_chunk(conn, ref, chunk, opts, acc) do
+      case HTTP.protocol(conn) do
+        :http2 ->
+          with {:ok, conn, acc} <- await_request_window(conn, ref, opts, acc) do
+            window_size = request_window_size(conn, ref)
+            chunk_size = min(byte_size(chunk), window_size)
+            <<body_chunk::binary-size(chunk_size), rest::binary>> = chunk
+
+            case HTTP.stream_request_body(conn, ref, body_chunk) do
+              {:ok, conn} -> stream_request_body_chunk(conn, ref, rest, opts, acc)
+              {:error, _conn, error} -> {:error, error}
+            end
+          end
+
+        _ ->
+          case HTTP.stream_request_body(conn, ref, chunk) do
+            {:ok, conn} -> {:ok, conn, acc}
+            {:error, _conn, error} -> {:error, error}
+          end
+      end
+    end
+
+    defp await_request_window(conn, ref, opts, acc) do
+      if request_window_size(conn, ref) > 0 do
+        {:ok, conn, acc}
+      else
+        with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc) do
+          await_request_window(conn, ref, opts, acc)
+        end
+      end
+    end
+
+    defp request_window_size(conn, ref) do
+      min(
+        Mint.HTTP2.get_window_size(conn, :connection),
+        Mint.HTTP2.get_window_size(conn, {:request, ref})
+      )
+    end
 
     defp reduce_responses(responses, ref, acc) do
       case Enum.reduce_while(responses, acc, &reduce_response(&1, ref, &2)) do

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -440,7 +440,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
     end
 
     defp next_iodata_chunk({[chunk | _rest], _buffer, _buffer_size}) do
-      IO.iodata_to_binary([chunk])
+      raise ArgumentError, "invalid iodata element in request body: #{inspect(chunk)}"
     end
 
     defp prepend_iodata([], rest), do: rest

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -76,12 +76,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
     def read_chunk(conn, ref, opts) do
       with {:ok, conn, acc} <- receive_packet(conn, ref, Enum.into(opts, %{})),
            {state, data} <- response_state(acc) do
-        {:ok, conn} =
-          if state == :fin and opts[:close_conn] do
-            close(conn)
-          else
-            {:ok, conn}
-          end
+        conn = if state == :fin, do: maybe_close(conn, opts), else: conn
 
         {state, conn, data}
       end
@@ -181,14 +176,9 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp parse_scheme(_), do: {:error, :unsupported_scheme}
 
     defp make_request(conn, method, path, headers, body, opts) when is_function(body) do
-      case HTTP.request(conn, method, path, headers, :stream) do
-        {:ok, conn, ref} ->
-          with {:ok, conn, response} <- stream_request(conn, ref, body, opts) do
-            {:ok, conn, ref, response}
-          end
-
-        {:error, conn, error} ->
-          close_on_error(conn, error, opts)
+      with {:ok, conn, ref} <- open_stream_request(conn, method, path, headers, opts),
+           {:ok, conn, response} <- stream_request(conn, ref, body, opts) do
+        {:ok, conn, ref, response}
       end
     end
 
@@ -201,23 +191,25 @@ if Code.ensure_loaded?(Mint.HTTP) do
         body = IO.iodata_to_binary(body)
         make_request(conn, method, path, headers, stream_to_fun([body]), opts)
       else
-        case HTTP.request(conn, method, path, headers, body) do
-          {:ok, conn, ref} ->
-            {:ok, conn, ref, %{}}
-
-          {:error, conn, error} ->
-            close_on_error(conn, error, opts)
-        end
+        send_request(conn, method, path, headers, body, opts)
       end
     end
 
     defp make_request(conn, method, path, headers, body, opts) do
-      case HTTP.request(conn, method, path, headers, body) do
-        {:ok, conn, ref} ->
-          {:ok, conn, ref, %{}}
+      send_request(conn, method, path, headers, body, opts)
+    end
 
-        {:error, conn, error} ->
-          close_on_error(conn, error, opts)
+    defp open_stream_request(conn, method, path, headers, opts) do
+      case HTTP.request(conn, method, path, headers, :stream) do
+        {:ok, conn, ref} -> {:ok, conn, ref}
+        {:error, conn, error} -> close_on_error(conn, error, opts)
+      end
+    end
+
+    defp send_request(conn, method, path, headers, body, opts) do
+      case HTTP.request(conn, method, path, headers, body) do
+        {:ok, conn, ref} -> {:ok, conn, ref, %{}}
+        {:error, conn, error} -> close_on_error(conn, error, opts)
       end
     end
 
@@ -233,10 +225,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
           end
 
         :eof ->
-          case HTTP.stream_request_body(conn, ref, :eof) do
-            {:ok, conn} -> {:ok, conn, acc}
-            {:error, conn, error} -> close_on_error(conn, error, opts)
-          end
+          send_body_chunk(conn, ref, :eof, opts, acc)
       end
     end
 
@@ -251,12 +240,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
              receive_headers_and_status(conn, ref, opts, response),
            {state, data} <-
              response_state(acc) do
-        {:ok, conn} =
-          if state == :fin and opts[:close_conn] do
-            close(conn)
-          else
-            {:ok, conn}
-          end
+        conn = if state == :fin, do: maybe_close(conn, opts), else: conn
 
         {:ok, status, headers, %{conn: conn, ref: ref, opts: opts, body: {state, data}}}
       end
@@ -270,8 +254,11 @@ if Code.ensure_loaded?(Mint.HTTP) do
           Stream.resource(
             fn -> %{conn: conn, data: acc[:data], done: acc[:done]} end,
             fn
-              %{conn: conn, data: data, done: true} ->
+              %{conn: conn, data: data, done: true} when is_binary(data) ->
                 {[data], %{conn: conn, is_fin: true}}
+
+              %{conn: conn, done: true} ->
+                {[], %{conn: conn, is_fin: true}}
 
               %{conn: conn, data: data} when is_binary(data) ->
                 {[data], %{conn: conn}}
@@ -297,7 +284,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
                     raise_stream_error(error)
                 end
             end,
-            fn %{conn: conn} -> if opts[:close_conn], do: {:ok, _conn} = close(conn) end
+            fn %{conn: conn} -> maybe_close(conn, opts) end
           )
 
         {:ok, status, headers, body_as_stream}
@@ -307,7 +294,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp receive_responses(conn, ref, opts, acc) do
       with :ok <- check_data_size(acc, conn, opts) do
         if acc[:done] do
-          if opts[:close_conn], do: {:ok, _conn} = close(conn)
+          maybe_close(conn, opts)
           {:ok, acc}
         else
           with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc) do
@@ -322,7 +309,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
       if max_body - byte_size(data) >= 0 do
         :ok
       else
-        if opts[:close_conn], do: {:ok, _conn} = close(conn)
+        maybe_close(conn, opts)
         {:error, :body_too_large}
       end
     end
@@ -347,26 +334,25 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp response_state(_), do: {:nofin, ""}
 
     defp receive_packet(conn, ref, opts, acc \\ %{}) do
-      with {:ok, conn, responses} <- receive_message(conn, opts),
-           {:ok, acc} <- reduce_responses(responses, ref, acc) do
-        {:ok, conn, acc}
-      else
-        {:error, error} ->
-          if opts[:close_conn], do: {:ok, _conn} = close(conn)
-          {:error, error}
+      case receive_message(conn, opts) do
+        {:ok, conn, responses} ->
+          case reduce_responses(responses, ref, acc) do
+            {:ok, acc} -> {:ok, conn, acc}
+            {:error, error} -> close_on_error(conn, error, opts)
+          end
 
-        {:error, conn, %Mint.TransportError{reason: :timeout}, _res} ->
-          if opts[:close_conn], do: {:ok, _conn} = close(conn)
-          {:error, :timeout}
+        {:error, :timeout} ->
+          close_on_error(conn, :timeout, opts)
 
-        {:error, conn, error, _res} ->
-          if opts[:close_conn], do: {:ok, _conn} = close(conn)
+        {:error, conn, %Mint.TransportError{reason: :timeout}, _responses} ->
+          close_on_error(conn, :timeout, opts)
+
+        {:error, conn, error, _responses} ->
           # TODO: (breaking change) fix typo in error message, "Encounter" => "Encountered"
-          {:error, "Encounter Mint error #{inspect(error)}"}
+          close_on_error(conn, "Encounter Mint error #{inspect(error)}", opts)
 
         :unknown ->
-          if opts[:close_conn], do: {:ok, _conn} = close(conn)
-          {:error, :unknown}
+          close_on_error(conn, :unknown, opts)
       end
     end
 
@@ -423,10 +409,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
           |> then(&stream_request_body_chunk(conn, ref, &1, opts, acc))
 
         _ ->
-          case HTTP.stream_request_body(conn, ref, chunk) do
-            {:ok, conn} -> {:ok, conn, acc}
-            {:error, conn, error} -> close_on_error(conn, error, opts)
-          end
+          send_body_chunk(conn, ref, chunk, opts, acc)
       end
     end
 
@@ -445,10 +428,14 @@ if Code.ensure_loaded?(Mint.HTTP) do
           )
 
         _ ->
-          case HTTP.stream_request_body(conn, ref, chunk) do
-            {:ok, conn} -> {:ok, conn, acc}
-            {:error, conn, error} -> close_on_error(conn, error, opts)
-          end
+          send_body_chunk(conn, ref, chunk, opts, acc)
+      end
+    end
+
+    defp send_body_chunk(conn, ref, chunk, opts, acc) do
+      case HTTP.stream_request_body(conn, ref, chunk) do
+        {:ok, conn} -> {:ok, conn, acc}
+        {:error, conn, error} -> close_on_error(conn, error, opts)
       end
     end
 
@@ -481,8 +468,17 @@ if Code.ensure_loaded?(Mint.HTTP) do
       end
     end
 
+    defp maybe_close(conn, opts) do
+      if opts[:close_conn] do
+        {:ok, conn} = close(conn)
+        conn
+      else
+        conn
+      end
+    end
+
     defp close_on_error(conn, error, opts) do
-      if opts[:close_conn], do: {:ok, _conn} = close(conn)
+      maybe_close(conn, opts)
       {:error, error}
     end
 

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -373,18 +373,14 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp raise_stream_error(error), do: raise(RuntimeError, message: inspect(error))
 
     defp put_default_content_length_header(headers, body_length) do
-      if has_header?(headers, "content-length") do
+      if Enum.any?(headers, &content_length?/1) do
         headers
       else
         [{"content-length", Integer.to_string(body_length)} | headers]
       end
     end
 
-    defp has_header?(headers, expected_name) do
-      Enum.any?(headers, fn {name, _value} ->
-        String.downcase(name) == expected_name
-      end)
-    end
+    defp content_length?({name, _value}), do: String.downcase(name) == "content-length"
 
     defp stream_request_body(conn, ref, chunk, opts, acc) when is_binary(chunk) do
       stream_request_body_chunk(conn, ref, chunk, opts, acc)
@@ -392,24 +388,17 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
     defp stream_request_body(conn, ref, chunk, opts, acc)
          when is_integer(chunk) and chunk >= 0 and chunk <= 255 do
-      stream_request_body_chunk(conn, ref, <<chunk>>, opts, acc)
+      stream_request_body(conn, ref, <<chunk>>, opts, acc)
     end
 
     defp stream_request_body(conn, ref, chunk, opts, acc) when is_list(chunk) do
-      chunk
-      |> IO.iodata_to_binary()
-      |> then(&stream_request_body_chunk(conn, ref, &1, opts, acc))
+      stream_request_body(conn, ref, IO.iodata_to_binary(chunk), opts, acc)
     end
 
     defp stream_request_body(conn, ref, chunk, opts, acc) do
       case HTTP.protocol(conn) do
-        :http2 ->
-          chunk
-          |> IO.iodata_to_binary()
-          |> then(&stream_request_body_chunk(conn, ref, &1, opts, acc))
-
-        _ ->
-          send_body_chunk(conn, ref, chunk, opts, acc)
+        :http2 -> stream_request_body(conn, ref, IO.iodata_to_binary(chunk), opts, acc)
+        _ -> send_body_chunk(conn, ref, chunk, opts, acc)
       end
     end
 

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -53,6 +53,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
     alias Mint.HTTP
 
     @default timeout: 2_000, body_as: :plain, close_conn: true
+    @http2_request_chunk_size 16_384
 
     @tags [:tcp_error, :ssl_error, :tcp_closed, :ssl_closed, :tcp, :ssl]
 
@@ -124,8 +125,8 @@ if Code.ensure_loaded?(Mint.HTTP) do
            path <- prepare_path(uri.path, uri.query),
            opts <- check_original(uri, opts),
            {:ok, conn, opts} <- open_conn(uri, opts),
-           {:ok, conn, ref} <- make_request(conn, method, path, headers, body) do
-        format_response(conn, ref, opts)
+           {:ok, conn, ref, response} <- make_request(conn, method, path, headers, body, opts) do
+        format_response(conn, ref, opts, response)
       end
     end
 
@@ -179,55 +180,75 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp parse_scheme("https"), do: {:ok, :https}
     defp parse_scheme(_), do: {:error, :unsupported_scheme}
 
-    defp make_request(conn, method, path, headers, body) when is_function(body) do
-      with {:ok, conn, ref} <-
-             HTTP.request(
-               conn,
-               method,
-               path,
-               headers,
-               :stream
-             ),
-           {:ok, conn} <- stream_request(conn, ref, body) do
-        {:ok, conn, ref}
+    defp make_request(conn, method, path, headers, body, opts) when is_function(body) do
+      case HTTP.request(conn, method, path, headers, :stream) do
+        {:ok, conn, ref} ->
+          with {:ok, conn, response} <- stream_request(conn, ref, body, opts) do
+            {:ok, conn, ref, response}
+          end
+
+        {:error, conn, error} ->
+          close_on_error(conn, error, opts)
       end
     end
 
-    defp make_request(conn, method, path, headers, body) do
+    defp make_request(conn, method, path, headers, body, opts)
+         when is_binary(body) or is_list(body) do
+      body_length = IO.iodata_length(body)
+
+      if HTTP.protocol(conn) == :http2 and body_length > 0 do
+        headers = put_default_content_length_header(headers, body_length)
+        body = IO.iodata_to_binary(body)
+        make_request(conn, method, path, headers, stream_to_fun([body]), opts)
+      else
+        case HTTP.request(conn, method, path, headers, body) do
+          {:ok, conn, ref} ->
+            {:ok, conn, ref, %{}}
+
+          {:error, conn, error} ->
+            close_on_error(conn, error, opts)
+        end
+      end
+    end
+
+    defp make_request(conn, method, path, headers, body, opts) do
       case HTTP.request(conn, method, path, headers, body) do
         {:ok, conn, ref} ->
-          {:ok, conn, ref}
+          {:ok, conn, ref, %{}}
 
-        {:error, _conn, error} ->
-          {:error, error}
+        {:error, conn, error} ->
+          close_on_error(conn, error, opts)
       end
     end
 
-    defp stream_request(conn, ref, fun) do
-      case next_chunk(fun) do
-        {:ok, item, fun} when is_list(item) ->
-          chunk = List.to_string(item)
-          {:ok, conn} = HTTP.stream_request_body(conn, ref, chunk)
-          stream_request(conn, ref, fun)
+    defp stream_request(conn, ref, fun, opts, acc \\ %{})
 
+    defp stream_request(conn, _ref, _fun, _opts, %{done: true} = acc), do: {:ok, conn, acc}
+
+    defp stream_request(conn, ref, fun, opts, acc) do
+      case next_chunk(fun) do
         {:ok, item, fun} ->
-          {:ok, conn} = HTTP.stream_request_body(conn, ref, item)
-          stream_request(conn, ref, fun)
+          with {:ok, conn, acc} <- stream_request_body(conn, ref, item, opts, acc) do
+            stream_request(conn, ref, fun, opts, acc)
+          end
 
         :eof ->
-          HTTP.stream_request_body(conn, ref, :eof)
+          case HTTP.stream_request_body(conn, ref, :eof) do
+            {:ok, conn} -> {:ok, conn, acc}
+            {:error, conn, error} -> close_on_error(conn, error, opts)
+          end
       end
     end
 
-    defp format_response(conn, ref, %{body_as: :plain} = opts) do
-      with {:ok, response} <- receive_responses(conn, ref, opts) do
+    defp format_response(conn, ref, %{body_as: :plain} = opts, response) do
+      with {:ok, response} <- receive_responses(conn, ref, opts, response) do
         {:ok, response[:status], response[:headers], response[:data]}
       end
     end
 
-    defp format_response(conn, ref, %{body_as: :chunks} = opts) do
+    defp format_response(conn, ref, %{body_as: :chunks} = opts, response) do
       with {:ok, conn, %{status: status, headers: headers} = acc} <-
-             receive_headers_and_status(conn, ref, opts),
+             receive_headers_and_status(conn, ref, opts, response),
            {state, data} <-
              response_state(acc) do
         {:ok, conn} =
@@ -241,10 +262,10 @@ if Code.ensure_loaded?(Mint.HTTP) do
       end
     end
 
-    defp format_response(conn, ref, %{body_as: :stream} = opts) do
+    defp format_response(conn, ref, %{body_as: :stream} = opts, response) do
       # there can be some data already
       with {:ok, conn, %{status: status, headers: headers} = acc} <-
-             receive_headers_and_status(conn, ref, opts) do
+             receive_headers_and_status(conn, ref, opts, response) do
         body_as_stream =
           Stream.resource(
             fn -> %{conn: conn, data: acc[:data], done: acc[:done]} end,
@@ -283,14 +304,15 @@ if Code.ensure_loaded?(Mint.HTTP) do
       end
     end
 
-    defp receive_responses(conn, ref, opts, acc \\ %{}) do
-      with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc),
-           :ok <- check_data_size(acc, conn, opts) do
+    defp receive_responses(conn, ref, opts, acc) do
+      with :ok <- check_data_size(acc, conn, opts) do
         if acc[:done] do
           if opts[:close_conn], do: {:ok, _conn} = close(conn)
           {:ok, acc}
         else
-          receive_responses(conn, ref, opts, acc)
+          with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc) do
+            receive_responses(conn, ref, opts, acc)
+          end
         end
       end
     end
@@ -307,13 +329,15 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
     defp check_data_size(_, _, _), do: :ok
 
-    defp receive_headers_and_status(conn, ref, opts, acc \\ %{}) do
-      with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc) do
-        case acc do
-          %{status: _status, headers: _headers} -> {:ok, conn, acc}
-          # if we don't have status or headers we try to get them in next packet
-          _ -> receive_headers_and_status(conn, ref, opts, acc)
-        end
+    defp receive_headers_and_status(conn, ref, opts, acc) do
+      case acc do
+        %{status: _status, headers: _headers} ->
+          {:ok, conn, acc}
+
+        _ ->
+          with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc) do
+            receive_headers_and_status(conn, ref, opts, acc)
+          end
       end
     end
 
@@ -361,6 +385,116 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp raise_stream_error(error) when Kernel.is_exception(error), do: raise(error)
     defp raise_stream_error(error) when is_binary(error), do: raise(RuntimeError, message: error)
     defp raise_stream_error(error), do: raise(RuntimeError, message: inspect(error))
+
+    defp put_default_content_length_header(headers, body_length) do
+      if has_header?(headers, "content-length") do
+        headers
+      else
+        [{"content-length", Integer.to_string(body_length)} | headers]
+      end
+    end
+
+    defp has_header?(headers, expected_name) do
+      Enum.any?(headers, fn {name, _value} ->
+        String.downcase(name) == expected_name
+      end)
+    end
+
+    defp stream_request_body(conn, ref, chunk, opts, acc) when is_binary(chunk) do
+      stream_request_body_chunk(conn, ref, chunk, opts, acc)
+    end
+
+    defp stream_request_body(conn, ref, chunk, opts, acc)
+         when is_integer(chunk) and chunk >= 0 and chunk <= 255 do
+      stream_request_body_chunk(conn, ref, <<chunk>>, opts, acc)
+    end
+
+    defp stream_request_body(conn, ref, chunk, opts, acc) when is_list(chunk) do
+      chunk
+      |> IO.iodata_to_binary()
+      |> then(&stream_request_body_chunk(conn, ref, &1, opts, acc))
+    end
+
+    defp stream_request_body(conn, ref, chunk, opts, acc) do
+      case HTTP.protocol(conn) do
+        :http2 ->
+          chunk
+          |> IO.iodata_to_binary()
+          |> then(&stream_request_body_chunk(conn, ref, &1, opts, acc))
+
+        _ ->
+          case HTTP.stream_request_body(conn, ref, chunk) do
+            {:ok, conn} -> {:ok, conn, acc}
+            {:error, conn, error} -> close_on_error(conn, error, opts)
+          end
+      end
+    end
+
+    defp stream_request_body_chunk(conn, _ref, "", _opts, acc), do: {:ok, conn, acc}
+
+    defp stream_request_body_chunk(conn, ref, chunk, opts, acc) do
+      case HTTP.protocol(conn) do
+        :http2 ->
+          stream_http2_body_chunk(
+            conn,
+            ref,
+            chunk,
+            opts,
+            acc,
+            min(byte_size(chunk), @http2_request_chunk_size)
+          )
+
+        _ ->
+          case HTTP.stream_request_body(conn, ref, chunk) do
+            {:ok, conn} -> {:ok, conn, acc}
+            {:error, conn, error} -> close_on_error(conn, error, opts)
+          end
+      end
+    end
+
+    defp stream_http2_body_chunk(conn, _ref, "", _opts, acc, _chunk_size), do: {:ok, conn, acc}
+
+    defp stream_http2_body_chunk(conn, ref, chunk, opts, acc, chunk_size) do
+      chunk_size = min(byte_size(chunk), chunk_size)
+      body_chunk = binary_part(chunk, 0, chunk_size)
+      rest = binary_part(chunk, chunk_size, byte_size(chunk) - chunk_size)
+
+      case HTTP.stream_request_body(conn, ref, body_chunk) do
+        {:ok, conn} ->
+          stream_http2_body_chunk(
+            conn,
+            ref,
+            rest,
+            opts,
+            acc,
+            min(byte_size(rest), @http2_request_chunk_size)
+          )
+
+        {:error, conn, %Mint.HTTPError{reason: {:exceeds_window_size, _, 0}}} ->
+          await_request_window(conn, ref, chunk, opts, acc, chunk_size)
+
+        {:error, conn, %Mint.HTTPError{reason: {:exceeds_window_size, _, window_size}}} ->
+          stream_http2_body_chunk(conn, ref, chunk, opts, acc, window_size)
+
+        {:error, conn, error} ->
+          close_on_error(conn, error, opts)
+      end
+    end
+
+    defp close_on_error(conn, error, opts) do
+      if opts[:close_conn], do: {:ok, _conn} = close(conn)
+      {:error, error}
+    end
+
+    defp await_request_window(conn, ref, chunk, opts, acc, chunk_size) do
+      with {:ok, conn, acc} <- receive_packet(conn, ref, opts, acc) do
+        if acc[:done] do
+          {:ok, conn, acc}
+        else
+          stream_http2_body_chunk(conn, ref, chunk, opts, acc, chunk_size)
+        end
+      end
+    end
 
     defp reduce_responses(responses, ref, acc) do
       case Enum.reduce_while(responses, acc, &reduce_response(&1, ref, &2)) do

--- a/test/support/mint_early_response_handler.ex
+++ b/test/support/mint_early_response_handler.ex
@@ -1,0 +1,6 @@
+defmodule Tesla.TestSupport.MintEarlyResponseHandler do
+  def init(req, state) do
+    req = :cowboy_req.reply(200, %{"content-type" => "text/plain"}, "early response", req)
+    {:ok, req, state}
+  end
+end

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -10,6 +10,8 @@ defmodule Tesla.Adapter.MintTest do
   use Tesla.AdapterCase.Multipart
   use Tesla.AdapterCase.StreamRequestBody
 
+  @large_http2_request_size 70_000
+
   use Tesla.AdapterCase.SSL,
     transport_opts: [
       cacertfile: Path.join([to_string(:code.priv_dir(:httparrot)), "/ssl/server-ca.crt"])
@@ -261,6 +263,49 @@ defmodule Tesla.Adapter.MintTest do
 
     test "don't reuse connection if original does not match", %{conn: conn} do
       assert_nonmatching_original_opens_new_conn(conn, mode: :passive)
+    end
+  end
+
+  describe "issue #394 - handle HTTP/2 request flow control" do
+    test "handles request bodies larger than the flow control window" do
+      body = String.duplicate("a", @large_http2_request_size)
+
+      request = %Env{
+        method: :post,
+        url: "#{@https}/post",
+        headers: [{"content-type", "text/plain"}],
+        body: body
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request,
+                 protocols: [:http2],
+                 transport_opts: [cacertfile: httparrot_cacertfile()]
+               )
+
+      assert response.status == 200
+      assert posted_data(response.body) == body
+    end
+
+    test "handles streamed request bodies larger than the flow control window" do
+      body = large_streamed_http2_body()
+      expected = String.duplicate("a", @large_http2_request_size)
+
+      request = %Env{
+        method: :post,
+        url: "#{@https}/post",
+        headers: [{"content-type", "text/plain"}],
+        body: body
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request,
+                 protocols: [:http2],
+                 transport_opts: [cacertfile: httparrot_cacertfile()]
+               )
+
+      assert response.status == 200
+      assert posted_data(response.body) == expected
     end
   end
 
@@ -527,6 +572,29 @@ defmodule Tesla.Adapter.MintTest do
         assert error.module == Mint.HTTP2
       end)
     end
+  end
+
+  defp large_streamed_http2_body do
+    chunks =
+      List.duplicate(String.duplicate("a", 8_192), div(@large_http2_request_size, 8_192))
+
+    chunks =
+      case rem(@large_http2_request_size, 8_192) do
+        0 -> chunks
+        remainder -> chunks ++ [String.duplicate("a", remainder)]
+      end
+
+    Stream.map(chunks, & &1)
+  end
+
+  defp posted_data(body) do
+    body
+    |> Jason.decode!()
+    |> Map.fetch!("data")
+  end
+
+  defp httparrot_cacertfile do
+    Path.join([to_string(:code.priv_dir(:httparrot)), "ssl/server-ca.crt"])
   end
 
   describe "issue #450 - handle missing Mint response types" do

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -267,6 +267,27 @@ defmodule Tesla.Adapter.MintTest do
   end
 
   describe "issue #394 - handle HTTP/2 request flow control" do
+    test "preserves automatic content-length for non-empty HTTP/2 request bodies" do
+      body = "hello"
+
+      request = %Env{
+        method: :post,
+        url: "#{@https}/post",
+        headers: [{"content-type", "text/plain"}],
+        body: body
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request,
+                 protocols: [:http2],
+                 transport_opts: [cacertfile: httparrot_cacertfile()]
+               )
+
+      assert response.status == 200
+      assert posted_data(response.body) == body
+      assert posted_headers(response.body)["content-length"] == Integer.to_string(byte_size(body))
+    end
+
     test "handles request bodies larger than the flow control window" do
       body = String.duplicate("a", @large_http2_request_size)
 
@@ -289,6 +310,27 @@ defmodule Tesla.Adapter.MintTest do
 
     test "handles streamed request bodies larger than the flow control window" do
       body = large_streamed_http2_body()
+      expected = String.duplicate("a", @large_http2_request_size)
+
+      request = %Env{
+        method: :post,
+        url: "#{@https}/post",
+        headers: [{"content-type", "text/plain"}],
+        body: body
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request,
+                 protocols: [:http2],
+                 transport_opts: [cacertfile: httparrot_cacertfile()]
+               )
+
+      assert response.status == 200
+      assert posted_data(response.body) == expected
+    end
+
+    test "handles large iodata request bodies without flattening them up front" do
+      body = large_iodata_http2_body()
       expected = String.duplicate("a", @large_http2_request_size)
 
       request = %Env{
@@ -587,10 +629,30 @@ defmodule Tesla.Adapter.MintTest do
     Stream.map(chunks, & &1)
   end
 
+  defp large_iodata_http2_body do
+    chunks =
+      List.duplicate(String.duplicate("a", 8_192), div(@large_http2_request_size, 8_192))
+
+    case rem(@large_http2_request_size, 8_192) do
+      0 -> [chunks]
+      remainder -> [chunks, [String.duplicate("a", remainder)]]
+    end
+  end
+
   defp posted_data(body) do
     body
-    |> Jason.decode!()
+    |> posted_response()
     |> Map.fetch!("data")
+  end
+
+  defp posted_headers(body) do
+    body
+    |> posted_response()
+    |> Map.fetch!("headers")
+  end
+
+  defp posted_response(body) do
+    Jason.decode!(body)
   end
 
   defp httparrot_cacertfile do

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -288,7 +288,7 @@ defmodule Tesla.Adapter.MintTest do
       assert posted_headers(response.body)["content-length"] == Integer.to_string(byte_size(body))
     end
 
-    test "handles request bodies larger than the flow control window" do
+    test "keeps plain request bodies subject to Mint's HTTP/2 flow control window" do
       body = String.duplicate("a", @large_http2_request_size)
 
       request = %Env{
@@ -298,39 +298,19 @@ defmodule Tesla.Adapter.MintTest do
         body: body
       }
 
-      assert {:ok, %Env{} = response} =
+      assert {:error,
+              %Mint.HTTPError{
+                reason: {:exceeds_window_size, _, _},
+                module: Mint.HTTP2
+              }} =
                call(request,
                  protocols: [:http2],
                  transport_opts: [cacertfile: httparrot_cacertfile()]
                )
-
-      assert response.status == 200
-      assert posted_data(response.body) == body
     end
 
     test "handles streamed request bodies larger than the flow control window" do
       body = large_streamed_http2_body()
-      expected = String.duplicate("a", @large_http2_request_size)
-
-      request = %Env{
-        method: :post,
-        url: "#{@https}/post",
-        headers: [{"content-type", "text/plain"}],
-        body: body
-      }
-
-      assert {:ok, %Env{} = response} =
-               call(request,
-                 protocols: [:http2],
-                 transport_opts: [cacertfile: httparrot_cacertfile()]
-               )
-
-      assert response.status == 200
-      assert posted_data(response.body) == expected
-    end
-
-    test "handles large iodata request bodies without flattening them up front" do
-      body = large_iodata_http2_body()
       expected = String.duplicate("a", @large_http2_request_size)
 
       request = %Env{
@@ -385,7 +365,7 @@ defmodule Tesla.Adapter.MintTest do
         method: :post,
         url: "#{early_response_url}/early-response",
         headers: [{"content-type", "text/plain"}],
-        body: String.duplicate("a", @large_http2_request_size)
+        body: large_streamed_http2_body()
       }
 
       assert {:ok, %Env{} = response} =
@@ -407,7 +387,7 @@ defmodule Tesla.Adapter.MintTest do
         method: :post,
         url: "#{early_response_url}/early-response",
         headers: [{"content-type", "text/plain"}],
-        body: String.duplicate("a", @large_http2_request_size)
+        body: large_streamed_http2_body()
       }
 
       assert {:ok, %Env{} = response} =
@@ -420,6 +400,29 @@ defmodule Tesla.Adapter.MintTest do
 
       assert response.status == 200
       assert %{body: {:fin, "early response"}} = response.body
+    end
+
+    test "returns streamed responses that already finished during upload", %{
+      early_response_url: early_response_url,
+      early_response_cacertfile: early_response_cacertfile
+    } do
+      request = %Env{
+        method: :post,
+        url: "#{early_response_url}/early-response",
+        headers: [{"content-type", "text/plain"}],
+        body: large_streamed_http2_body()
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request,
+                 body_as: :stream,
+                 protocols: [:http2],
+                 timeout: 200,
+                 transport_opts: [cacertfile: early_response_cacertfile]
+               )
+
+      assert response.status == 200
+      assert Enum.join(response.body) == "early response"
     end
   end
 
@@ -699,16 +702,6 @@ defmodule Tesla.Adapter.MintTest do
       end
 
     Stream.map(chunks, & &1)
-  end
-
-  defp large_iodata_http2_body do
-    chunks =
-      List.duplicate(String.duplicate("a", 8_192), div(@large_http2_request_size, 8_192))
-
-    case rem(@large_http2_request_size, 8_192) do
-      0 -> [chunks]
-      remainder -> [chunks, [String.duplicate("a", remainder)]]
-    end
   end
 
   defp posted_data(body) do

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -288,7 +288,7 @@ defmodule Tesla.Adapter.MintTest do
       assert posted_headers(response.body)["content-length"] == Integer.to_string(byte_size(body))
     end
 
-    test "keeps plain request bodies subject to Mint's HTTP/2 flow control window" do
+    test "handles request bodies larger than the flow control window" do
       body = String.duplicate("a", @large_http2_request_size)
 
       request = %Env{
@@ -298,15 +298,14 @@ defmodule Tesla.Adapter.MintTest do
         body: body
       }
 
-      assert {:error,
-              %Mint.HTTPError{
-                reason: {:exceeds_window_size, _, _},
-                module: Mint.HTTP2
-              }} =
+      assert {:ok, %Env{} = response} =
                call(request,
                  protocols: [:http2],
                  transport_opts: [cacertfile: httparrot_cacertfile()]
                )
+
+      assert response.status == 200
+      assert posted_data(response.body) == body
     end
 
     test "handles streamed request bodies larger than the flow control window" do
@@ -365,7 +364,7 @@ defmodule Tesla.Adapter.MintTest do
         method: :post,
         url: "#{early_response_url}/early-response",
         headers: [{"content-type", "text/plain"}],
-        body: large_streamed_http2_body()
+        body: String.duplicate("a", @large_http2_request_size)
       }
 
       assert {:ok, %Env{} = response} =
@@ -387,7 +386,7 @@ defmodule Tesla.Adapter.MintTest do
         method: :post,
         url: "#{early_response_url}/early-response",
         headers: [{"content-type", "text/plain"}],
-        body: large_streamed_http2_body()
+        body: String.duplicate("a", @large_http2_request_size)
       }
 
       assert {:ok, %Env{} = response} =
@@ -410,7 +409,7 @@ defmodule Tesla.Adapter.MintTest do
         method: :post,
         url: "#{early_response_url}/early-response",
         headers: [{"content-type", "text/plain"}],
-        body: large_streamed_http2_body()
+        body: String.duplicate("a", @large_http2_request_size)
       }
 
       assert {:ok, %Env{} = response} =

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -351,6 +351,78 @@ defmodule Tesla.Adapter.MintTest do
     end
   end
 
+  describe "issue #394 - handle early HTTP/2 responses during upload" do
+    setup do
+      listener_ref = :"mint-early-response-#{System.unique_integer([:positive])}"
+      dispatch = early_response_dispatch()
+      priv_dir = :code.priv_dir(:httparrot)
+
+      {:ok, _pid} =
+        :cowboy.start_tls(
+          listener_ref,
+          [
+            port: 0,
+            certfile: priv_dir ++ ~c"/ssl/server.crt",
+            keyfile: priv_dir ++ ~c"/ssl/server.key"
+          ],
+          %{env: %{dispatch: dispatch}}
+        )
+
+      on_exit(fn -> :cowboy.stop_listener(listener_ref) end)
+
+      {_, port} = :ranch.get_addr(listener_ref)
+
+      {:ok,
+       early_response_url: "https://localhost:#{port}",
+       early_response_cacertfile: Path.join([to_string(priv_dir), "ssl/server-ca.crt"])}
+    end
+
+    test "returns the response body without waiting for another packet", %{
+      early_response_url: early_response_url,
+      early_response_cacertfile: early_response_cacertfile
+    } do
+      request = %Env{
+        method: :post,
+        url: "#{early_response_url}/early-response",
+        headers: [{"content-type", "text/plain"}],
+        body: String.duplicate("a", @large_http2_request_size)
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request,
+                 protocols: [:http2],
+                 timeout: 200,
+                 transport_opts: [cacertfile: early_response_cacertfile]
+               )
+
+      assert response.status == 200
+      assert response.body == "early response"
+    end
+
+    test "returns chunked responses that already finished during upload", %{
+      early_response_url: early_response_url,
+      early_response_cacertfile: early_response_cacertfile
+    } do
+      request = %Env{
+        method: :post,
+        url: "#{early_response_url}/early-response",
+        headers: [{"content-type", "text/plain"}],
+        body: String.duplicate("a", @large_http2_request_size)
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request,
+                 body_as: :chunks,
+                 protocols: [:http2],
+                 timeout: 200,
+                 transport_opts: [cacertfile: early_response_cacertfile]
+               )
+
+      assert response.status == 200
+      assert %{body: {:fin, "early response"}} = response.body
+    end
+  end
+
   def read_body(conn, _ref, _opts, {:fin, body}), do: {:ok, conn, body}
 
   def read_body(conn, ref, opts, {:nofin, acc}),
@@ -813,5 +885,11 @@ defmodule Tesla.Adapter.MintTest do
     else
       recv_until_response(conn, match?, timeout, attempts - 1, responses)
     end
+  end
+
+  defp early_response_dispatch do
+    :cowboy_router.compile([
+      {:_, [{"/early-response", Tesla.TestSupport.MintEarlyResponseHandler, []}]}
+    ])
   end
 end

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -11,6 +11,8 @@ defmodule Tesla.Adapter.MintTest do
   use Tesla.AdapterCase.StreamRequestBody
   use Tesla.AdapterCase.Query
 
+  @large_http2_request_size 70_000
+
   use Tesla.AdapterCase.SSL,
     transport_opts: [
       cacertfile: Path.join([to_string(:code.priv_dir(:httparrot)), "/ssl/server-ca.crt"])
@@ -75,6 +77,24 @@ defmodule Tesla.Adapter.MintTest do
     after_count = :erlang.system_info(:atom_count)
 
     assert after_count == before_count
+  end
+
+  test "streamed request that Mint rejects returns a two-tuple error" do
+    request = %Env{
+      method: :post,
+      url: "#{@http}/post",
+      headers: [{"bad header", "value"}],
+      body: Stream.map(["a"], & &1)
+    }
+
+    before_ports = owned_port_count()
+
+    for _ <- 1..20 do
+      assert {:error, %Mint.HTTPError{reason: {:invalid_header_name, "bad header"}}} =
+               call(request, protocols: [:http1])
+    end
+
+    assert owned_port_count() == before_ports
   end
 
   test "certificates_verification" do
@@ -262,6 +282,189 @@ defmodule Tesla.Adapter.MintTest do
 
     test "don't reuse connection if original does not match", %{conn: conn} do
       assert_nonmatching_original_opens_new_conn(conn, mode: :passive)
+    end
+  end
+
+  describe "issue #394 - handle HTTP/2 request flow control" do
+    test "preserves automatic content-length for non-empty HTTP/2 request bodies" do
+      body = "hello"
+
+      request = %Env{
+        method: :post,
+        url: "#{@https}/post",
+        headers: [{"content-type", "text/plain"}],
+        body: body
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request,
+                 protocols: [:http2],
+                 transport_opts: [cacertfile: httparrot_cacertfile()]
+               )
+
+      assert response.status == 200
+      assert posted_data(response.body) == body
+      assert posted_headers(response.body)["content-length"] == Integer.to_string(byte_size(body))
+    end
+
+    test "handles request bodies larger than the flow control window" do
+      body = String.duplicate("a", @large_http2_request_size)
+
+      request = %Env{
+        method: :post,
+        url: "#{@https}/post",
+        headers: [{"content-type", "text/plain"}],
+        body: body
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request,
+                 protocols: [:http2],
+                 transport_opts: [cacertfile: httparrot_cacertfile()]
+               )
+
+      assert response.status == 200
+      assert posted_data(response.body) == body
+    end
+
+    for size <- [65_535, 65_536, 1_000_000] do
+      @flow_control_size size
+
+      test "uploads #{size} bytes across the HTTP/2 flow control window" do
+        body = String.duplicate("a", @flow_control_size)
+
+        request = %Env{
+          method: :post,
+          url: "#{@https}/post",
+          headers: [{"content-type", "text/plain"}],
+          body: body
+        }
+
+        assert {:ok, %Env{} = response} =
+                 call(request,
+                   protocols: [:http2],
+                   transport_opts: [cacertfile: httparrot_cacertfile()]
+                 )
+
+        assert response.status == 200
+        assert byte_size(posted_data(response.body)) == @flow_control_size
+      end
+    end
+
+    test "handles streamed request bodies larger than the flow control window" do
+      body = large_streamed_http2_body()
+      expected = String.duplicate("a", @large_http2_request_size)
+
+      request = %Env{
+        method: :post,
+        url: "#{@https}/post",
+        headers: [{"content-type", "text/plain"}],
+        body: body
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request,
+                 protocols: [:http2],
+                 transport_opts: [cacertfile: httparrot_cacertfile()]
+               )
+
+      assert response.status == 200
+      assert posted_data(response.body) == expected
+    end
+  end
+
+  describe "issue #394 - handle early HTTP/2 responses during upload" do
+    setup do
+      listener_ref = :"mint-early-response-#{System.unique_integer([:positive])}"
+      dispatch = early_response_dispatch()
+      priv_dir = :code.priv_dir(:httparrot)
+
+      {:ok, _pid} =
+        :cowboy.start_tls(
+          listener_ref,
+          [
+            port: 0,
+            certfile: priv_dir ++ ~c"/ssl/server.crt",
+            keyfile: priv_dir ++ ~c"/ssl/server.key"
+          ],
+          %{env: %{dispatch: dispatch}}
+        )
+
+      on_exit(fn -> :cowboy.stop_listener(listener_ref) end)
+
+      {_, port} = :ranch.get_addr(listener_ref)
+
+      {:ok,
+       early_response_url: "https://localhost:#{port}",
+       early_response_cacertfile: Path.join([to_string(priv_dir), "ssl/server-ca.crt"])}
+    end
+
+    test "returns the response body without waiting for another packet", %{
+      early_response_url: early_response_url,
+      early_response_cacertfile: early_response_cacertfile
+    } do
+      request = %Env{
+        method: :post,
+        url: "#{early_response_url}/early-response",
+        headers: [{"content-type", "text/plain"}],
+        body: String.duplicate("a", @large_http2_request_size)
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request,
+                 protocols: [:http2],
+                 timeout: 200,
+                 transport_opts: [cacertfile: early_response_cacertfile]
+               )
+
+      assert response.status == 200
+      assert response.body == "early response"
+    end
+
+    test "returns chunked responses that already finished during upload", %{
+      early_response_url: early_response_url,
+      early_response_cacertfile: early_response_cacertfile
+    } do
+      request = %Env{
+        method: :post,
+        url: "#{early_response_url}/early-response",
+        headers: [{"content-type", "text/plain"}],
+        body: String.duplicate("a", @large_http2_request_size)
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request,
+                 body_as: :chunks,
+                 protocols: [:http2],
+                 timeout: 200,
+                 transport_opts: [cacertfile: early_response_cacertfile]
+               )
+
+      assert response.status == 200
+      assert %{body: {:fin, "early response"}} = response.body
+    end
+
+    test "returns streamed responses that already finished during upload", %{
+      early_response_url: early_response_url,
+      early_response_cacertfile: early_response_cacertfile
+    } do
+      request = %Env{
+        method: :post,
+        url: "#{early_response_url}/early-response",
+        headers: [{"content-type", "text/plain"}],
+        body: String.duplicate("a", @large_http2_request_size)
+      }
+
+      assert {:ok, %Env{} = response} =
+               call(request,
+                 body_as: :stream,
+                 protocols: [:http2],
+                 timeout: 200,
+                 transport_opts: [cacertfile: early_response_cacertfile]
+               )
+
+      assert response.status == 200
+      assert Enum.join(response.body) == "early response"
     end
   end
 
@@ -530,6 +733,39 @@ defmodule Tesla.Adapter.MintTest do
     end
   end
 
+  defp large_streamed_http2_body do
+    chunks =
+      List.duplicate(String.duplicate("a", 8_192), div(@large_http2_request_size, 8_192))
+
+    chunks =
+      case rem(@large_http2_request_size, 8_192) do
+        0 -> chunks
+        remainder -> chunks ++ [String.duplicate("a", remainder)]
+      end
+
+    Stream.map(chunks, & &1)
+  end
+
+  defp posted_data(body) do
+    body
+    |> posted_response()
+    |> Map.fetch!("data")
+  end
+
+  defp posted_headers(body) do
+    body
+    |> posted_response()
+    |> Map.fetch!("headers")
+  end
+
+  defp posted_response(body) do
+    Jason.decode!(body)
+  end
+
+  defp httparrot_cacertfile do
+    Path.join([to_string(:code.priv_dir(:httparrot)), "ssl/server-ca.crt"])
+  end
+
   describe "issue #450 - handle missing Mint response types" do
     setup do
       listener_ref = @push_promise_listener_ref
@@ -684,5 +920,17 @@ defmodule Tesla.Adapter.MintTest do
     else
       recv_until_response(conn, match?, timeout, attempts - 1, responses)
     end
+  end
+
+  defp owned_port_count do
+    Enum.count(:erlang.ports(), fn port ->
+      :erlang.port_info(port, :connected) == {:connected, self()}
+    end)
+  end
+
+  defp early_response_dispatch do
+    :cowboy_router.compile([
+      {:_, [{"/early-response", Tesla.TestSupport.MintEarlyResponseHandler, []}]}
+    ])
   end
 end

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -48,6 +48,17 @@ defmodule Tesla.Adapter.MintTest do
     assert Enum.join(response.body) |> byte_size() == 2245
   end
 
+  test "response body as stream is empty when the response has no body" do
+    request = %Env{
+      method: :get,
+      url: "#{@http}/status/204"
+    }
+
+    assert {:ok, %Env{} = response} = call(request, body_as: :stream)
+    assert response.status == 204
+    assert Enum.to_list(response.body) == []
+  end
+
   test "response body as chunks with closing body with default" do
     request = %Env{
       method: :get,


### PR DESCRIPTION
Closes #394

- Large HTTP/2 uploads currently fail once the request body exceeds Mint's flow-control window, forcing callers to fall back to HTTP/1 as a workaround.
- Streamed HTTP/2 uploads can crash instead of recovering when window updates arrive mid-request.
- A server that answers before the upload finishes should have its response returned, rather than the upload continuing against a closed stream.