### PR TITLE
docs(env): define URL input ownership

### DIFF
--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -25,6 +25,18 @@ defmodule Tesla.Env do
 
   @type client :: Tesla.Client.t()
   @type method :: :head | :get | :delete | :trace | :options | :post | :put | :patch
+
+  @typedoc """
+  Request URL or request target.
+
+  Examples:
+
+  - `"https://www.google.com"`
+  - `"/users/1"` when used with `Tesla.Middleware.BaseUrl`
+
+  Callers are expected to pass a valid, already-encoded value.
+  Tesla leaves the URL untouched and does not validate or normalize malformed input.
+  """
   @type url :: binary
   @type query_key :: binary | atom
   @type query_scalar :: String.Chars.t()

--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -34,8 +34,9 @@ defmodule Tesla.Env do
   - `"https://www.google.com"`
   - `"/users/1"` when used with `Tesla.Middleware.BaseUrl`
 
-  Callers are expected to pass a valid, already-encoded value.
-  Tesla leaves the URL untouched and does not validate or normalize malformed input.
+  Callers are expected to pass a valid, already-encoded URL or request target.
+  Tesla does not automatically validate, normalize, or percent-encode the URL path.
+  Some middleware may rewrite `env.url`.
   """
   @type url :: binary
   @type query_key :: binary | atom

--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -35,7 +35,7 @@ defmodule Tesla.Env do
   - `"/users/1"` when used with `Tesla.Middleware.BaseUrl`
 
   Callers are expected to pass a valid, already-encoded URL or request target.
-  Tesla does not automatically validate, normalize, or percent-encode the URL path.
+  `Tesla` does not automatically validate, normalize, or percent-encode the URL path.
   Some middleware may rewrite `env.url`.
   """
   @type url :: binary


### PR DESCRIPTION
- make the URL contract explicit for callers discussing malformed request targets in #798
- keep encoding, validation, and normalization decisions with applications instead of baking adapter-specific semantics into Tesla