### PR TITLE
fix(mint): avoid crashes on HTTP/2 request resets

### DIFF
--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -262,6 +262,9 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
                   {:ok, conn, _} ->
                     {[], %{conn: conn}}
+
+                  {:error, error} ->
+                    raise_stream_error(error)
                 end
             end,
             fn %{conn: conn} -> if opts[:close_conn], do: {:ok, _conn} = close(conn) end
@@ -312,7 +315,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
     defp receive_packet(conn, ref, opts, acc \\ %{}) do
       with {:ok, conn, responses} <- receive_message(conn, opts),
-           acc <- reduce_responses(responses, ref, acc) do
+           {:ok, acc} <- reduce_responses(responses, ref, acc) do
         {:ok, conn, acc}
       else
         {:error, error} ->
@@ -346,23 +349,43 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp receive_message(conn, %{mode: :passive} = opts),
       do: HTTP.recv(conn, 0, opts[:timeout])
 
+    defp raise_stream_error(error) when Kernel.is_exception(error), do: raise(error)
+    defp raise_stream_error(error) when is_binary(error), do: raise(RuntimeError, message: error)
+    defp raise_stream_error(error), do: raise(RuntimeError, message: inspect(error))
+
     defp reduce_responses(responses, ref, acc) do
-      Enum.reduce(responses, acc, fn
-        {:status, ^ref, code}, acc ->
-          Map.put(acc, :status, code)
-
-        {:headers, ^ref, headers}, acc ->
-          Map.update(acc, :headers, headers, &(&1 ++ headers))
-
-        {:data, ^ref, data}, acc ->
-          Map.update(acc, :data, data, &(&1 <> data))
-
-        {:done, ^ref}, acc ->
-          Map.put(acc, :done, true)
-
-        {:push_promise, ^ref, _promised_ref, _headers}, acc ->
-          acc
-      end)
+      case Enum.reduce_while(responses, acc, &reduce_response(&1, ref, &2)) do
+        {:error, _} = error -> error
+        acc -> {:ok, acc}
+      end
     end
+
+    defp reduce_response({:status, response_ref, code}, ref, acc) when response_ref == ref,
+      do: {:cont, Map.put(acc, :status, code)}
+
+    defp reduce_response({:headers, response_ref, headers}, ref, acc) when response_ref == ref,
+      do: {:cont, Map.update(acc, :headers, headers, &(&1 ++ headers))}
+
+    defp reduce_response({:data, response_ref, data}, ref, acc) when response_ref == ref,
+      do: {:cont, Map.update(acc, :data, data, &(&1 <> data))}
+
+    defp reduce_response({:done, response_ref}, ref, acc) when response_ref == ref,
+      do: {:cont, Map.put(acc, :done, true)}
+
+    defp reduce_response({:error, response_ref, error}, ref, _acc) when response_ref == ref,
+      do: {:halt, {:error, error}}
+
+    defp reduce_response({:pong, response_ref}, ref, acc) when response_ref == ref,
+      do: {:cont, acc}
+
+    defp reduce_response({:status, _other_ref, _code}, _ref, acc), do: {:cont, acc}
+    defp reduce_response({:headers, _other_ref, _headers}, _ref, acc), do: {:cont, acc}
+    defp reduce_response({:data, _other_ref, _data}, _ref, acc), do: {:cont, acc}
+    defp reduce_response({:done, _other_ref}, _ref, acc), do: {:cont, acc}
+    defp reduce_response({:error, _other_ref, _error}, _ref, acc), do: {:cont, acc}
+    defp reduce_response({:pong, _other_ref}, _ref, acc), do: {:cont, acc}
+
+    defp reduce_response({:push_promise, _parent_ref, _promised_ref, _headers}, _ref, acc),
+      do: {:cont, acc}
   end
 end

--- a/test/support/mint_internal_error_handlers.ex
+++ b/test/support/mint_internal_error_handlers.ex
@@ -1,0 +1,45 @@
+defmodule Tesla.TestSupport.MintInternalErrorRequestHandler do
+  def init(req, state) do
+    receive do
+    after
+      50 -> {:ok, req, state}
+    end
+  end
+end
+
+defmodule Tesla.TestSupport.MintInternalErrorAfterHeadersRequestHandler do
+  def init(req, _state) do
+    :cowboy_req.stream_reply(200, %{"content-type" => "text/plain"}, req)
+    raise "issue 553 after headers"
+  end
+end
+
+defmodule Tesla.TestSupport.MintInternalErrorStreamHandler do
+  @behaviour :cowboy_stream
+
+  def init(stream_id, req, opts) do
+    {commands, state} = :cowboy_stream.init(stream_id, req, opts)
+
+    if :cowboy_req.path(req) == "/stream-reset" do
+      {commands ++ [{:internal_error, :issue_553, ~c"Issue 553 reproduction"}], state}
+    else
+      {commands, state}
+    end
+  end
+
+  def data(stream_id, is_fin, data, state) do
+    :cowboy_stream.data(stream_id, is_fin, data, state)
+  end
+
+  def info(stream_id, info, state) do
+    :cowboy_stream.info(stream_id, info, state)
+  end
+
+  def terminate(stream_id, reason, state) do
+    :cowboy_stream.terminate(stream_id, reason, state)
+  end
+
+  def early_error(stream_id, reason, partial_req, resp, opts) do
+    :cowboy_stream.early_error(stream_id, reason, partial_req, resp, opts)
+  end
+end

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -1,5 +1,9 @@
 defmodule Tesla.Adapter.MintTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
