### PR TITLE
fix(gun): keep timeout-wrapped streams readable

### DIFF
--- a/lib/tesla/adapter/gun.ex
+++ b/lib/tesla/adapter/gun.ex
@@ -187,7 +187,7 @@ if Code.ensure_loaded?(:gun) do
           opts
         )
         |> Enum.into(%{})
-        |> maybe_put_gun_reply_to(env.private[:tesla_gun_reply_to])
+        |> maybe_put_gun_stream_owner(env.private[:tesla_gun_stream_owner])
 
       request(
         Tesla.Adapter.Shared.format_method(env.method),
@@ -198,10 +198,10 @@ if Code.ensure_loaded?(:gun) do
       )
     end
 
-    defp maybe_put_gun_reply_to(opts, reply_to) when is_pid(reply_to),
-      do: Map.put_new(opts, :tesla_gun_reply_to, reply_to)
+    defp maybe_put_gun_stream_owner(opts, stream_owner) when is_pid(stream_owner),
+      do: Map.put_new(opts, :tesla_gun_stream_owner, stream_owner)
 
-    defp maybe_put_gun_reply_to(opts, _reply_to), do: opts
+    defp maybe_put_gun_stream_owner(opts, _stream_owner), do: opts
 
     defp request(method, url, headers, %Stream{} = body, opts),
       do: do_request(method, url, headers, body, Map.put(opts, :send_body, :stream))
@@ -447,27 +447,64 @@ if Code.ensure_loaded?(:gun) do
       open_stream(pid, method, path, headers, body, req_opts, opts[:send_body])
     end
 
-    defp reply_to(%{body_as: body_as} = opts) when body_as in [:stream, :chunks] do
+    defp reply_to(%{body_as: body_as, tesla_gun_stream_owner: stream_owner} = opts)
+         when body_as in [:stream, :chunks] and is_pid(stream_owner) do
       request_owner = self()
-      stream_owner = opts[:reply_to] || opts[:tesla_gun_reply_to] || request_owner
+      original_reply_to = opts[:reply_to] || request_owner
 
       if stream_owner == request_owner do
-        request_owner
+        original_reply_to
       else
         fn
           {:gun_data, _pid, _stream, _is_fin, _data} = message ->
-            send(stream_owner, message)
+            send(request_owner, message)
+            notify_reply_to(original_reply_to, request_owner, message)
+            notify_stream_owner(stream_owner, request_owner, original_reply_to, message)
 
           {:gun_error, _pid, _stream, _reason} = message ->
-            send(stream_owner, message)
+            send(request_owner, message)
+            notify_reply_to(original_reply_to, request_owner, message)
+            notify_stream_owner(stream_owner, request_owner, original_reply_to, message)
 
           message ->
             send(request_owner, message)
+            notify_reply_to(original_reply_to, request_owner, message)
         end
       end
     end
 
-    defp reply_to(_opts), do: self()
+    defp reply_to(opts), do: opts[:reply_to] || self()
+
+    defp notify_reply_to(reply_to, request_owner, _message)
+         when is_pid(reply_to) and reply_to == request_owner,
+         do: :ok
+
+    defp notify_reply_to(reply_to, _request_owner, message) when is_pid(reply_to) do
+      send(reply_to, message)
+    end
+
+    defp notify_reply_to({module, function, args}, _request_owner, message)
+         when is_atom(module) and is_atom(function) and is_list(args) do
+      apply(module, function, [message | args])
+    end
+
+    defp notify_reply_to({function, args}, _request_owner, message)
+         when is_list(args) and is_function(function, length(args) + 1) do
+      apply(function, [message | args])
+    end
+
+    defp notify_reply_to(function, _request_owner, message) when is_function(function, 1) do
+      function.(message)
+    end
+
+    defp notify_stream_owner(stream_owner, request_owner, reply_to, _message)
+         when stream_owner == request_owner or
+                (is_pid(reply_to) and stream_owner == reply_to),
+         do: :ok
+
+    defp notify_stream_owner(stream_owner, _request_owner, _reply_to, message) do
+      send(stream_owner, message)
+    end
 
     defp open_stream(pid, method, path, headers, body, req_opts, :stream) do
       stream = perform_stream_request(pid, method, path, headers, req_opts)

--- a/lib/tesla/adapter/gun.ex
+++ b/lib/tesla/adapter/gun.ex
@@ -455,25 +455,116 @@ if Code.ensure_loaded?(:gun) do
       if stream_owner == request_owner do
         original_reply_to
       else
