### PR TITLE
feat(query): support API-specific query serialization

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -373,7 +373,8 @@ defmodule Tesla do
   @deprecated "Use client/1 or client/2 instead"
   def build_adapter(fun), do: Tesla.Builder.client([], [], fun)
 
-  @type encoding_strategy :: :rfc3986 | :www_form
+  @type query_encoding_fun :: (Tesla.Env.query() -> binary)
+  @type encoding_strategy :: :rfc3986 | :www_form | query_encoding_fun
 
   @doc """
   Builds URL with the given URL and query params.
@@ -381,8 +382,9 @@ defmodule Tesla do
   Useful when you need to create a URL with dynamic query params from a Keyword
   list
 
-  Allows to specify the `encoding` strategy to be one either `:www_form` or
-  `:rfc3986`. Read more about encoding at `URI.encode_query/2`.
+  Allows to specify the `encoding` strategy as either `:www_form`,
+  `:rfc3986`, or a custom function that receives the query params and returns
+  the encoded query string.
 
   - `url` - the base URL to which the query params will be appended.
   - `query` - a list of key-value pairs to be encoded as query params.
@@ -408,11 +410,34 @@ defmodule Tesla do
 
       iex> Tesla.build_url("https://api.example.com", [user_name: "John Smith"], :rfc3986)
       "https://api.example.com?user_name=John%20Smith"
+
+  Custom encoding function:
+
+      Tesla.get(
+        "http://example.com",
+        query: [username: "John Smith"],
+        opts: [query_encoding: &Plug.Conn.Query.encode/1]
+      )
+
+      Tesla.build_url(
+        "https://api.example.com",
+        [filters: [pagination: [page: 2]]],
+        &Plug.Conn.Query.encode/1
+      )
+      #=> "https://api.example.com?filters[pagination][page]=2"
+
+  This keeps query params structured inside Tesla while letting applications
+  delegate serialization to encoders such as `Plug.Conn.Query.encode/1`.
+
+  When query params are passed as maps, the encoded parameter order is
+  unspecified. Pass an ordered list of pairs if the exact query string order
+  matters.
   """
   @spec build_url(Tesla.Env.url(), Tesla.Env.query(), encoding_strategy) :: binary
   def build_url(url, query, encoding \\ :www_form)
 
   def build_url(url, [], _encoding), do: url
+  def build_url(url, query, _encoding) when map_size(query) == 0, do: url
 
   def build_url(url, query, encoding) do
     join = if String.contains?(url, "?"), do: "&", else: "?"
@@ -431,16 +456,24 @@ defmodule Tesla do
     Tesla.build_url(env.url, env.query, query_encoding)
   end
 
-  def encode_query(query, encoding \\ :www_form) do
+  @spec encode_query(Tesla.Env.query(), encoding_strategy) :: binary
+  def encode_query(query, encoding \\ :www_form)
+
+  def encode_query(query, fun) when is_function(fun, 1), do: fun.(query)
+
+  def encode_query(query, encoding) do
     query
     |> Enum.flat_map(&encode_pair/1)
     |> URI.encode_query(encoding)
   end
 
   @doc false
+  def encode_pair({key, value}) when is_map(value) and not is_struct(value),
+    do: encode_nested_pairs(key, value)
+
   def encode_pair({key, value}) when is_list(value) do
     if list_of_tuples?(value) do
-      Enum.flat_map(value, fn {k, v} -> encode_pair({"#{key}[#{k}]", v}) end)
+      encode_nested_pairs(key, value)
     else
       Enum.map(value, fn e -> {"#{key}[]", e} end)
     end
@@ -448,6 +481,16 @@ defmodule Tesla do
 
   @doc false
   def encode_pair({key, value}), do: [{key, value}]
+
+  defp encode_nested_pairs(parent_key, value) do
+    Enum.flat_map(value, &encode_nested_pair(parent_key, &1))
+  end
+
+  defp encode_nested_pair(parent_key, {key, value}) do
+    encode_pair({nested_key(parent_key, key), value})
+  end
+
+  defp nested_key(parent_key, key), do: "#{parent_key}[#{key}]"
 
   defp list_of_tuples?([{k, _} | rest]) when is_atom(k) or is_binary(k), do: list_of_tuples?(rest)
   defp list_of_tuples?([]), do: true

