### PR TITLE
feat: support OpenAPI-friendly path params

### DIFF
--- a/lib/tesla/middleware/path_params.ex
+++ b/lib/tesla/middleware/path_params.ex
@@ -10,6 +10,10 @@ defmodule Tesla.Middleware.PathParams do
   Parameter values may be `t:struct/0` or must implement the `Enumerable`
   protocol and produce `{key, value}` tuples when enumerated.
 
+  By default, this middleware preserves legacy string substitution. Pass
+  `mode: :modern` to require a list of `Tesla.PathParam` values and
+  use their explicit serialization settings.
+
   ## Parameter Name Restrictions
 
   Phoenix style parameters may contain letters, numbers, or underscores,
@@ -52,8 +56,12 @@ defmodule Tesla.Middleware.PathParams do
 
   @behaviour Tesla.Middleware
 
+  alias Tesla.Middleware.PathParams.Modern
+
   @impl Tesla.Middleware
-  def call(env, next, _) do
+  def call(env, next, mode: :modern), do: Modern.call(env, next)
+
+  def call(env, next, _opts) do
     url = build_url(env.url, env.opts[:path_params])
     Tesla.run(%{env | url: url}, next)
   end

--- a/lib/tesla/middleware/path_params/modern.ex
+++ b/lib/tesla/middleware/path_params/modern.ex
@@ -1,0 +1,246 @@
+defmodule Tesla.Middleware.PathParams.Modern do
+  @moduledoc false
+
+  alias Tesla.PathParam
+
+  def call(env, next) do
+    url = build_url(env.url, env.opts[:path_params])
+    Tesla.run(%{env | url: url}, next)
+  end
+
+  defp build_url(url, nil) do
+    url
+  end
+
+  defp build_url(url, params) when is_list(params) do
+    params = index_params!(params)
+
+    Regex.replace(~r/[{]([^{}]+)[}]/, url, &replace_placeholder(params, &1, &2))
+  end
+
+  defp build_url(url, _params) do
+    url
+  end
+
+  defp index_params!(params) do
+    Enum.reduce(params, %{}, &index_param!/2)
+  end
+
+  defp index_param!(%PathParam{name: name} = param, params) do
+    case Map.has_key?(params, name) do
+      true ->
+        raise ArgumentError, "duplicate path parameter #{inspect(name)} in modern mode"
+
+      false ->
+        Map.put(params, name, param)
+    end
+  end
+
+  defp index_param!(value, _params) do
+    raise ArgumentError,
+          "expected path_params to be a list of #{inspect(PathParam)} structs in modern mode; got #{inspect(value)}"
+  end
+
+  defp replace_placeholder(params, match, name) when is_map(params) do
+    params
+    |> Map.get(name)
+    |> replace_param(match)
+  end
+
+  defp replace_param(%PathParam{value: nil}, match) do
+    match
+  end
+
+  defp replace_param(%PathParam{} = param, _match) do
+    serialize_value(param)
+  end
+
+  defp replace_param(nil, match) do
+    match
+  end
+
+  defp serialize_undefined(:simple, _param) do
+    ""
+  end
+
+  defp serialize_undefined(:matrix, param) do
+    ";" <> PathParam.encode_value(param, param.name)
+  end
+
+  defp serialize_undefined(:label, _param) do
+    "."
+  end
+
+  defp serialize_value(%PathParam{style: :simple} = param) do
+    serialize_simple(classify_param(param), param)
+  end
+
+  defp serialize_value(%PathParam{style: :matrix} = param) do
+    serialize_matrix(classify_param(param), param)
+  end
+
+  defp serialize_value(%PathParam{style: :label} = param) do
+    serialize_label(classify_param(param), param)
+  end
+
+  defp serialize_simple({:primitive, value}, param) do
+    PathParam.encode_value(param, value)
+  end
+
+  defp serialize_simple({:array, []}, param) do
+    serialize_undefined(:simple, param)
+  end
+
+  defp serialize_simple({:array, items}, param) do
+    join_encoded_values(items, ",", param)
+  end
+
+  defp serialize_simple({:object, []}, param) do
+    serialize_undefined(:simple, param)
+  end
+
+  defp serialize_simple({:object, pairs}, %PathParam{explode: true} = param) do
+    join_encoded_pairs(pairs, ",", param)
+  end
+
+  defp serialize_simple({:object, pairs}, %PathParam{explode: false} = param) do
+    pairs
+    |> flatten_pairs()
+    |> join_encoded_values(",", param)
+  end
+
+  defp serialize_matrix({:primitive, value}, param) do
+    ";" <>
+      PathParam.encode_value(param, param.name) <> "=" <> PathParam.encode_value(param, value)
+  end
+
+  defp serialize_matrix({:array, []}, param) do
+    serialize_undefined(:matrix, param)
+  end
+
+  defp serialize_matrix({:array, items}, %PathParam{explode: true} = param) do
+    Enum.map_join(items, "", &serialize_matrix_array_item(&1, param))
+  end
+
+  defp serialize_matrix({:array, items}, %PathParam{explode: false} = param) do
+    ";" <>
+      PathParam.encode_value(param, param.name) <>
+      "=" <> join_encoded_values(items, ",", param)
+  end
+
+  defp serialize_matrix({:object, []}, param) do
+    serialize_undefined(:matrix, param)
+  end
+
+  defp serialize_matrix({:object, pairs}, %PathParam{explode: true} = param) do
+    Enum.map_join(pairs, "", &serialize_matrix_pair(&1, param))
+  end
+
+  defp serialize_matrix({:object, pairs}, %PathParam{explode: false} = param) do
+    ";" <>
+      PathParam.encode_value(param, param.name) <>
+      "=" <>
+      (pairs
+       |> flatten_pairs()
+       |> join_encoded_values(",", param))
+  end
+
+  defp serialize_label({:primitive, value}, param) do
+    "." <> PathParam.encode_value(param, value)
+  end
+
+  defp serialize_label({:array, []}, param) do
+    serialize_undefined(:label, param)
+  end
+
+  defp serialize_label({:array, items}, %PathParam{explode: true} = param) do
+    "." <> join_encoded_values(items, ".", param)
+  end
+
+  defp serialize_label({:array, items}, %PathParam{explode: false} = param) do
+    "." <> join_encoded_values(items, ",", param)
+  end
+
+  defp serialize_label({:object, []}, param) do
+    serialize_undefined(:label, param)
+  end
+
+  defp serialize_label({:object, pairs}, %PathParam{explode: true} = param) do
+    "." <> join_encoded_pairs(pairs, ".", param)
+  end
+
+  defp serialize_label({:object, pairs}, %PathParam{explode: false} = param) do
+    "." <>
+      (pairs
+       |> flatten_pairs()
+       |> join_encoded_values(",", param))
+  end
+
+  defp serialize_matrix_array_item(value, param) do
+    ";" <>
+      PathParam.encode_value(param, param.name) <> "=" <> PathParam.encode_value(param, value)
+  end
+
+  defp serialize_matrix_pair(pair, param) do
+    ";" <> serialize_key_value_pair(pair, param)
+  end
+
+  defp join_encoded_pairs(pairs, separator, param) do
+    Enum.map_join(pairs, separator, &serialize_key_value_pair(&1, param))
+  end
+
+  defp serialize_key_value_pair({key, value}, param) do
+    "#{PathParam.encode_value(param, key)}=#{PathParam.encode_value(param, value)}"
+  end
+
+  defp flatten_pairs(pairs) do
+    Enum.flat_map(pairs, &pair_values/1)
+  end
+
+  defp pair_values({key, value}) do
+    [key, value]
+  end
+
+  defp join_encoded_values(values, separator, param) do
+    Enum.map_join(values, separator, &PathParam.encode_value(param, &1))
+  end
+
+  defp classify_param(%PathParam{value: value}) do
+    classify_value(value)
+  end
+
+  defp classify_value(value) when is_struct(value) do
+    classify_value(Map.from_struct(value))
+  end
+
+  defp classify_value(value) when is_map(value) do
+    {:object, value |> Map.to_list() |> Enum.map(&stringify_pair/1)}
+  end
+
+  defp classify_value([]) do
+    {:array, []}
+  end
+
+  defp classify_value(value) when is_list(value) do
+    case Enum.all?(value, &object_pair?/1) do
+      true -> {:object, Enum.map(value, &stringify_pair/1)}
+      false -> {:array, value}
+    end
+  end
+
+  defp classify_value(value) do
+    {:primitive, value}
+  end
+
+  defp stringify_pair({key, value}) do
+    {to_string(key), value}
+  end
+
+  defp object_pair?({key, _value}) when is_atom(key) or is_binary(key) do
+    true
+  end
+
+  defp object_pair?(_value) do
+    false
+  end
+end