-        fn
-          {:gun_data, _pid, _stream, _is_fin, _data} = message ->
-            send(request_owner, message)
-            notify_reply_to(original_reply_to, request_owner, message)
-            notify_stream_owner(stream_owner, request_owner, original_reply_to, message)
-
-          {:gun_error, _pid, _stream, _reason} = message ->
-            send(request_owner, message)
-            notify_reply_to(original_reply_to, request_owner, message)
-            notify_stream_owner(stream_owner, request_owner, original_reply_to, message)
-
-          message ->
-            send(request_owner, message)
-            notify_reply_to(original_reply_to, request_owner, message)
-        end
+        wrap_reply_to(request_owner, stream_owner, original_reply_to)
       end
     end
 
     defp reply_to(opts), do: opts[:reply_to] || self()
+
+    if Application.spec(:gun, :vsn) |> List.to_string() |> Version.match?("~> 2.0") do
+      defp wrap_reply_to(request_owner, stream_owner, original_reply_to) do
+        fn message ->
+          route_reply_message(request_owner, stream_owner, original_reply_to, message)
+        end
+      end
+    else
+      defp wrap_reply_to(request_owner, stream_owner, original_reply_to) do
+        spawn(fn ->
+          request_owner_ref = Process.monitor(request_owner)
+
+          stream_owner_ref =
+            if stream_owner == request_owner, do: nil, else: Process.monitor(stream_owner)
+
+          reply_router(
+            request_owner,
+            request_owner_ref,
+            stream_owner,
+            stream_owner_ref,
+            original_reply_to,
+            :waiting_response
+          )
+        end)
+      end
+
+      defp reply_router(
+             request_owner,
+             request_owner_ref,
+             stream_owner,
+             stream_owner_ref,
+             original_reply_to,
+             state
+           ) do
+        receive do
+          {:DOWN, ^request_owner_ref, :process, ^request_owner, _reason} ->
+            if state == :waiting_response do
+              :ok
+            else
+              reply_router(
+                request_owner,
+                request_owner_ref,
+                stream_owner,
+                stream_owner_ref,
+                original_reply_to,
+                state
+              )
+            end
+
+          {:DOWN, ^stream_owner_ref, :process, ^stream_owner, _reason} ->
+            :ok
+
+          message ->
+            route_reply_message(request_owner, stream_owner, original_reply_to, message)
+
+            unless terminal_reply_message?(message) do
+              reply_router(
+                request_owner,
+                request_owner_ref,
+                stream_owner,
+                stream_owner_ref,
+                original_reply_to,
+                next_reply_state(state, message)
+              )
+            end
+        end
+      end
+    end
+
+    defp route_reply_message(request_owner, stream_owner, original_reply_to, message) do
+      case message do
+        {:gun_data, _pid, _stream, _is_fin, _data} ->
+          send(request_owner, message)
+          notify_reply_to(original_reply_to, request_owner, message)
+          notify_stream_owner(stream_owner, request_owner, original_reply_to, message)
+
+        {:gun_error, _pid, _stream, _reason} ->
+          send(request_owner, message)
+          notify_reply_to(original_reply_to, request_owner, message)
+          notify_stream_owner(stream_owner, request_owner, original_reply_to, message)
+
+        _ ->
+          send(request_owner, message)
+          notify_reply_to(original_reply_to, request_owner, message)
+      end
+    end
+
+    defp next_reply_state(_state, {:gun_response, _pid, _stream, :nofin, _status, _headers}),
+      do: :streaming
+
+    defp next_reply_state(state, _message), do: state
+
+    defp terminal_reply_message?({:gun_response, _pid, _stream, :fin, _status, _headers}),
+      do: true
+
+    defp terminal_reply_message?({:gun_data, _pid, _stream, :fin, _data}), do: true
+    defp terminal_reply_message?({:gun_error, _pid, _stream, _reason}), do: true
+    defp terminal_reply_message?({:gun_error, _pid, _reason}), do: true
+
+    defp terminal_reply_message?(
+           {:gun_down, _pid, _protocol, _reason, _killed_streams, _unprocessed}
+         ),
+         do: true
+
+    defp terminal_reply_message?(_message), do: false
 
     defp notify_reply_to(reply_to, request_owner, _message)
          when is_pid(reply_to) and reply_to == request_owner,

--- a/lib/tesla/adapter/gun.ex
+++ b/lib/tesla/adapter/gun.ex
@@ -180,19 +180,28 @@ if Code.ensure_loaded?(:gun) do
     end
 
     defp request(env, opts) do