+
+  @internal_error_listener_ref :"mint-internal-error"
+  @push_promise_listener_ref :"mint-push-promise"
 
   use Tesla.AdapterCase, adapter: Tesla.Adapter.Mint
   use Tesla.AdapterCase.Basic
@@ -371,9 +375,150 @@ defmodule Tesla.Adapter.MintTest do
     Keyword.merge([conn: conn, original: original, close_conn: false], opts)
   end
 
+  describe "issue #553 - prove real HTTP/2 request resets" do
+    setup do
+      listener_ref = @internal_error_listener_ref
+      dispatch = internal_error_dispatch()
+      priv_dir = :code.priv_dir(:httparrot)
+
+      {:ok, _pid} =
+        :cowboy.start_tls(
+          listener_ref,
+          [
+            port: 0,
+            certfile: priv_dir ++ ~c"/ssl/server.crt",
+            keyfile: priv_dir ++ ~c"/ssl/server.key"
+          ],
+          %{
+            env: %{dispatch: dispatch},
+            stream_handlers: [Tesla.TestSupport.MintInternalErrorStreamHandler, :cowboy_stream_h]
+          }
+        )
+
+      on_exit(fn -> :cowboy.stop_listener(listener_ref) end)
+
+      {_, port} = :ranch.get_addr(listener_ref)
+
+      {:ok,
+       reset_url: "https://localhost:#{port}",
+       reset_cacertfile: Path.join([to_string(priv_dir), "ssl/server-ca.crt"])}
+    end
+
+    test "Mint emits server_closed_request from a live HTTP/2 peer", %{
+      reset_url: reset_url,
+      reset_cacertfile: reset_cacertfile
+    } do
+      uri = URI.parse(reset_url)
+
+      assert {:ok, conn} =
+               Mint.HTTP.connect(:https, uri.host, uri.port,
+                 mode: :passive,
+                 protocols: [:http2],
+                 transport_opts: [cacertfile: reset_cacertfile]
+               )
+
+      assert {:ok, conn, ref} = Mint.HTTP.request(conn, "GET", "/stream-reset", [], nil)
+
+      {conn, responses} = recv_until_response(conn, &match?({:error, ^ref, _}, &1))
+
+      assert {:error, ^ref,
+              %Mint.HTTPError{
+                reason: {:server_closed_request, :internal_error},
+                module: Mint.HTTP2
+              }} =
+               Enum.find(responses, &match?({:error, ^ref, _}, &1))
+
+      assert {:ok, _conn} = Mint.HTTP.close(conn)
+    end
+
+    test "Mint emits status and headers before a mid-stream HTTP/2 reset", %{
+      reset_url: reset_url,
+      reset_cacertfile: reset_cacertfile
+    } do
+      capture_log(fn ->
+        uri = URI.parse(reset_url)
+
+        assert {:ok, conn} =
+                 Mint.HTTP.connect(:https, uri.host, uri.port,
+                   mode: :passive,
+                   protocols: [:http2],
+                   transport_opts: [cacertfile: reset_cacertfile]
+                 )
+
+        assert {:ok, conn, ref} =
+                 Mint.HTTP.request(conn, "GET", "/stream-reset-after-headers", [], nil)
+
+        {conn, responses} = recv_until_response(conn, &match?({:error, ^ref, _}, &1))
+
+        assert {:status, ^ref, 200} = Enum.find(responses, &match?({:status, ^ref, _}, &1))
+
+        assert {:headers, ^ref, _headers} =
+                 Enum.find(responses, &match?({:headers, ^ref, _}, &1))
+
+        assert {:error, ^ref,
+                %Mint.HTTPError{
+                  reason: {:server_closed_request, :internal_error},
+                  module: Mint.HTTP2
+                }} =
+                 Enum.find(responses, &match?({:error, ^ref, _}, &1))
+
+        assert {:ok, _conn} = Mint.HTTP.close(conn)
+      end)
+    end
+
+    test "Tesla adapter returns the Mint request error instead of crashing", %{
+      reset_url: reset_url,
+      reset_cacertfile: reset_cacertfile
+    } do
+      request = %Env{
+        method: :get,
+        url: "#{reset_url}/stream-reset"
+      }
+
+      assert {:error,
+              %Mint.HTTPError{
+                reason: {:server_closed_request, :internal_error},
+                module: Mint.HTTP2
+              }} =
+               call(request,
+                 protocols: [:http2],
+                 transport_opts: [cacertfile: reset_cacertfile]
+               )
+    end
+
+    test "Tesla adapter raises the Mint request error while enumerating stream bodies", %{
+      reset_url: reset_url,
+      reset_cacertfile: reset_cacertfile
+    } do
+      capture_log(fn ->
+        request = %Env{
+          method: :get,
+          url: "#{reset_url}/stream-reset-after-headers"
+        }
+
+        assert {:ok, %Env{} = response} =
+                 call(request,
+                   body_as: :stream,
+                   protocols: [:http2],
+                   transport_opts: [cacertfile: reset_cacertfile]
+                 )
+
+        assert response.status == 200
+
+        error =
+          assert_raise Mint.HTTPError, fn ->
+            Enum.to_list(response.body)
+          end
+
+        assert error.reason == {:server_closed_request, :internal_error}
+        assert error.module == Mint.HTTP2
+      end)
+    end
+  end
+
   describe "issue #450 - handle missing Mint response types" do
     setup do