--- a/lib/tesla/builder.ex
+++ b/lib/tesla/builder.ex
@@ -51,7 +51,7 @@ defmodule Tesla.Builder do
 
         - `:method` - the request method, one of [`:head`, `:get`, `:delete`, `:trace`, `:options`, `:post`, `:put`, `:patch`]
         - `:url` - either full url e.g. "http://example.com/some/path" or just "/some/path" if using `Tesla.Middleware.BaseUrl`
-        - `:query` - a keyword list of query params, e.g. `[page: 1, per_page: 100]`
+        - `:query` - a keyword list or nested map of query params, e.g. `[page: 1, per_page: 100]`
         - `:headers` - a keyword list of headers, e.g. `[{"content-type", "text/plain"}]`
         - `:body` - depends on used middleware:
             - by default it can be a binary
@@ -62,6 +62,8 @@ defmodule Tesla.Builder do
         ## Examples
 
             ExampleApi.request(method: :get, url: "/users/path")
+
+            ExampleApi.get("/users", query: [username: "John Smith"], opts: [query_encoding: &Plug.Conn.Query.encode/1])
 
             # use shortcut methods
             ExampleApi.get("/users/1")

--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -6,8 +6,7 @@ defmodule Tesla.Env do
 
   - `:method` - method of request. Example: `:get`
   - `:url` - request url. Example: `"https://www.google.com"`
-  - `:query` - list of query params.
-    Example: `[{"param", "value"}]` will be translated to `?params=value`.
+  - `:query` - structured query params. See `t:query/0`.
     Note: query params passed in url (e.g. `"/get?param=value"`) are not parsed to `query` field.
   - `:headers` - list of request/response headers.
     Example: `[{"content-type", "application/json"}]`.
@@ -27,8 +26,26 @@ defmodule Tesla.Env do
   @type client :: Tesla.Client.t()
   @type method :: :head | :get | :delete | :trace | :options | :post | :put | :patch
   @type url :: binary
-  @type param :: binary | [{binary | atom, param}]
-  @type query :: [{binary | atom, param}]
+  @type query_key :: binary | atom
+  @type query_scalar :: String.Chars.t()
+  @type query_scalar_list :: [query_scalar]
+  @type query_pair :: {query_key, param}
+  @type query_list :: [query_pair]
+  @type param :: query_scalar | query_scalar_list | query_list | %{optional(query_key) => param}
+
+  @typedoc """
+  Structured query params as a list or map, including nested maps.
+
+  ## Examples
+
+  - `[{"param", "value"}]` will be translated to `?param=value`.
+  - `%{filters: %{page: 1}}` will be translated to `?filters%5Bpage%5D=1`
+    (that is, `filters[page]` with brackets percent-encoded by default).
+
+  Map query params do not guarantee encoded parameter order. Pass an ordered list
+  of pairs if the exact query string order matters.
+  """
+  @type query :: [query_pair] | %{optional(query_key) => param}
   @type headers :: [{binary, binary}]
 
   @type body :: any

--- a/lib/tesla/middleware/logger.ex
+++ b/lib/tesla/middleware/logger.ex
@@ -434,6 +434,7 @@ defmodule Tesla.Middleware.Logger do
   end
 
   defp debug_query([]), do: @debug_no_query
+  defp debug_query(query) when map_size(query) == 0, do: @debug_no_query
 
   defp debug_query(query) do
     query

--- a/lib/tesla/middleware/query.ex
+++ b/lib/tesla/middleware/query.ex
@@ -27,6 +27,17 @@ defmodule Tesla.Middleware.Query do
   defp merge(env, nil), do: env
 
   defp merge(env, query) do
-    Map.update!(env, :query, &(&1 ++ query))
+    Map.update!(env, :query, &merge_query_params(&1, query))
   end
