### PR TITLE
fix(json): do not override custom content-type request header

### DIFF
--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -82,10 +82,14 @@ defmodule Tesla.Middleware.JSON do
   def encode(env, opts) do
     with true <- encodable?(env),
          {:ok, body} <- encode_body(env.body, opts) do
-      {:ok,
-       env
-       |> Tesla.put_body(body)
-       |> Tesla.put_headers([{"content-type", encode_content_type(opts)}])}
+      if Tesla.get_header(env, "content-type") do
+        {:ok, env |> Tesla.put_body(body)}
+      else
+        {:ok,
+         env
+         |> Tesla.put_body(body)
+         |> Tesla.put_headers([{"content-type", encode_content_type(opts)}])}
+      end
     else
       false -> {:ok, env}
       error -> error

--- a/test/tesla/middleware/json_test.exs
+++ b/test/tesla/middleware/json_test.exs
@@ -300,6 +300,32 @@ defmodule Tesla.Middleware.JsonTest do
     end
   end
 
+  describe "Function: encode/2" do
+    test "does not add content-type header if body is not encodable" do
+      env = %Tesla.Env{body: "hello"}
+
+      {:ok, %Tesla.Env{headers: headers}} = Tesla.Middleware.JSON.encode(env, [])
+
+      assert headers == []
+    end
+
+    test "adds content-type header automatically if one is not present and body is encodable" do
+      env = %Tesla.Env{body: %{}}
+
+      {:ok, %Tesla.Env{headers: headers}} = Tesla.Middleware.JSON.encode(env, [])
+
+      assert [{"content-type", _}] = headers
+    end
+
+    test "does not put own content-type header if one is already present and body is encodable" do
+      env = %Tesla.Env{body: %{}, headers: [{"content-type", "application/x-ndjson"}]}
+
+      {:ok, %Tesla.Env{headers: headers}} = Tesla.Middleware.JSON.encode(env, [])
+
+      assert [{"content-type", "application/x-ndjson"}] = headers
+    end
+  end
+
   if Code.ensure_loaded?(JSON) do
     describe "Engine: JSON" do
       defmodule JSONClient do


### PR DESCRIPTION
## Preamble

I am working with Elasticsearch, which uses a bulk endpoint that uses NDJSON, and expects a `content-type: application/x-ndjson` header.

However, Tesla's JSON encoder middleware does not allow the header to be overridden, so I have to use workarounds to set the header when sending the request:

```elixir
defp client(opts \\ []) do
  request_content_type = Keyword.get(opts, :request_content_type, "application/json")

  base_headers = [{"accept", "application/json"}]

  # Set custom headers and middleware based on the payload type. (This is a workaround to fix
  # Tesla's lack of support for Elasticsearch's bulk NDJSON endpoint)
  {headers, tesla_json_middleware} =
    case request_content_type do
      "application/json" ->
        {base_headers, {Tesla.Middleware.JSON, engine: JSON}}

      "application/x-ndjson" ->
        headers = base_headers ++ [{"content-type", "application/x-ndjson"}]

        {headers, {Tesla.Middleware.DecodeJson, engine: JSON}}
    end

  middleware =
    [
      {Tesla.Middleware.BaseUrl, base_url},
      {Tesla.Middleware.Headers, headers},
      tesla_json_middleware,
      # Other middleware excluded for brevity...
    ]

  Tesla.client(middleware)
end
```

## Solution

This pull request resolves the issue by allowing the `content-type` header to be overridden, but falls back to the default `application/json` if no custom `content-type` header is present in the request.

This allows me to remove my workaround logic and just use plain old `Tesla.Middleware.JSON` in my client with the custom header that is required by Elasticsearch.