--- a/lib/tesla/path_param.ex
+++ b/lib/tesla/path_param.ex
@@ -1,0 +1,187 @@
+defmodule Tesla.PathParam do
+  @moduledoc """
+  A path parameter with explicit serialization settings.
+
+  `Tesla.PathParam` is a Tesla-native value object for path parameters whose
+  serialization needs to be controlled explicitly. Its serialization options
+  follow the OpenAPI path parameter style semantics, while keeping the public
+  API focused on the path use case.
+
+  In `Tesla.Middleware.PathParams` `:modern` mode, wrap each path parameter
+  explicitly, even when the default path serialization is enough:
+
+      opts: [path_params: [PathParam.new!("id", 42)]]
+
+  Pass options when a value needs non-default path serialization:
+
+      alias Tesla.PathParam
+
+      opts: [
+        path_params: [
+          PathParam.new!("coords", ["blue", "black"], style: :matrix, explode: true)
+        ]
+      ]
+
+  ## Options
+
+  `new!/3` accepts a keyword list using Elixir atoms for hand-written Tesla
+  code:
+
+    * `:style` — one of `:simple`, `:matrix`, `:label`. Defaults to `:simple`.
+    * `:explode` — boolean. Defaults to `false`.
+    * `:allow_reserved` — boolean. Defaults to `false`.
+
+  [oas-style]: https://spec.openapis.org/oas/latest.html#style-values
+
+  ## Encoding
+
+  `Tesla.Middleware.PathParams` serializes `Tesla.PathParam` values using the
+  [OpenAPI path parameter rules][oas-style] for the `simple`, `matrix`, and
+  `label` styles. Serialized values are percent-encoded against the RFC 3986
+  unreserved set (`A-Z`, `a-z`, `0-9`, `-`, `_`, `.`, `~`); spaces become
+  `%20` (not `+`).
+
+  With `allow_reserved: true`, path-safe reserved characters are preserved, but
+  characters that would change the URL path shape, such as `/`, `?`, or `#`,
+  are still percent-encoded.
+
+  ## Object Value Ordering
+
+  Object values may be passed as maps, structs, or keyword lists. Keyword lists
+  preserve insertion order; map iteration order is intrinsic and not guaranteed
+  across Elixir versions. Pass an ordered keyword list when the exact
+  serialized order matters.
+
+  ## Missing And Empty Values
+
+  `nil` values and missing path parameters are handled by
+  `Tesla.Middleware.PathParams`, which leaves unmatched placeholders untouched.
+  Empty arrays and empty objects serialize according to the OpenAPI
+  "undefined" column for the selected style.
+  """
+
+  @derive {Inspect, except: [:value]}
+  @enforce_keys [:name, :value, :style, :explode, :allow_reserved]
+  defstruct [:name, :value, :style, :explode, :allow_reserved]
+
+  @type style :: :simple | :matrix | :label
+  @opaque t :: %__MODULE__{
+            name: String.t(),
+            value: term(),
+            style: style(),
+            explode: boolean(),
+            allow_reserved: boolean()
+          }
+
+  @spec new!(String.t(), term(), keyword()) :: t()
+  def new!(name, value, opts \\ [])
+
+  def new!(name, value, opts) when is_binary(name) and is_list(opts) do
+    build!(opts, name, value)
+  end
+
+  def new!(name, _value, _opts) when not is_binary(name) do
+    raise ArgumentError, "expected path parameter name to be a string; got #{inspect(name)}"
+  end
+
+  def new!(_name, _value, opts) do
+    raise ArgumentError,
+          "expected path parameter options to be a keyword list; got #{inspect(opts)}"
+  end
+
+  @doc false
+  @spec encode_value(%__MODULE__{}, term()) :: String.t()
+  def encode_value(%__MODULE__{allow_reserved: false}, value) do
+    value |> to_string() |> URI.encode(&unreserved?/1)
+  end
+
+  def encode_value(%__MODULE__{allow_reserved: true}, value) do
+    value |> to_string() |> encode_reserved_path()
+  end
+
+  defp build!(opts, name, value) do
+    opts = Keyword.validate!(opts, style: :simple, explode: false, allow_reserved: false)
+
+    %__MODULE__{
+      name: name,
+      value: value,
+      style: opts[:style] |> validate_style!(),
+      explode: validate_boolean!(:explode, opts[:explode]),
+      allow_reserved: validate_boolean!(:allow_reserved, opts[:allow_reserved])
+    }
+  end
+
+  defp validate_style!(style) when style in [:simple, :matrix, :label], do: style
+
+  defp validate_style!(style) do
+    raise ArgumentError,
+          "unknown path parameter style #{inspect(style)}; expected :simple, :matrix, or :label"
+  end
+
+  defp validate_boolean!(_key, value) when is_boolean(value), do: value
+
+  defp validate_boolean!(key, value) do
+    raise ArgumentError, "expected #{inspect(key)} to be a boolean; got #{inspect(value)}"
+  end
+
+  defp encode_reserved_path(<<"%", h1, h2, rest::binary>>)
+       when h1 in ?0..?9 or h1 in ?A..?F or h1 in ?a..?f do
+    case hex?(h2) do
+      true -> "%" <> <<h1, h2>> <> encode_reserved_path(rest)
+      false -> "%25" <> encode_reserved_path(<<h1, h2, rest::binary>>)
+    end
+  end
+
+  defp encode_reserved_path(<<c::utf8, rest::binary>>) do
+    char = <<c::utf8>>
+
+    case byte_size(char) == 1 and reserved_path_allowed?(c) do
+      true -> char <> encode_reserved_path(rest)
+      false -> URI.encode(char, &reserved_path_allowed?/1) <> encode_reserved_path(rest)
+    end
+  end
+
+  defp encode_reserved_path("") do
+    ""
+  end
+
+  defp hex?(c) when c in ?0..?9 do
+    true
+  end
+
+  defp hex?(c) when c in ?A..?F do
+    true
+  end
+
+  defp hex?(c) when c in ?a..?f do
+    true
+  end
+
+  defp hex?(_c) do
+    false
+  end
+
+  defp unreserved?(c) when c in ?A..?Z do
+    true
+  end
+
+  defp unreserved?(c) when c in ?a..?z do
+    true
+  end
+
+  defp unreserved?(c) when c in ?0..?9 do
+    true
+  end
+
+  defp unreserved?(c) when c in [?-, ?_, ?., ?~] do
+    true
+  end
+
+  defp unreserved?(_c) do
+    false
+  end
+
+  defp reserved_path_allowed?(c) do
+    unreserved?(c) or c in [?!, ?$, ?&, ?', ?(, ?), ?*, ?+, ?,, ?;, ?=, ?:, ?@]
+  end
+end

--- a/test/tesla/middleware/path_params/modern_test.exs
+++ b/test/tesla/middleware/path_params/modern_test.exs
@@ -1,0 +1,1067 @@
+defmodule Tesla.Middleware.PathParams.ModernTest do
+  use ExUnit.Case, async: true
+
+  alias Tesla.Env
+  alias Tesla.PathParam
+
+  @middleware Tesla.Middleware.PathParams
+
+  defmodule TestUser do
+    defstruct [:id]
+  end
+
+  defp path_param(value), do: PathParam.new!("id", value)
+  defp path_param(name, value) when is_binary(name), do: PathParam.new!(name, value)
+  defp path_param(value, opts) when is_list(opts), do: PathParam.new!("id", value, opts)
+  defp path_param(name, value, opts), do: PathParam.new!(name, value, opts)
+
+  describe "mode: :modern — simple style" do
+    test "primitive (explode false) renders raw value" do
+      opts = [path_params: [path_param(5, style: :simple, explode: false)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/5"
+    end
+
+    test "primitive (explode true) renders raw value" do
+      opts = [path_params: [path_param(5, style: :simple, explode: true)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/5"
+    end
+
+    test "array (explode false) is comma-joined" do
+      opts = [path_params: [path_param([3, 4, 5], style: :simple, explode: false)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/3,4,5"
+    end
+
+    test "array (explode true) is also comma-joined" do
+      opts = [path_params: [path_param([3, 4, 5], style: :simple, explode: true)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/3,4,5"
+    end
+
+    test "object (explode false) flattens key-value pairs with commas" do
+      opts = [
+        path_params: [
+          path_param([role: "admin", firstName: "Alex"], style: :simple, explode: false)
+        ]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/role,admin,firstName,Alex"
+    end
+
+    test "object (explode true) joins key=value with commas" do
+      opts = [
+        path_params: [
+          path_param([role: "admin", firstName: "Alex"], style: :simple, explode: true)
+        ]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/role=admin,firstName=Alex"
+    end
+  end
+
+  describe "mode: :modern — matrix style" do
+    test "primitive renders ;name=value" do
+      opts = [path_params: [path_param(5, style: :matrix, explode: false)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/;id=5"
+    end
+
+    test "array (explode false) renders ;name=v1,v2,v3" do
+      opts = [path_params: [path_param([3, 4, 5], style: :matrix, explode: false)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/;id=3,4,5"
+    end
+
+    test "array (explode true) repeats ;name=v" do
+      opts = [path_params: [path_param([3, 4, 5], style: :matrix, explode: true)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/;id=3;id=4;id=5"
+    end
+
+    test "object (explode false) renders ;name=k1,v1,k2,v2" do
+      opts = [
+        path_params: [
+          path_param([role: "admin", firstName: "Alex"], style: :matrix, explode: false)
+        ]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/;id=role,admin,firstName,Alex"
+    end
+
+    test "object (explode true) renders ;k1=v1;k2=v2 (no name prefix)" do
+      opts = [
+        path_params: [
+          path_param([role: "admin", firstName: "Alex"], style: :matrix, explode: true)
+        ]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/;role=admin;firstName=Alex"
+    end
+  end
+
+  describe "mode: :modern — label style" do
+    test "primitive renders .value" do
+      opts = [path_params: [path_param(5, style: :label, explode: false)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/.5"
+    end
+
+    test "array (explode false) renders .v1,v2,v3" do
+      opts = [path_params: [path_param([3, 4, 5], style: :label, explode: false)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/.3,4,5"
+    end
+
+    test "array (explode true) renders .v1.v2.v3" do
+      opts = [path_params: [path_param([3, 4, 5], style: :label, explode: true)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/.3.4.5"
+    end
+
+    test "object (explode false) flattens key-value pairs with commas" do
+      opts = [
+        path_params: [
+          path_param([role: "admin", firstName: "Alex"], style: :label, explode: false)
+        ]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/.role,admin,firstName,Alex"
+    end
+
+    test "object (explode true) joins key=value with dots" do
+      opts = [
+        path_params: [
+          path_param([role: "admin", firstName: "Alex"], style: :label, explode: true)
+        ]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/.role=admin.firstName=Alex"
+    end
+  end
+
+  describe "mode: :modern — OpenAPI specification style examples" do
+    spec_examples = [
+      {"matrix explode=false string", :matrix, false, "blue", ";color=blue"},
+      {"matrix explode=false array", :matrix, false, ["blue", "black", "brown"],
+       ";color=blue,black,brown"},
+      {"matrix explode=false object", :matrix, false, [R: 100, G: 200, B: 150],
+       ";color=R,100,G,200,B,150"},
+      {"matrix explode=true string", :matrix, true, "blue", ";color=blue"},
+      {"matrix explode=true array", :matrix, true, ["blue", "black", "brown"],
+       ";color=blue;color=black;color=brown"},
+      {"matrix explode=true object", :matrix, true, [R: 100, G: 200, B: 150],
+       ";R=100;G=200;B=150"},
+      {"label explode=false string", :label, false, "blue", ".blue"},
+      {"label explode=false array", :label, false, ["blue", "black", "brown"],
+       ".blue,black,brown"},
+      {"label explode=false object", :label, false, [R: 100, G: 200, B: 150],
+       ".R,100,G,200,B,150"},
+      {"label explode=true string", :label, true, "blue", ".blue"},
+      {"label explode=true array", :label, true, ["blue", "black", "brown"], ".blue.black.brown"},
+      {"label explode=true object", :label, true, [R: 100, G: 200, B: 150], ".R=100.G=200.B=150"},
+      {"simple explode=false string", :simple, false, "blue", "blue"},
+      {"simple explode=false array", :simple, false, ["blue", "black", "brown"],
+       "blue,black,brown"},
+      {"simple explode=false object", :simple, false, [R: 100, G: 200, B: 150],
+       "R,100,G,200,B,150"},
+      {"simple explode=true string", :simple, true, "blue", "blue"},
+      {"simple explode=true array", :simple, true, ["blue", "black", "brown"],
+       "blue,black,brown"},
+      {"simple explode=true object", :simple, true, [R: 100, G: 200, B: 150], "R=100,G=200,B=150"}
+    ]
+
+    for {name, style, explode, value, expected} <- spec_examples do
+      test name do
+        opts = [
+          path_params: [
+            path_param("color", unquote(Macro.escape(value)),
+              style: unquote(style),
+              explode: unquote(explode)
+            )
+          ]
+        ]
+
+        assert {:ok, env} =
+                 @middleware.call(
+                   %Env{url: "/users/{color}", opts: opts},
+                   [],
+                   mode: :modern
+                 )
+
+        assert env.url == "/users/" <> unquote(expected)
+      end
+    end
+  end
+
+  describe "mode: :modern — OpenAPI undefined value examples" do
+    undefined_examples = [
+      {"matrix explode=false empty array", :matrix, false, [], ";color"},
+      {"matrix explode=true empty array", :matrix, true, [], ";color"},
+      {"matrix explode=false empty object", :matrix, false, %{}, ";color"},
+      {"matrix explode=true empty object", :matrix, true, %{}, ";color"},
+      {"label explode=false empty array", :label, false, [], "."},
+      {"label explode=true empty array", :label, true, [], "."},
+      {"label explode=false empty object", :label, false, %{}, "."},
+      {"label explode=true empty object", :label, true, %{}, "."},
+      {"simple explode=false empty array", :simple, false, [], ""},
+      {"simple explode=true empty array", :simple, true, [], ""},
+      {"simple explode=false empty object", :simple, false, %{}, ""},
+      {"simple explode=true empty object", :simple, true, %{}, ""}
+    ]
+
+    for {name, style, explode, value, expected} <- undefined_examples do
+      test name do
+        opts = [
+          path_params: [
+            path_param("color", unquote(Macro.escape(value)),
+              style: unquote(style),
+              explode: unquote(explode)
+            )
+          ]
+        ]
+
+        assert {:ok, env} =
+                 @middleware.call(
+                   %Env{url: "/users/{color}", opts: opts},
+                   [],
+                   mode: :modern
+                 )
+
+        assert env.url == "/users/" <> unquote(expected)
+      end
+    end
+  end
+
+  describe "mode: :modern — OpenAPI path template names" do
+    test "replaces template names that start with a number" do
+      opts = [path_params: [path_param("1color", "blue")]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{1color}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/blue"
+    end
+
+    test "replaces template names that start with an underscore" do
+      opts = [path_params: [path_param("_color", "blue")]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{_color}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/blue"
+    end
+
+    test "replaces template names that start with a dash" do
+      opts = [path_params: [path_param("-color", "blue")]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{-color}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/blue"
+    end
+
+    test "replaces template names containing path-template punctuation" do
+      opts = [path_params: [path_param("color.name+shade", "blue")]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{color.name+shade}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/blue"
+    end
+
+    test "matches path template names case-sensitively" do
+      opts = [
+        path_params: [
+          path_param("id", "lower"),
+          path_param("Id", "upper")
+        ]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}/{Id}/{ID}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/lower/upper/{ID}"
+    end
+
+    test "replaces repeated template expressions with the same parameter value" do
+      opts = [path_params: [path_param("id", "blue")]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}/related/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/blue/related/blue"
+    end
+
+    test "percent-encodes non-RFC6570 template names when the name is serialized" do
+      opts = [path_params: [path_param("color name", "blue", style: :matrix)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{color name}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/;color%20name=blue"
+    end
+
+    test "leaves empty template expressions untouched" do
+      opts = [path_params: [path_param("", "blue")]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/{}"
+    end
+  end
+
+  describe "mode: :modern — OpenAPI path serialization limits" do
+    for style <- [:form, :spaceDelimited, :pipeDelimited, :deepObject, :cookie] do
+      test "rejects non-path style #{style}" do
+        assert_raise ArgumentError, ~r/expected :simple, :matrix, or :label/, fn ->
+          path_param("color", "blue", style: unquote(style))
+        end
+      end
+    end
+  end
+
+  describe "mode: :modern — OpenAPI percent encoding" do
+    spec_path_examples = [
+      {"Edsger Dijkstra", "edijkstra", "edijkstra"},
+      {"Diṅnāga", "diṅnāga", "di%E1%B9%85n%C4%81ga"},
+      {"Al-Khwarizmi", "الخوارزميّ",
+       "%D8%A7%D9%84%D8%AE%D9%88%D8%A7%D8%B1%D8%B2%D9%85%D9%8A%D9%91"}
+    ]
+
+    for {name, value, expected} <- spec_path_examples do
+      test "OpenAPI path example #{name}" do
+        opts = [path_params: [path_param("username", unquote(value))]]
+
+        assert {:ok, env} =
+                 @middleware.call(
+                   %Env{url: "/users/{username}", opts: opts},
+                   [],
+                   mode: :modern
+                 )
+
+        assert env.url == "/users/" <> unquote(expected)
+      end
+    end
+
+    empty_string_examples = [
+      {"simple empty string", :simple, ""},
+      {"matrix empty string", :matrix, ";color="},
+      {"label empty string", :label, "."}
+    ]
+
+    for {name, style, expected} <- empty_string_examples do
+      test "#{name} follows primitive serialization" do
+        opts = [path_params: [path_param("color", "", style: unquote(style))]]
+
+        assert {:ok, env} =
+                 @middleware.call(
+                   %Env{url: "/users/{color}", opts: opts},
+                   [],
+                   mode: :modern
+                 )
+
+        assert env.url == "/users/" <> unquote(expected)
+      end
+    end
+
+    test "encodes path-forbidden generic syntax characters" do
+      opts = [path_params: [path_param("color", "a/b?c#d")]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{color}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/a%2Fb%3Fc%23d"
+    end
+
+    test "encodes delimiter characters inside non-reserved array values" do
+      opts = [path_params: [path_param("color", ["blue,green", "black"], style: :simple)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{color}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/blue%2Cgreen,black"
+    end
+
+    test "encodes delimiter characters inside non-reserved object values" do
+      opts = [
+        path_params: [
+          path_param("color", [R: "100,200", G: "x+y"], style: :matrix, explode: true)
+        ]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{color}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/;R=100%2C200;G=x%2By"
+    end
+
+    test "allowReserved keeps path-legal reserved characters" do
+      opts = [
+        path_params: [path_param("color", "x+y:@", style: :simple, allow_reserved: true)]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{color}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/x+y:@"
+    end
+
+    test "allowReserved still encodes generic syntax characters forbidden in path values" do
+      opts = [
+        path_params: [path_param("color", "a/b?c#d", style: :simple, allow_reserved: true)]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{color}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/a%2Fb%3Fc%23d"
+    end
+
+    test "allowReserved preserves existing percent-encoded octets" do
+      opts = [
+        path_params: [path_param("color", "x%2By", style: :simple, allow_reserved: true)]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{color}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/x%2By"
+    end
+
+    test "allowReserved encodes percent signs outside percent-encoded octets" do
+      opts = [
+        path_params: [path_param("color", "x%2G%", style: :simple, allow_reserved: true)]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{color}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/x%252G%25"
+    end
+
+    test "allowReserved still encodes characters that are not valid path output" do
+      opts = [
+        path_params: [path_param("color", "[x]| y", style: :simple, allow_reserved: true)]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{color}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/%5Bx%5D%7C%20y"
+    end
+  end
+
+  describe "mode: :modern — encoding & edge cases" do
+    test "leaves URL untouched when no path_params are provided" do
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}"},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/{id}"
+    end
+
+    test "percent-encodes reserved characters per RFC 3986" do
+      opts = [path_params: [path_param("a/b c#d")]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/a%2Fb%20c%23d"
+    end
+
+    test "spaces become %20 (not +)" do
+      opts = [path_params: [path_param("John Smith")]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/John%20Smith"
+    end
+
+    test "leaves placeholder when value is missing" do
+      opts = [path_params: [path_param("other", 1)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/{id}"
+    end
+
+    test "leaves placeholder when PathParam value is nil" do
+      opts = [path_params: [path_param(nil)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/{id}"
+    end
+
+    test "serializes empty array as OpenAPI undefined" do
+      opts = [path_params: [path_param([])]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/"
+    end
+
+    test "serializes empty object as OpenAPI undefined" do
+      opts = [path_params: [path_param(%{})]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/"
+    end
+
+    test "PathParam value uses defaults (style: :simple, explode: false)" do
+      opts = [path_params: [path_param(42)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/42"
+    end
+
+    test "PathParam opts default :explode to false when omitted" do
+      opts = [path_params: [path_param([3, 4, 5], style: :matrix)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/;id=3,4,5"
+    end
+
+    test "PathParam opts default :style to :simple when omitted" do
+      opts = [path_params: [path_param([3, 4, 5], explode: false)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/3,4,5"
+    end
+
+    test "rejects unknown PathParam option keys" do
+      assert_raise ArgumentError, ~r/unknown keys \[:future_field\]/, fn ->
+        path_param(5, style: :simple, explode: false, future_field: :foo)
+      end
+    end
+
+    test "accepts struct as object value" do
+      opts = [path_params: [path_param(%TestUser{id: 7}, style: :simple, explode: true)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/id=7"
+    end
+
+    test "accepts string-keyed object pair lists" do
+      opts = [
+        path_params: [
+          path_param("color", [{"R", 100}, {"G", 200}], style: :simple, explode: false)
+        ]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{color}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/R,100,G,200"
+    end
+
+    test "accepts string-keyed maps as object values" do
+      opts = [
+        path_params: [
+          path_param("color", %{"R" => 100}, style: :simple, explode: true)
+        ]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{color}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/R=100"
+    end
+
+    test "supports list-shaped path_params" do
+      opts = [
+        path_params: [
+          path_param(5),
+          path_param("coords", ["blue", "black"], style: :matrix, explode: true)
+        ]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/items/{id}{coords}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/items/5;coords=blue;coords=black"
+    end
+
+    test "supports named PathParam structs" do
+      opts = [path_params: [path_param(42)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/42"
+    end
+
+    test "raises on duplicate PathParam names" do
+      opts = [path_params: [path_param(1), path_param(2)]]
+
+      assert_raise ArgumentError, ~r/duplicate path parameter "id" in modern mode/, fn ->
+        @middleware.call(
+          %Env{url: "/users/{id}", opts: opts},
+          [],
+          mode: :modern
+        )
+      end
+    end
+
+    test "does not treat maps as modern path_params" do
+      opts = [path_params: %{"id" => path_param(42)}]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/{id}"
+    end
+
+    test "ignores struct-shaped outer containers" do
+      opts = [path_params: %TestUser{id: path_param(7)}]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/{id}"
+    end
+
+    test "leaves Phoenix-style placeholders untouched" do
+      opts = [path_params: [path_param([3, 4, 5], style: :matrix, explode: true)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/:id", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/:id"
+    end
+
+    test "raises on unsupported style atom" do
+      assert_raise ArgumentError, ~r/expected :simple, :matrix, or :label/, fn ->
+        path_param(5, style: :form, explode: false)
+      end
+    end
+
+    test "expands multiple placeholders in one URL" do
+      opts = [
+        path_params: [
+          path_param(5),
+          path_param("coords", ["blue", "black"], style: :matrix, explode: true),
+          path_param("tags", ["a", "b", "c"], style: :label, explode: false)
+        ]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/items/{id}{coords}{tags}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/items/5;coords=blue;coords=black.a,b,c"
+    end
+
+    test "leaves URL untouched when path_params is an unsupported type" do
+      opts = [path_params: 42]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/{id}"
+    end
+
+    test "raises when list entries are not PathParam structs" do
+      opts = [path_params: [id: path_param(42)]]
+
+      assert_raise ArgumentError,
+                   ~r/expected path_params to be a list of Tesla.PathParam structs in modern mode/,
+                   fn ->
+                     @middleware.call(
+                       %Env{url: "/users/{id}", opts: opts},
+                       [],
+                       mode: :modern
+                     )
+                   end
+    end
+
+    test "raises when modern path_params value is not a PathParam" do
+      opts = [path_params: [42]]
+
+      assert_raise ArgumentError,
+                   ~r/expected path_params to be a list of Tesla.PathParam structs in modern mode/,
+                   fn ->
+                     @middleware.call(
+                       %Env{url: "/users/{id}", opts: opts},
+                       [],
+                       mode: :modern
+                     )
+                   end
+    end
+
+    test "raises when modern path_params value is an option map instead of a PathParam" do
+      opts = [path_params: [%{style: :simple}]]
+
+      assert_raise ArgumentError,
+                   ~r/expected path_params to be a list of Tesla.PathParam structs in modern mode/,
+                   fn ->
+                     @middleware.call(
+                       %Env{url: "/users/{id}", opts: opts},
+                       [],
+                       mode: :modern
+                     )
+                   end
+    end
+
+    test "raises when modern path_params value is a struct instead of a PathParam" do
+      opts = [path_params: [%TestUser{id: 7}]]
+
+      assert_raise ArgumentError,
+                   ~r/expected path_params to be a list of Tesla.PathParam structs in modern mode/,
+                   fn ->
+                     @middleware.call(
+                       %Env{url: "/users/{id}", opts: opts},
+                       [],
+                       mode: :modern
+                     )
+                   end
+    end
+
+    test "matrix style: empty array serializes as OpenAPI undefined" do
+      opts = [path_params: [path_param([], style: :matrix, explode: false)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/;id"
+    end
+
+    test "matrix style: empty object serializes as OpenAPI undefined" do
+      opts = [path_params: [path_param(%{}, style: :matrix, explode: true)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/;id"
+    end
+
+    test "label style: empty array serializes as OpenAPI undefined" do
+      opts = [path_params: [path_param([], style: :label, explode: true)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/."
+    end
+
+    test "label style: empty object serializes as OpenAPI undefined" do
+      opts = [path_params: [path_param(%{}, style: :label, explode: false)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/."
+    end
+
+    test "RFC 3986 unreserved set (-, _, ., ~) is kept as-is" do
+      opts = [path_params: [path_param("a-b_c.d~e")]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: opts},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/a-b_c.d~e"
+    end
+
+    test "uses legacy behavior unless modern mode is matched" do
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{url: "/users/{id}", opts: [path_params: [id: 1]]},
+                 [],
+                 mode: :foo
+               )
+
+      assert env.url == "/users/1"
+    end
+  end
+end

--- a/test/tesla/middleware/path_params_test.exs
+++ b/test/tesla/middleware/path_params_test.exs
@@ -261,6 +261,13 @@ defmodule Tesla.Middleware.PathParamsTest do
 
       assert env.url == "/users/user%231/p/post%232"
     end
+
+    test "leaves URL untouched when path_params is an unsupported type" do
+      opts = [path_params: 42]
+
+      assert {:ok, env} = @middleware.call(%Env{url: "/users/{id}", opts: opts}, [], nil)
+      assert env.url == "/users/{id}"
+    end
   end
 
   describe "Mixed params (not recommended, {id} and :id)" do

--- a/test/tesla/path_param_test.exs
+++ b/test/tesla/path_param_test.exs
@@ -1,0 +1,141 @@
+defmodule Tesla.PathParamTest do
+  use ExUnit.Case, async: true
+
+  alias Tesla.Env
+  alias Tesla.PathParam
+
+  @middleware Tesla.Middleware.PathParams
+
+  test "uses default serialization options" do
+    assert %PathParam{
+             name: "id",
+             value: 42,
+             style: :simple,
+             explode: false,
+             allow_reserved: false
+           } = PathParam.new!("id", 42)
+  end
+
+  test "accepts explicit serialization options" do
+    assert %PathParam{
+             name: "id",
+             value: ["blue", "black"],
+             style: :label,
+             explode: true,
+             allow_reserved: true
+           } =
+             PathParam.new!("id", ["blue", "black"],
+               style: :label,
+               explode: true,
+               allow_reserved: true
+             )
+  end
+
+  test "does not inspect runtime values" do
+    inspected = inspect(PathParam.new!("token", "secret-token", style: :matrix))
+
+    refute inspected =~ "secret-token"
+    assert inspected =~ ~s(name: "token")
+    assert inspected =~ "style: :matrix"
+  end
+
+  test "serializes a path parameter with explicit keyword options" do
+    opts = [
+      path_params: [
+        PathParam.new!("coords", ["blue", "black"], style: :matrix, explode: true)
+      ]
+    ]
+
+    assert {:ok, env} =
+             @middleware.call(
+               %Env{url: "/items/{coords}", opts: opts},
+               [],
+               mode: :modern
+             )
+
+    assert env.url == "/items/;coords=blue;coords=black"
+  end
+
+  test "rejects document location as a hand-written option" do
+    assert_raise ArgumentError, ~r/unknown keys \[:in\]/, fn ->
+      PathParam.new!("color", "blue", in: :path)
+    end
+  end
+
+  test "rejects string styles in hand-written keyword options" do
+    assert_raise ArgumentError, ~r/expected :simple, :matrix, or :label/, fn ->
+      PathParam.new!("color", "blue", style: "matrix")
+    end
+  end
+
+  test "rejects non-path style atoms" do
+    for style <- [:form, :spaceDelimited, :pipeDelimited, :deepObject, :cookie] do
+      assert_raise ArgumentError, ~r/expected :simple, :matrix, or :label/, fn ->
+        PathParam.new!("color", "blue", style: style)
+      end
+    end
+  end
+
+  test "rejects non-string names" do
+    assert_raise ArgumentError, ~r/expected path parameter name to be a string/, fn ->
+      PathParam.new!(:color, "blue")
+    end
+  end
+
+  test "rejects non-boolean explode option" do
+    assert_raise ArgumentError, ~r/expected :explode to be a boolean/, fn ->
+      PathParam.new!("color", "blue", explode: "true")
+    end
+  end
+
+  test "rejects non-boolean allow_reserved option" do
+    assert_raise ArgumentError, ~r/expected :allow_reserved to be a boolean/, fn ->
+      PathParam.new!("color", "blue", allow_reserved: 1)
+    end
+  end
+
+  test "rejects atom-keyed maps as options" do
+    assert_raise ArgumentError, ~r/expected path parameter options to be a keyword list/, fn ->
+      PathParam.new!("color", "blue", %{style: :matrix})
+    end
+  end
+
+  test "rejects string-keyed maps as options" do
+    assert_raise ArgumentError, ~r/expected path parameter options to be a keyword list/, fn ->
+      PathParam.new!("color", "blue", %{"style" => :matrix})
+    end
+  end
+
+  test "rejects non-keyword lists as options" do
+    assert_raise ArgumentError, ~r/expected a keyword list/, fn ->
+      PathParam.new!("color", "blue", [:matrix])
+    end
+  end
+
+  test "accepts nil values" do
+    assert %PathParam{name: "color", value: nil, style: :matrix} =
+             PathParam.new!("color", nil, style: :matrix)
+  end
+
+  test "encodes values with the unreserved set by default" do
+    param = PathParam.new!("id", nil)
+
+    assert PathParam.encode_value(param, "AZaz09-_.~") == "AZaz09-_.~"
+    assert PathParam.encode_value(param, "a b/c?d#é%") == "a%20b%2Fc%3Fd%23%C3%A9%25"
+  end
+
+  test "encodes values while preserving allowed reserved path characters" do
+    param = PathParam.new!("id", nil, allow_reserved: true)
+
+    assert PathParam.encode_value(param, "!$&'()*+,;=:@") == "!$&'()*+,;=:@"
+    assert PathParam.encode_value(param, "/?#[] é") == "%2F%3F%23%5B%5D%20%C3%A9"
+    assert PathParam.encode_value(param, "") == ""
+  end
+
+  test "preserves valid percent triplets and escapes invalid ones when reserved are allowed" do
+    param = PathParam.new!("id", nil, allow_reserved: true)
+
+    assert PathParam.encode_value(param, "%20%2F%AF%af") == "%20%2F%AF%af"
+    assert PathParam.encode_value(param, "%2G%zz%") == "%252G%25zz%25"
+  end
+end


### PR DESCRIPTION
- OpenAPI-generated clients need a path-parameter contract that can express official serialization semantics without changing existing PathParams behavior.
- The opt-in path keeps legacy replacement stable for current callers while making spec-driven clients possible.
- A structured value object keeps path serialization explicit without accepting loosely shaped option maps.