+
+  defp merge_query_params(existing, query) when is_map(existing) and is_map(query) do
+    Map.merge(query, existing)
+  end
+
+  defp merge_query_params(existing, query) do
+    to_query_list(existing) ++ to_query_list(query)
+  end
+
+  defp to_query_list(query) when is_map(query), do: Map.to_list(query)
+  defp to_query_list(query), do: List.wrap(query)
 end

--- a/test/support/test_support.ex
+++ b/test/support/test_support.ex
@@ -1,4 +1,6 @@
 defmodule TestSupport do
+  def custom_query_encoder(query), do: URI.encode_query(query)
+
   def gzip_headers(env) do
     env.headers
     |> Enum.map_join("|", fn {key, value} -> "#{key}: #{value}" end)

--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -75,6 +75,28 @@ defmodule Tesla.Middleware.LoggerTest do
 
       assert log =~ "test=foo%20bar"
     end
+
+    test "encodes nested maps" do
+      log =
+        capture_log(fn ->
+          Client.get("/ok", query: %{filters: %{name: "foo", pagination: %{page: 2}}})
+        end)
+
+      assert log =~ "filters%5Bname%5D=foo"
+      assert log =~ "filters%5Bpagination%5D%5Bpage%5D=2"
+    end
+
+    test "encodes with custom function" do
+      log =
+        capture_log(fn ->
+          Client.get("/ok",
+            query: [user_name: "John Smith"],
+            opts: [query_encoding: &TestSupport.custom_query_encoder/1]
+          )
+        end)
+
+      assert log =~ "user_name=John+Smith"
+    end
   end
 
   describe "Debug mode" do
@@ -88,10 +110,27 @@ defmodule Tesla.Middleware.LoggerTest do
       assert log =~ "Query: test: true"
     end
 
+    test "ok with empty map params" do
+      log = capture_log(fn -> Client.get("/ok", query: %{}) end)
+      assert log =~ "(no query)"
+    end
+
     test "ok with list params" do
       log = capture_log(fn -> Client.get("/ok", query: %{"test" => ["first", "second"]}) end)
       assert log =~ "Query: test[]: first"
       assert log =~ "Query: test[]: second"
+    end
+
+    test "ok with nested map params" do
+      log =
+        capture_log(fn ->
+          Client.get("/ok",
+            query: %{"filters" => %{"name" => "foo", "pagination" => %{"page" => 2}}}
+          )
+        end)
+
+      assert log =~ "Query: filters[name]: foo"
+      assert log =~ "Query: filters[pagination][page]: 2"
     end
 
     test "multipart" do

--- a/test/tesla/middleware/query_test.exs
+++ b/test/tesla/middleware/query_test.exs
@@ -13,4 +13,32 @@ defmodule Tesla.Middleware.QueryTest do
     assert {:ok, env} = @middleware.call(%Env{query: [page: 1]}, [], page: 5)
     assert env.query == [page: 1, page: 5]
   end
+
+  test "merges query maps without overriding existing keys" do
+    assert {:ok, env} =
+             @middleware.call(%Env{query: %{page: 1, filters: %{name: "foo"}}}, [], %{
+               page: 5,
+               per_page: 10
+             })
+
+    assert env.query == %{page: 1, per_page: 10, filters: %{name: "foo"}}
+  end
+
+  test "merges existing map query with list defaults without crashing" do
+    assert {:ok, env} = @middleware.call(%Env{query: %{page: 1}}, [], per_page: 10)
+    assert env.query == [page: 1, per_page: 10]
+  end
+
+  test "merges map query with list defaults without losing params" do
+    assert {:ok, env} =
+             @middleware.call(%Env{url: "http://example.com", query: %{b: 2, a: 1}}, [], c: 3)
+
+    assert URI.decode_query(Tesla.build_url(env) |> URI.parse() |> Map.fetch!(:query)) ==
+             %{"a" => "1", "b" => "2", "c" => "3"}
+  end
+
+  test "merges existing list query with map defaults without crashing" do
+    assert {:ok, env} = @middleware.call(%Env{query: [page: 1]}, [], %{per_page: 10})
+    assert env.query == [page: 1, per_page: 10]
+  end
 end

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -305,6 +305,47 @@ defmodule TeslaTest do
                @api_url <> "?nested%5Bmore_nested%5D%5Bargument%5D=1"
     end
 