-      request(
-        Tesla.Adapter.Shared.format_method(env.method),
-        Tesla.build_url(env),
-        format_headers(env.headers),
-        env.body || "",
+      opts =
         Tesla.Adapter.opts(
           [close_conn: true, body_as: :plain, send_body: :at_once, receive: true],
           env,
           opts
         )
         |> Enum.into(%{})
+        |> maybe_put_gun_reply_to(env.private[:tesla_gun_reply_to])
+
+      request(
+        Tesla.Adapter.Shared.format_method(env.method),
+        Tesla.build_url(env),
+        format_headers(env.headers),
+        env.body || "",
+        opts
       )
     end
+
+    defp maybe_put_gun_reply_to(opts, reply_to) when is_pid(reply_to),
+      do: Map.put_new(opts, :tesla_gun_reply_to, reply_to)
+
+    defp maybe_put_gun_reply_to(opts, _reply_to), do: opts
 
     defp request(method, url, headers, %Stream{} = body, opts),
       do: do_request(method, url, headers, body, Map.put(opts, :send_body, :stream))
@@ -440,7 +449,7 @@ if Code.ensure_loaded?(:gun) do
 
     defp reply_to(%{body_as: body_as} = opts) when body_as in [:stream, :chunks] do
       request_owner = self()
-      stream_owner = opts[:reply_to] || request_owner
+      stream_owner = opts[:reply_to] || opts[:tesla_gun_reply_to] || request_owner
 
       if stream_owner == request_owner do
         request_owner

--- a/lib/tesla/adapter/gun.ex
+++ b/lib/tesla/adapter/gun.ex
@@ -140,7 +140,7 @@ if Code.ensure_loaded?(:gun) do
     Returns `{:fin, binary()}` if all body received, otherwise returns `{:nofin, binary()}`.
     """
     @spec read_chunk(pid(), reference(), keyword() | map()) ::
-            {:fin, binary()} | {:nofin, binary()} | {:error, atom()}
+            {:fin, binary()} | {:nofin, binary()} | {:error, any()}
     def read_chunk(pid, stream, opts) do
       with {status, _} = chunk when status in [:fin, :error] <- do_read_chunk(pid, stream, opts) do
         if opts[:close_conn], do: close(pid)
@@ -155,6 +155,9 @@ if Code.ensure_loaded?(:gun) do
 
         {:gun_data, ^pid, ^stream, :nofin, part} ->
           {:nofin, part}
+
+        {:gun_error, ^pid, ^stream, reason} ->
+          {:error, reason}
 
         {:DOWN, _, _, _, reason} ->
           {:error, reason}
@@ -430,10 +433,32 @@ if Code.ensure_loaded?(:gun) do
     defp add_socks_proxy_auth_credentials(opts, _), do: opts
 
     defp open_stream(pid, method, path, headers, body, opts) do
-      req_opts = %{reply_to: opts[:reply_to] || self()}
+      req_opts = %{reply_to: reply_to(opts)}
 
       open_stream(pid, method, path, headers, body, req_opts, opts[:send_body])
     end
+
+    defp reply_to(%{body_as: body_as} = opts) when body_as in [:stream, :chunks] do
+      request_owner = self()
+      stream_owner = opts[:reply_to] || request_owner
+
+      if stream_owner == request_owner do
+        request_owner
+      else
+        fn
+          {:gun_data, _pid, _stream, _is_fin, _data} = message ->
+            send(stream_owner, message)
+
+          {:gun_error, _pid, _stream, _reason} = message ->
+            send(stream_owner, message)
+
+          message ->
+            send(request_owner, message)
+        end
+      end
+    end
+
+    defp reply_to(_opts), do: self()
 
     defp open_stream(pid, method, path, headers, body, req_opts, :stream) do
       stream = perform_stream_request(pid, method, path, headers, req_opts)
@@ -494,6 +519,7 @@ if Code.ensure_loaded?(:gun) do
               case read_chunk(pid, stream, opts) do
                 {:nofin, part} -> {[part], %{pid: pid, stream: stream}}
                 {:fin, body} -> {[body], %{pid: pid, final: :fin}}
+                {:error, error} -> raise_stream_error(error)
               end
 
             %{pid: pid, final: :fin} ->
@@ -510,6 +536,10 @@ if Code.ensure_loaded?(:gun) do
     defp format_response(pid, stream, opts, status, headers, :chunks) do
       {:ok, status, headers, %{pid: pid, stream: stream, opts: Enum.into(opts, [])}}
     end
+
+    defp raise_stream_error(error) when Kernel.is_exception(error), do: raise(error)
+    defp raise_stream_error(error) when is_binary(error), do: raise(RuntimeError, message: error)
+    defp raise_stream_error(error), do: raise(RuntimeError, message: inspect(error))
 
     defp read_body(pid, stream, opts, acc \\ "") do
       limit = opts[:max_body]

--- a/lib/tesla/middleware/timeout.ex
+++ b/lib/tesla/middleware/timeout.ex
@@ -48,6 +48,7 @@ defmodule Tesla.Middleware.Timeout do
     opts = opts || []
     timeout = Keyword.get(opts, :timeout, @default_timeout)
     task_module = Keyword.get(opts, :task_module, Task)
+    env = put_adapter_reply_to(env, self())
 
     task = safe_async(task_module, fn -> Tesla.run(env, next) end)
 
@@ -74,6 +75,15 @@ defmodule Tesla.Middleware.Timeout do
           {type, value}
       end
     end)
+  end
+
+  defp put_adapter_reply_to(env, reply_to) do
+    adapter_opts = env.opts[:adapter] || []
+
+    %{
+      env
+      | opts: Keyword.put(env.opts, :adapter, Keyword.put_new(adapter_opts, :reply_to, reply_to))
+    }
   end
 
   defp repass_error({:exception, error, stacktrace}), do: reraise(error, stacktrace)

--- a/lib/tesla/middleware/timeout.ex
+++ b/lib/tesla/middleware/timeout.ex
@@ -48,7 +48,7 @@ defmodule Tesla.Middleware.Timeout do
     opts = opts || []
     timeout = Keyword.get(opts, :timeout, @default_timeout)
     task_module = Keyword.get(opts, :task_module, Task)
-    env = put_gun_reply_to(env, self())
+    env = put_gun_stream_owner(env, self())
 
     task = safe_async(task_module, fn -> Tesla.run(env, next) end)
 
@@ -77,8 +77,8 @@ defmodule Tesla.Middleware.Timeout do
     end)
   end
 
-  defp put_gun_reply_to(env, reply_to),
-    do: %{env | private: Map.put_new(env.private, :tesla_gun_reply_to, reply_to)}
+  defp put_gun_stream_owner(env, stream_owner),
+    do: %{env | private: Map.put_new(env.private, :tesla_gun_stream_owner, stream_owner)}
 
   defp repass_error({:exception, error, stacktrace}), do: reraise(error, stacktrace)
 

--- a/lib/tesla/middleware/timeout.ex
+++ b/lib/tesla/middleware/timeout.ex
@@ -48,7 +48,7 @@ defmodule Tesla.Middleware.Timeout do
     opts = opts || []
     timeout = Keyword.get(opts, :timeout, @default_timeout)
     task_module = Keyword.get(opts, :task_module, Task)
-    env = put_adapter_reply_to(env, self())
+    env = put_gun_reply_to(env, self())
 
     task = safe_async(task_module, fn -> Tesla.run(env, next) end)
 
@@ -77,14 +77,8 @@ defmodule Tesla.Middleware.Timeout do
     end)
   end
 
-  defp put_adapter_reply_to(env, reply_to) do
-    adapter_opts = env.opts[:adapter] || []
-
-    %{
-      env
-      | opts: Keyword.put(env.opts, :adapter, Keyword.put_new(adapter_opts, :reply_to, reply_to))
-    }
-  end
+  defp put_gun_reply_to(env, reply_to),
+    do: %{env | private: Map.put_new(env.private, :tesla_gun_reply_to, reply_to)}
 
   defp repass_error({:exception, error, stacktrace}), do: reraise(error, stacktrace)
 

--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -198,20 +198,50 @@ defmodule Tesla.Adapter.GunTest do
     assert is_pid(pid)
   end
 
-  test "passes explicit reply_to through to gun on plain responses" do
+  test "passes explicit pid reply_to through to gun on plain responses" do
     request = %Env{
       method: :get,
       url: "#{@http}/stream-bytes/10"
     }
 
     test_pid = self()
-    reply_to = fn message -> send(test_pid, {:gun_reply_to, message}) end
+
+    reply_to =
+      spawn(fn ->
+        receive do
+          message -> send(test_pid, {:gun_reply_to, message})
+        end
+      end)
 
     assert {:error, :recv_response_timeout} = call(request, reply_to: reply_to, timeout: 100)
 
     assert_receive {:gun_reply_to, {:gun_response, pid, stream, :nofin, 200, _headers}}
     assert is_pid(pid)
     assert is_reference(stream)
+  end
+
+  test "preserves explicit function reply_to when stream ownership is handed off" do
+    request = %Env{
+      method: :get,
+      url: "#{@http}/stream-bytes/10",
+      private: %{tesla_gun_stream_owner: self()}
+    }
+
+    test_pid = self()
+    reply_to = fn message -> send(test_pid, {:gun_reply_to, message}) end
+
+    task =
+      Task.async(fn ->
+        Tesla.Adapter.Gun.call(request, body_as: :stream, reply_to: reply_to)
+      end)
+
+    assert {:ok, %Env{status: 200, body: body}} = Task.await(task)
+    assert body |> Enum.join() |> byte_size() == 16
+
+    assert_receive {:gun_reply_to, {:gun_response, pid, stream, :nofin, 200, _headers}}
+    assert is_pid(pid)
+    assert is_reference(stream)
+    assert_receive {:gun_reply_to, {:gun_data, ^pid, ^stream, _, _}}
   end
 
   test "on TLS errors get timeout error from await_up method" do

--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -198,6 +198,22 @@ defmodule Tesla.Adapter.GunTest do
     assert is_pid(pid)
   end
 
+  test "passes explicit reply_to through to gun on plain responses" do
+    request = %Env{
+      method: :get,
+      url: "#{@http}/stream-bytes/10"
+    }
+
+    test_pid = self()
+    reply_to = fn message -> send(test_pid, {:gun_reply_to, message}) end
+
+    assert {:error, :recv_response_timeout} = call(request, reply_to: reply_to, timeout: 100)
+
+    assert_receive {:gun_reply_to, {:gun_response, pid, stream, :nofin, 200, _headers}}
+    assert is_pid(pid)
+    assert is_reference(stream)
+  end
+
   test "on TLS errors get timeout error from await_up method" do
     request = %Env{
       method: :get,

--- a/test/tesla/middleware/timeout_test.exs
+++ b/test/tesla/middleware/timeout_test.exs
@@ -79,6 +79,16 @@ defmodule Tesla.Middleware.TimeoutTest do
     adapter Tesla.Adapter.Gun
   end
 
+  defmodule AdapterOptsClient do
+    use Tesla
+
+    plug Tesla.Middleware.Timeout, timeout: 100
+
+    adapter fn env ->
+      {:ok, %{env | status: 200, body: env.opts[:adapter] || []}}
+    end
+  end
+
   describe "using custom timeout (100ms)" do
     test "should return timeout error when the stack timeout" do
       assert {:error, :timeout} = Client.get("/sleep_150ms")
@@ -97,6 +107,13 @@ defmodule Tesla.Middleware.TimeoutTest do
         end)
 
       assert_receive {:EXIT, ^pid, :normal}, 200
+    end
+
+    test "should not inject gun-specific adapter opts into other adapters" do
+      assert {:ok, %Tesla.Env{status: 200, body: body}} =
+               AdapterOptsClient.get("/ok", opts: [adapter: [preserved: :value]])
+
+      assert body == [preserved: :value]
     end
   end
 

--- a/test/tesla/middleware/timeout_test.exs
+++ b/test/tesla/middleware/timeout_test.exs
@@ -204,5 +204,22 @@ defmodule Tesla.Middleware.TimeoutTest do
 
       assert body |> Enum.join() |> byte_size() == 16
     end
+
+    test "should preserve explicit gun reply_to while streaming through the timeout task" do
+      test_pid = self()
+      reply_to = fn message -> send(test_pid, {:gun_reply_to, message}) end
+
+      assert {:ok, %Tesla.Env{status: 200, body: body}} =
+               __MODULE__.GunStreamClient.get("#{@url}/stream-bytes/10",
+                 opts: [adapter: [body_as: :stream, reply_to: reply_to]]
+               )
+
+      assert body |> Enum.join() |> byte_size() == 16
+
+      assert_receive {:gun_reply_to, {:gun_response, pid, stream, :nofin, 200, _headers}}
+      assert is_pid(pid)
+      assert is_reference(stream)
+      assert_receive {:gun_reply_to, {:gun_data, ^pid, ^stream, _, _}}
+    end
   end
 end

--- a/test/tesla/middleware/timeout_test.exs
+++ b/test/tesla/middleware/timeout_test.exs
@@ -71,14 +71,12 @@ defmodule Tesla.Middleware.TimeoutTest do
     end
   end
 
-  if Code.ensure_loaded?(:gun) do
-    defmodule GunStreamClient do
-      use Tesla
+  defmodule GunStreamClient do
+    use Tesla
 
-      plug Tesla.Middleware.Timeout, timeout: 5_000
+    plug Tesla.Middleware.Timeout, timeout: 5_000
 
-      adapter Tesla.Adapter.Gun
-    end
+    adapter Tesla.Adapter.Gun
   end
 
   describe "using custom timeout (100ms)" do
@@ -180,16 +178,14 @@ defmodule Tesla.Middleware.TimeoutTest do
     end
   end
 
-  if Code.ensure_loaded?(:gun) do
-    describe "streaming with the gun adapter" do
-      test "should preserve streamed responses through the timeout task" do
-        assert {:ok, %Tesla.Env{status: 200, body: body}} =
-                 __MODULE__.GunStreamClient.get("#{@url}/stream-bytes/10",
-                   opts: [adapter: [body_as: :stream]]
-                 )
+  describe "streaming with the gun adapter" do
+    test "should preserve streamed responses through the timeout task" do
+      assert {:ok, %Tesla.Env{status: 200, body: body}} =
+               __MODULE__.GunStreamClient.get("#{@url}/stream-bytes/10",
+                 opts: [adapter: [body_as: :stream]]
+               )
 
-        assert body |> Enum.join() |> byte_size() == 16
-      end
+      assert body |> Enum.join() |> byte_size() == 16
     end
   end
 end

--- a/test/tesla/middleware/timeout_test.exs
+++ b/test/tesla/middleware/timeout_test.exs
@@ -1,6 +1,8 @@
 defmodule Tesla.Middleware.TimeoutTest do
   use ExUnit.Case, async: false
 
+  @url "http://localhost:#{Application.compile_env(:httparrot, :http_port)}"
+
   defmodule Client do
     use Tesla
 
@@ -69,6 +71,16 @@ defmodule Tesla.Middleware.TimeoutTest do
     end
   end
 
+  if Code.ensure_loaded?(:gun) do
+    defmodule GunStreamClient do
+      use Tesla
+
+      plug Tesla.Middleware.Timeout, timeout: 5_000
+
+      adapter Tesla.Adapter.Gun
+    end
+  end
+
   describe "using custom timeout (100ms)" do
     test "should return timeout error when the stack timeout" do
       assert {:error, :timeout} = Client.get("/sleep_150ms")
@@ -116,7 +128,7 @@ defmodule Tesla.Middleware.TimeoutTest do
 
           assert Tesla.Middleware.TimeoutTest.Client == last_module
           assert file_info[:file] == ~c"lib/tesla/builder.ex"
-          assert file_info[:line] == 23
+          assert file_info[:line] == 25
       else
         _ ->
           flunk("Expected exception to be thrown")
@@ -131,7 +143,7 @@ defmodule Tesla.Middleware.TimeoutTest do
           [_, {timeout_module, _, _, module_file_info} | _] = __STACKTRACE__
 
           assert Tesla.Middleware.Timeout == timeout_module
-          assert module_file_info == [file: ~c"lib/tesla/middleware/timeout.ex", line: 68]
+          assert module_file_info == [file: ~c"lib/tesla/middleware/timeout.ex", line: 69]
       else
         _ ->
           flunk("Expected exception to be thrown")
@@ -165,6 +177,19 @@ defmodule Tesla.Middleware.TimeoutTest do
         end)
 
       assert_receive {:EXIT, ^pid, :normal}, 200
+    end
+  end
+
+  if Code.ensure_loaded?(:gun) do
+    describe "streaming with the gun adapter" do
+      test "should preserve streamed responses through the timeout task" do
+        assert {:ok, %Tesla.Env{status: 200, body: body}} =
+                 __MODULE__.GunStreamClient.get("#{@url}/stream-bytes/10",
+                   opts: [adapter: [body_as: :stream]]
+                 )
+
+        assert body |> Enum.join() |> byte_size() == 16
+      end
     end
   end
 end


### PR DESCRIPTION
- Timeout middleware moves request execution into a separate task, so Gun streamed responses need to keep headers readable there while leaving body chunks readable from the original caller.
- Stream read failures should surface as stream errors instead of crashing with a case clause mismatch.
- This preserves the Gun streaming path reported in #709.