-      listener_ref = :"mint-push-promise-#{System.unique_integer([:positive])}"
+      listener_ref = @push_promise_listener_ref
       dispatch = push_promise_dispatch()
       priv_dir = :code.priv_dir(:httparrot)
 
@@ -440,6 +585,34 @@ defmodule Tesla.Adapter.MintTest do
       assert byte_size(data) > 0
     end
 
+    test "handles pushed stream responses from a real HTTP/2 server", %{
+      push_url: push_url,
+      push_cacertfile: push_cacertfile
+    } do
+      %{host: host, port: port} = URI.parse(push_url)
+
+      assert {:ok, conn} =
+               Mint.HTTP.connect(:https, host, port,
+                 mode: :passive,
+                 transport_opts: [cacertfile: push_cacertfile],
+                 protocols: [:http2]
+               )
+
+      assert {:ok, conn, ref} = Mint.HTTP.request(conn, "GET", "/index.html", [], nil)
+
+      {conn, responses} =
+        recv_until_response(conn, &match?({:push_promise, ^ref, _, _}, &1))
+
+      assert {:push_promise, ^ref, promised_ref, _headers} =
+               Enum.find(responses, &match?({:push_promise, ^ref, _, _}, &1))
+
+      {_conn, responses} =
+        recv_until_response(conn, &match?({:done, ^promised_ref}, &1), 100, 10, responses)
+
+      assert Enum.any?(responses, &match?({:status, ^promised_ref, 200}, &1))
+      assert Enum.any?(responses, &match?({:data, ^promised_ref, _}, &1))
+    end
+
     test "handles push_promise responses from a real HTTP/2 server", %{
       push_url: push_url,
       push_cacertfile: push_cacertfile
@@ -468,5 +641,34 @@ defmodule Tesla.Adapter.MintTest do
          {"/style.css", Tesla.TestSupport.MintPushPromiseStyleHandler, []}
        ]}
     ])
+  end
+
+  defp internal_error_dispatch do
+    :cowboy_router.compile([
+      {:_,
+       [
+         {"/stream-reset", Tesla.TestSupport.MintInternalErrorRequestHandler, []},
+         {"/stream-reset-after-headers",
+          Tesla.TestSupport.MintInternalErrorAfterHeadersRequestHandler, []}
+       ]}
+    ])
+  end
+
+  defp recv_until_response(conn, match?, timeout \\ 100, attempts \\ 10, responses \\ [])
+
+  defp recv_until_response(_conn, _match?, _timeout, 0, responses) do
+    flunk("expected Mint to emit a matching response, got: #{inspect(responses)}")
+  end
+
+  defp recv_until_response(conn, match?, timeout, attempts, responses) do
+    assert {:ok, conn, new_responses} = Mint.HTTP.recv(conn, 0, timeout)
+
+    responses = responses ++ new_responses
+
+    if Enum.any?(responses, match?) do
+      {conn, responses}
+    else
+      recv_until_response(conn, match?, timeout, attempts - 1, responses)
+    end
   end
 end


### PR DESCRIPTION
- closes #553 by anchoring the change to the live HTTP/2 request-reset behavior that originally crashed the Mint adapter
- preserve Mint's request-scoped error for callers instead of turning that response into a `FunctionClauseError` inside the adapter
- keep the regression proof at the transport level so future changes stay pinned to the reported failure mode