+    test "returns URL with query params from nested map" do
+      query_params = %{filters: %{direction: "asc", name: "dave", pagination: %{page: 1}}}
+
+      assert URI.decode_query(
+               build_url(@api_url, query_params)
+               |> URI.parse()
+               |> Map.fetch!(:query)
+             ) ==
+               %{
+                 "filters[direction]" => "asc",
+                 "filters[name]" => "dave",
+                 "filters[pagination][page]" => "1"
+               }
+    end
+
+    test "returns URL with query params from map" do
+      query_params = %{b: 2, a: 1}
+
+      assert URI.decode_query(
+               build_url(@api_url, query_params)
+               |> URI.parse()
+               |> Map.fetch!(:query)
+             ) ==
+               %{"a" => "1", "b" => "2"}
+    end
+
+    test "returns URL with query params from nested maps" do
+      query_params = %{filters: %{b: 2, a: 1}}
+
+      assert URI.decode_query(
+               build_url(@api_url, query_params)
+               |> URI.parse()
+               |> Map.fetch!(:query)
+             ) ==
+               %{"filters[a]" => "1", "filters[b]" => "2"}
+    end
+
+    test "treats structs as scalar query values" do
+      assert build_url(@api_url, on: ~D[2026-04-21]) == @api_url <> "?on=2026-04-21"
+    end
+
     test "returns URL with new query params concated from keyword list" do
       url_with_param = @api_url <> "?user=4"
       query_params = [page: 2, status: true]
@@ -313,6 +354,14 @@ defmodule TeslaTest do
 
     test "returns normal URL when query list is empty" do
       assert build_url(@api_url, []) == @api_url
+    end
+
+    test "returns normal URL when query map is empty" do
+      assert build_url(@api_url, %{}) == @api_url
+    end
+
+    test "does not append separator when empty query map is used with existing query params" do
+      assert build_url(@api_url <> "?user=4", %{}) == @api_url <> "?user=4"
     end
 
     test "returns error when passing wrong params" do
@@ -341,12 +390,37 @@ defmodule TeslaTest do
       query_params = [name: "foo bar", page: 2]
       assert build_url(@api_url, query_params, :www_form) == build_url(@api_url, query_params)
     end
+
+    test "encoding with custom function" do
+      query_params = [name: "foo bar", page: 2]
+
+      assert build_url(@api_url, query_params, &TestSupport.custom_query_encoder/1) ==
+               @api_url <> "?name=foo+bar&page=2"
+    end
   end
 
   describe "build_url/1" do
     test "returns URL with query params from Tesla.Env struct" do
       env = %Tesla.Env{url: @api_url, query: [user: 3, page: 2]}
       assert Tesla.build_url(env) == @api_url <> "?user=3&page=2"
+    end
+
+    test "returns URL with query params from Tesla.Env struct using nested map" do
+      env = %Tesla.Env{url: @api_url, query: %{filters: %{pagination: %{page: 1}}}}
+
+      assert URI.decode_query(Tesla.build_url(env) |> URI.parse() |> Map.fetch!(:query)) ==
+               %{"filters[pagination][page]" => "1"}
+    end
+
+    test "returns URL with query params from Tesla.Env struct using custom encoding function" do
+      env =
+        %Tesla.Env{
+          url: @api_url,
+          query: [user_name: "John Smith"],
+          opts: [query_encoding: &TestSupport.custom_query_encoder/1]
+        }
+
+      assert Tesla.build_url(env) == @api_url <> "?user_name=John+Smith"
     end
   end
 end


### PR DESCRIPTION
- keeps query parameters as structured data so middleware and logging can still reason about them
- lets callers use API-specific serializers without forcing Tesla to depend on Plug
- closes #538 by covering nested maps and caller-provided query encoding in the request path