### PR TITLE
feat: support OpenAPI-friendly query params

### DIFF
--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -44,6 +44,7 @@ defmodule Tesla.Env do
   @type query_scalar_list :: [query_scalar]
   @type query_pair :: {query_key, param}
   @type query_list :: [query_pair]
+  @type query_param :: Tesla.QueryParam.t()
   @type param :: query_scalar | query_scalar_list | query_list | %{optional(query_key) => param}
 
   @typedoc """
@@ -58,7 +59,7 @@ defmodule Tesla.Env do
   Map query params do not guarantee encoded parameter order. Pass an ordered list
   of pairs if the exact query string order matters.
   """
-  @type query :: [query_pair] | %{optional(query_key) => param}
+  @type query :: [query_pair] | [query_param] | %{optional(query_key) => param}
   @type headers :: [{binary, binary}]
 
   @type body :: any

--- a/lib/tesla/middleware/query.ex
+++ b/lib/tesla/middleware/query.ex
@@ -17,7 +17,11 @@ defmodule Tesla.Middleware.Query do
 
   @behaviour Tesla.Middleware
 
+  alias Tesla.Middleware.Query.Modern
+
   @impl Tesla.Middleware
+  def call(env, next, mode: :modern), do: Modern.call(env, next)
+
   def call(env, next, query) do
     env
     |> merge(query)

--- a/lib/tesla/middleware/query/modern.ex
+++ b/lib/tesla/middleware/query/modern.ex
@@ -1,0 +1,260 @@
+defmodule Tesla.Middleware.Query.Modern do
+  @moduledoc false
+
+  alias Tesla.QueryParam
+
+  def call(env, next) do
+    env
+    |> build_url()
+    |> Tesla.run(next)
+  end
+
+  defp build_url(%{query: nil} = env) do
+    %{env | query: []}
+  end
+
+  defp build_url(%{query: params} = env) when is_list(params) do
+    parts = Enum.flat_map(params, &serialize_param/1)
+
+    %{env | url: append_query(env.url, parts), query: []}
+  end
+
+  defp build_url(%{query: params}) do
+    raise ArgumentError,
+          "expected query to be a list of #{inspect(QueryParam)} structs in modern mode; got #{inspect(params)}"
+  end
+
+  defp append_query(url, []) do
+    url
+  end
+
+  defp append_query(url, parts) do
+    url = url || ""
+    separator = query_separator(url)
+
+    url <> separator <> Enum.join(parts, "&")
+  end
+
+  defp query_separator(url) do
+    case String.contains?(url, "?") do
+      true -> "&"
+      false -> "?"
+    end
+  end
+
+  defp serialize_param(%QueryParam{style: :form} = param) do
+    param
+    |> classify_param()
+    |> serialize_form(param)
+  end
+
+  defp serialize_param(%QueryParam{style: :space_delimited} = param) do
+    param
+    |> classify_param()
+    |> serialize_space_delimited(param)
+  end
+
+  defp serialize_param(%QueryParam{style: :pipe_delimited} = param) do
+    param
+    |> classify_param()
+    |> serialize_pipe_delimited(param)
+  end
+
+  defp serialize_param(%QueryParam{style: :deep_object} = param) do
+    param
+    |> classify_param()
+    |> serialize_deep_object(param)
+  end
+
+  defp serialize_param(param) do
+    raise ArgumentError,
+          "expected query to be a list of #{inspect(QueryParam)} structs in modern mode; got #{inspect(param)}"
+  end
+
+  defp serialize_form(:undefined, param) do
+    [serialize_empty(param)]
+  end
+
+  defp serialize_form({:primitive, value}, param) do
+    [serialize_named_value(param, value)]
+  end
+
+  defp serialize_form({:array, []}, _param) do
+    []
+  end
+
+  defp serialize_form({:array, items}, %QueryParam{explode: true} = param) do
+    Enum.map(items, &serialize_named_value(param, &1))
+  end
+
+  defp serialize_form({:array, items}, %QueryParam{explode: false} = param) do
+    [QueryParam.encode_name(param.name) <> "=" <> join_encoded_values(items, ",", param)]
+  end
+
+  defp serialize_form({:object, []}, _param) do
+    []
+  end
+
+  defp serialize_form({:object, pairs}, %QueryParam{explode: true} = param) do
+    Enum.map(pairs, &serialize_query_pair(&1, param))
+  end
+
+  defp serialize_form({:object, pairs}, %QueryParam{explode: false} = param) do
+    [
+      QueryParam.encode_name(param.name) <>
+        "=" <>
+        (pairs
+         |> flatten_pairs()
+         |> join_encoded_values(",", param))
+    ]
+  end
+
+  defp serialize_space_delimited(_classified, %QueryParam{explode: true} = param) do
+    raise ArgumentError,
+          ":space_delimited style does not define explode: true serialization for parameter #{inspect(param.name)}"
+  end
+
+  defp serialize_space_delimited({:array, []}, _param) do
+    []
+  end
+
+  defp serialize_space_delimited({:array, items}, param) do
+    [QueryParam.encode_name(param.name) <> "=" <> join_encoded_values(items, "%20", param)]
+  end
+
+  defp serialize_space_delimited({:object, []}, _param) do
+    []
+  end
+
+  defp serialize_space_delimited({:object, pairs}, param) do
+    [
+      QueryParam.encode_name(param.name) <>
+        "=" <>
+        (pairs
+         |> flatten_pairs()
+         |> join_encoded_values("%20", param))
+    ]
+  end
+
+  defp serialize_space_delimited(_classified, param) do
+    raise ArgumentError,
+          ":space_delimited style requires an array or object value for parameter #{inspect(param.name)}"
+  end
+
+  defp serialize_pipe_delimited(_classified, %QueryParam{explode: true} = param) do
+    raise ArgumentError,
+          ":pipe_delimited style does not define explode: true serialization for parameter #{inspect(param.name)}"
+  end
+
+  defp serialize_pipe_delimited({:array, []}, _param) do
+    []
+  end
+
+  defp serialize_pipe_delimited({:array, items}, param) do
+    [QueryParam.encode_name(param.name) <> "=" <> join_encoded_values(items, "%7C", param)]
+  end
+
+  defp serialize_pipe_delimited({:object, []}, _param) do
+    []
+  end
+
+  defp serialize_pipe_delimited({:object, pairs}, param) do
+    [
+      QueryParam.encode_name(param.name) <>
+        "=" <>
+        (pairs
+         |> flatten_pairs()
+         |> join_encoded_values("%7C", param))
+    ]
+  end
+
+  defp serialize_pipe_delimited(_classified, param) do
+    raise ArgumentError,
+          ":pipe_delimited style requires an array or object value for parameter #{inspect(param.name)}"
+  end
+
+  defp serialize_deep_object({:object, []}, _param) do
+    []
+  end
+
+  defp serialize_deep_object({:object, pairs}, param) do
+    Enum.map(pairs, &serialize_deep_object_pair(&1, param))
+  end
+
+  defp serialize_deep_object(_classified, param) do
+    raise ArgumentError,
+          ":deep_object style requires an object value for parameter #{inspect(param.name)}"
+  end
+
+  defp serialize_empty(param) do
+    QueryParam.encode_name(param.name) <> "="
+  end
+
+  defp serialize_named_value(param, value) do
+    QueryParam.encode_name(param.name) <> "=" <> QueryParam.encode_value(param, value)
+  end
+
+  defp serialize_query_pair({key, value}, param) do
+    QueryParam.encode_name(key) <> "=" <> QueryParam.encode_value(param, value)
+  end
+
+  defp serialize_deep_object_pair({key, value}, param) do
+    QueryParam.encode_name(param.name) <>
+      "%5B" <> QueryParam.encode_name(key) <> "%5D=" <> QueryParam.encode_value(param, value)
+  end
+
+  defp flatten_pairs(pairs) do
+    Enum.flat_map(pairs, &pair_values/1)
+  end
+
+  defp pair_values({key, value}) do
+    [key, value]
+  end
+
+  defp join_encoded_values(values, separator, param) do
+    Enum.map_join(values, separator, &QueryParam.encode_value(param, &1))
+  end
+
+  defp classify_param(%QueryParam{value: value}) do
+    classify_value(value)
+  end
+
+  defp classify_value(nil) do
+    :undefined
+  end
+
+  defp classify_value(value) when is_struct(value) do
+    classify_value(Map.from_struct(value))
+  end
+
+  defp classify_value(value) when is_map(value) do
+    {:object, value |> Map.to_list() |> Enum.map(&stringify_pair/1)}
+  end
+
+  defp classify_value([]) do
+    {:array, []}
+  end
+
+  defp classify_value(value) when is_list(value) do
+    case Enum.all?(value, &object_pair?/1) do
+      true -> {:object, Enum.map(value, &stringify_pair/1)}
+      false -> {:array, value}
+    end
+  end
+
+  defp classify_value(value) do
+    {:primitive, value}
+  end
+
+  defp stringify_pair({key, value}) do
+    {to_string(key), value}
+  end
+
+  defp object_pair?({key, _value}) when is_atom(key) or is_binary(key) do
+    true
+  end
+
+  defp object_pair?(_value) do
+    false
+  end
+end

--- a/lib/tesla/query_param.ex
+++ b/lib/tesla/query_param.ex
@@ -1,0 +1,228 @@
+defmodule Tesla.QueryParam do
+  @moduledoc """
+  A query parameter with explicit serialization settings.
+
+  `Tesla.QueryParam` is a Tesla-native value object for query parameters whose
+  serialization needs to be controlled explicitly. Its serialization options
+  follow the OpenAPI query parameter style semantics, while keeping the public
+  API focused on the query use case.
+
+  In `Tesla.Middleware.Query` `:modern` mode, wrap each query parameter
+  explicitly, even when the default query serialization is enough:
+
+      query: [QueryParam.new!("id", 42)]
+
+  Pass options when a value needs non-default query serialization:
+
+      alias Tesla.QueryParam
+
+      query: [
+        QueryParam.new!("ids", [1, 2, 3], style: :pipe_delimited)
+      ]
+
+  ## Options
+
+  `new!/3` accepts a keyword list using Elixir atoms for hand-written Tesla
+  code:
+
+    * `:style` - one of `:form`, `:space_delimited`, `:pipe_delimited`, or
+      `:deep_object`. Defaults to `:form`.
+    * `:explode` - boolean. Defaults to `true` when the style is `:form`,
+      and `false` for all other styles.
+    * `:allow_reserved` - boolean. Defaults to `false`.
+
+  [oas-style]: https://spec.openapis.org/oas/latest.html#style-values
+
+  ## Encoding
+
+  `Tesla.Middleware.Query` serializes `Tesla.QueryParam` values using the
+  [OpenAPI query parameter rules][oas-style] for the `form`, `space_delimited`,
+  `pipe_delimited`, and `deep_object` styles. Serialized names and values are
+  percent-encoded against the RFC 3986 unreserved set (`A-Z`, `a-z`, `0-9`,
+  `-`, `_`, `.`, `~`); spaces become `%20` (not `+`).
+
+  With `allow_reserved: true`, reserved characters and already-encoded percent
+  triples in values are preserved. Names are always encoded with the default
+  query-name encoding.
+
+  ## Object Value Ordering
+
+  Object values may be passed as maps, structs, or keyword lists. Keyword lists
+  preserve insertion order; map iteration order is intrinsic and not guaranteed
+  across Elixir versions. Pass an ordered keyword list when the exact
+  serialized order matters.
+
+  ## Missing And Empty Values
+
+  Skip a query parameter by leaving it out of `env.query`. A `nil` value
+  represents the OpenAPI "undefined" value and only has a defined serialization
+  for `:form`.
+  """
+
+  @derive {Inspect, except: [:value]}
+  @enforce_keys [:name, :value, :style, :explode, :allow_reserved]
+  defstruct [:name, :value, :style, :explode, :allow_reserved]
+
+  @type style :: :form | :space_delimited | :pipe_delimited | :deep_object
+  @opaque t :: %__MODULE__{
+            name: String.t(),
+            value: term(),
+            style: style(),
+            explode: boolean(),
+            allow_reserved: boolean()
+          }
+
+  @styles [:form, :space_delimited, :pipe_delimited, :deep_object]
+  @reserved ~c":/?#[]@!$&'()*+,;="
+
+  @spec new!(String.t(), term(), keyword()) :: t()
+  def new!(name, value, opts \\ [])
+
+  def new!(name, value, opts) when is_binary(name) and is_list(opts) do
+    build!(opts, name, value)
+  end
+
+  def new!(name, _value, _opts) when not is_binary(name) do
+    raise ArgumentError, "expected query parameter name to be a string; got #{inspect(name)}"
+  end
+
+  def new!(_name, _value, opts) do
+    raise ArgumentError,
+          "expected query parameter options to be a keyword list; got #{inspect(opts)}"
+  end
+
+  @doc false
+  @spec encode_name(term()) :: String.t()
+  def encode_name(value) do
+    value
+    |> to_string()
+    |> URI.encode(&unreserved?/1)
+  end
+
+  @doc false
+  @spec encode_value(%__MODULE__{}, term()) :: String.t()
+  def encode_value(%__MODULE__{allow_reserved: false}, value) do
+    value
+    |> to_string()
+    |> URI.encode(&unreserved?/1)
+  end
+
+  def encode_value(%__MODULE__{allow_reserved: true}, value) do
+    value
+    |> to_string()
+    |> encode_reserved()
+  end
+
+  defp build!(opts, name, value) do
+    opts = Keyword.validate!(opts, [:style, :explode, :allow_reserved])
+    style = opts |> Keyword.get(:style, :form) |> validate_style!()
+
+    %__MODULE__{
+      name: name,
+      value: value,
+      style: style,
+      explode:
+        opts |> Keyword.get(:explode, default_explode(style)) |> validate_boolean!(:explode),
+      allow_reserved:
+        opts |> Keyword.get(:allow_reserved, false) |> validate_boolean!(:allow_reserved)
+    }
+  end
+
+  defp validate_style!(style) when style in @styles do
+    style
+  end
+
+  defp validate_style!(style) do
+    raise ArgumentError,
+          "unknown query parameter style #{inspect(style)}; expected :form, :space_delimited, :pipe_delimited, or :deep_object"
+  end
+
+  defp validate_boolean!(value, _key) when is_boolean(value) do
+    value
+  end
+
+  defp validate_boolean!(value, key) do
+    raise ArgumentError,
+          "expected query parameter #{inspect(key)} to be a boolean; got #{inspect(value)}"
+  end
+
+  defp default_explode(:form) do
+    true
+  end
+
+  defp default_explode(_style) do
+    false
+  end
+
+  defp encode_reserved(<<>>) do
+    ""
+  end
+
+  defp encode_reserved(<<"%", high, low, rest::binary>>) do
+    case hex_digit?(high) and hex_digit?(low) do
+      true ->
+        "%" <> <<high, low>> <> encode_reserved(rest)
+
+      false ->
+        "%25" <> encode_reserved(<<high, low, rest::binary>>)
+    end
+  end
+
+  defp encode_reserved(<<"%", rest::binary>>) do
+    "%25" <> encode_reserved(rest)
+  end
+
+  defp encode_reserved(<<byte, rest::binary>>) do
+    case unreserved_or_reserved?(byte) do
+      true ->
+        <<byte>> <> encode_reserved(rest)
+
+      false ->
+        percent_encode_byte(byte) <> encode_reserved(rest)
+    end
+  end
+
+  defp percent_encode_byte(byte) do
+    "%" <> Base.encode16(<<byte>>)
+  end
+
+  defp hex_digit?(byte) when byte in ?0..?9 do
+    true
+  end
+
+  defp hex_digit?(byte) when byte in ?A..?F do
+    true
+  end
+
+  defp hex_digit?(byte) when byte in ?a..?f do
+    true
+  end
+
+  defp hex_digit?(_byte) do
+    false
+  end
+
+  defp unreserved_or_reserved?(byte) do
+    unreserved?(byte) or byte in @reserved
+  end
+
+  defp unreserved?(byte) when byte in ?A..?Z do
+    true
+  end
+
+  defp unreserved?(byte) when byte in ?a..?z do
+    true
+  end
+
+  defp unreserved?(byte) when byte in ?0..?9 do
+    true
+  end
+
+  defp unreserved?(byte) when byte in [?-, ?_, ?., ?~] do
+    true
+  end
+
+  defp unreserved?(_byte) do
+    false
+  end
+end

--- a/test/tesla/middleware/path_params/modern_test.exs
+++ b/test/tesla/middleware/path_params/modern_test.exs
@@ -458,7 +458,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
   end
 
   describe "mode: :modern — OpenAPI path serialization limits" do
-    for style <- [:form, :spaceDelimited, :pipeDelimited, :deepObject, :cookie] do
+    for style <- [:form, :space_delimited, :pipe_delimited, :deep_object, :cookie] do
       test "rejects non-path style #{style}" do
         assert_raise ArgumentError, ~r/expected :simple, :matrix, or :label/, fn ->
           path_param("color", "blue", style: unquote(style))

--- a/test/tesla/middleware/query/modern_test.exs
+++ b/test/tesla/middleware/query/modern_test.exs
@@ -1,0 +1,347 @@
+defmodule Tesla.Middleware.Query.ModernTest do
+  use ExUnit.Case
+
+  alias Tesla.Env
+  alias Tesla.Middleware.Query
+  alias Tesla.QueryParam
+
+  defmodule TestFilter do
+    defstruct [:role, :id]
+  end
+
+  describe "OpenAPI style examples" do
+    test "form style with explode false" do
+      assert_url(QueryParam.new!("color", nil, explode: false), "/colors?color=")
+      assert_url(QueryParam.new!("color", "blue", explode: false), "/colors?color=blue")
+
+      assert_url(
+        QueryParam.new!("color", ["blue", "black", "brown"], explode: false),
+        "/colors?color=blue,black,brown"
+      )
+
+      assert_url(
+        QueryParam.new!("color", [R: 100, G: 200, B: 150], explode: false),
+        "/colors?color=R,100,G,200,B,150"
+      )
+    end
+
+    test "form style with explode true" do
+      assert_url(QueryParam.new!("color", nil), "/colors?color=")
+      assert_url(QueryParam.new!("color", "blue"), "/colors?color=blue")
+
+      assert_url(
+        QueryParam.new!("color", ["blue", "black", "brown"]),
+        "/colors?color=blue&color=black&color=brown"
+      )
+
+      assert_url(
+        QueryParam.new!("color", R: 100, G: 200, B: 150),
+        "/colors?R=100&G=200&B=150"
+      )
+    end
+
+    test "space_delimited style with explode false" do
+      assert_url(
+        QueryParam.new!("color", ["blue", "black", "brown"], style: :space_delimited),
+        "/colors?color=blue%20black%20brown"
+      )
+
+      assert_url(
+        QueryParam.new!("color", [R: 100, G: 200, B: 150], style: :space_delimited),
+        "/colors?color=R%20100%20G%20200%20B%20150"
+      )
+    end
+
+    test "pipe_delimited style with explode false" do
+      assert_url(
+        QueryParam.new!("color", ["blue", "black", "brown"], style: :pipe_delimited),
+        "/colors?color=blue%7Cblack%7Cbrown"
+      )
+
+      assert_url(
+        QueryParam.new!("color", [R: 100, G: 200, B: 150], style: :pipe_delimited),
+        "/colors?color=R%7C100%7CG%7C200%7CB%7C150"
+      )
+    end
+
+    test "deep_object style" do
+      assert_url(
+        QueryParam.new!("color", [R: 100, G: 200, B: 150], style: :deep_object),
+        "/colors?color%5BR%5D=100&color%5BG%5D=200&color%5BB%5D=150"
+      )
+    end
+  end
+
+  describe "modern mode contract" do
+    test "serializes a representative multi-style query" do
+      assert_url(
+        [
+          QueryParam.new!("page", 1),
+          QueryParam.new!("tags", ["blue", "black"]),
+          QueryParam.new!("ids", [1, 2, 3], style: :pipe_delimited),
+          QueryParam.new!("filter", [role: "admin"], style: :deep_object)
+        ],
+        "/colors?page=1&tags=blue&tags=black&ids=1%7C2%7C3&filter%5Brole%5D=admin"
+      )
+    end
+
+    test "appends to an existing query string" do
+      assert_url(QueryParam.new!("page", 2), "/colors?existing=1&page=2", "/colors?existing=1")
+    end
+
+    test "clears env.query so downstream URL builders do not encode twice" do
+      assert {:ok, env} =
+               Query.call(
+                 %Env{url: "/colors", query: [QueryParam.new!("page", 1)]},
+                 [],
+                 mode: :modern
+               )
+
+      assert env.query == []
+    end
+
+    test "leaves URL untouched when query is empty" do
+      assert {:ok, env} = Query.call(%Env{url: "/colors", query: []}, [], mode: :modern)
+
+      assert env.url == "/colors"
+      assert env.query == []
+    end
+
+    test "leaves URL untouched when query is nil" do
+      assert {:ok, env} = Query.call(%Env{url: "/colors", query: nil}, [], mode: :modern)
+
+      assert env.url == "/colors"
+      assert env.query == []
+    end
+
+    test "requires query to be a list of QueryParam structs" do
+      assert_raise ArgumentError,
+                   ~r/expected query to be a list of Tesla.QueryParam structs/,
+                   fn ->
+                     Query.call(%Env{url: "/colors", query: [id: 1]}, [], mode: :modern)
+                   end
+    end
+
+    test "rejects map-shaped query params" do
+      assert_raise ArgumentError,
+                   ~r/expected query to be a list of Tesla.QueryParam structs/,
+                   fn ->
+                     Query.call(%Env{url: "/colors", query: %{id: 1}}, [], mode: :modern)
+                   end
+    end
+
+    test "rejects tuple-style rich values from the old PR shape" do
+      assert_raise ArgumentError,
+                   ~r/expected query to be a list of Tesla.QueryParam structs/,
+                   fn ->
+                     Query.call(%Env{url: "/colors", query: [id: {1, style: :form}]}, [],
+                       mode: :modern
+                     )
+                   end
+    end
+  end
+
+  describe "OpenAPI style rules" do
+    for {style, value, label} <- [
+          {:space_delimited, nil, "undefined"},
+          {:space_delimited, "blue", "string"},
+          {:pipe_delimited, nil, "undefined"},
+          {:pipe_delimited, "blue", "string"}
+        ] do
+      test "#{style} with explode false rejects #{label}" do
+        assert_raise ArgumentError, fn ->
+          assert_url(
+            QueryParam.new!("color", unquote(Macro.escape(value)), style: unquote(style)),
+            "/colors"
+          )
+        end
+      end
+    end
+
+    for {style, value, label} <- [
+          {:space_delimited, nil, "undefined"},
+          {:space_delimited, "blue", "string"},
+          {:space_delimited, ["blue"], "array"},
+          {:space_delimited, [R: 100], "object"},
+          {:pipe_delimited, nil, "undefined"},
+          {:pipe_delimited, "blue", "string"},
+          {:pipe_delimited, ["blue"], "array"},
+          {:pipe_delimited, [R: 100], "object"}
+        ] do
+      test "#{style} with explode true rejects #{label}" do
+        assert_raise ArgumentError, fn ->
+          assert_url(
+            QueryParam.new!("color", unquote(Macro.escape(value)),
+              style: unquote(style),
+              explode: true
+            ),
+            "/colors"
+          )
+        end
+      end
+    end
+
+    for {value, label} <- [
+          {nil, "undefined"},
+          {"blue", "string"},
+          {["blue"], "array"}
+        ] do
+      test "deep_object rejects #{label}" do
+        assert_raise ArgumentError, fn ->
+          assert_url(
+            QueryParam.new!("color", unquote(Macro.escape(value)), style: :deep_object),
+            "/colors"
+          )
+        end
+      end
+    end
+
+    test "space_delimited does not define explode true" do
+      assert_raise ArgumentError, ~r/:space_delimited style does not define explode: true/, fn ->
+        assert_url(
+          QueryParam.new!("color", ["blue"], style: :space_delimited, explode: true),
+          "/colors?color=blue"
+        )
+      end
+    end
+
+    test "space_delimited requires an array or object" do
+      assert_raise ArgumentError,
+                   ~r/:space_delimited style requires an array or object value/,
+                   fn ->
+                     assert_url(
+                       QueryParam.new!("color", "blue", style: :space_delimited),
+                       "/colors?color=blue"
+                     )
+                   end
+    end
+
+    test "pipe_delimited does not define explode true" do
+      assert_raise ArgumentError, ~r/:pipe_delimited style does not define explode: true/, fn ->
+        assert_url(
+          QueryParam.new!("color", ["blue"], style: :pipe_delimited, explode: true),
+          "/colors?color=blue"
+        )
+      end
+    end
+
+    test "pipe_delimited requires an array or object" do
+      assert_raise ArgumentError,
+                   ~r/:pipe_delimited style requires an array or object value/,
+                   fn ->
+                     assert_url(
+                       QueryParam.new!("color", "blue", style: :pipe_delimited),
+                       "/colors?color=blue"
+                     )
+                   end
+    end
+
+    test "deep_object requires an object" do
+      assert_raise ArgumentError, ~r/:deep_object style requires an object value/, fn ->
+        assert_url(QueryParam.new!("color", ["blue"], style: :deep_object), "/colors?color=blue")
+      end
+    end
+
+    test "deep_object ignores explode" do
+      assert_url(
+        QueryParam.new!("color", [R: 100], style: :deep_object, explode: true),
+        "/colors?color%5BR%5D=100"
+      )
+
+      assert_url(
+        QueryParam.new!("color", [R: 100], style: :deep_object, explode: false),
+        "/colors?color%5BR%5D=100"
+      )
+    end
+  end
+
+  describe "encoding" do
+    test "percent-encodes reserved characters by default" do
+      assert_url(QueryParam.new!("q", "a/b c#d"), "/colors?q=a%2Fb%20c%23d")
+    end
+
+    test "keeps reserved characters in values when allow_reserved is true" do
+      assert_url(QueryParam.new!("q", "a/b c#d", allow_reserved: true), "/colors?q=a/b%20c#d")
+    end
+
+    test "spaces become percent-encoded spaces, not plus signs" do
+      assert_url(QueryParam.new!("q", "John Smith"), "/colors?q=John%20Smith")
+    end
+
+    test "unreserved characters stay as-is" do
+      assert_url(QueryParam.new!("q", "a-b_c.d~e"), "/colors?q=a-b_c.d~e")
+    end
+
+    test "query names are encoded even when allow_reserved is true" do
+      assert_url(
+        QueryParam.new!("filter[role]", "admin", allow_reserved: true),
+        "/colors?filter%5Brole%5D=admin"
+      )
+    end
+  end
+
+  describe "object values" do
+    test "supports struct values as objects" do
+      assert {:ok, env} =
+               Query.call(
+                 %Env{
+                   url: "/colors",
+                   query: [
+                     QueryParam.new!("filter", %TestFilter{role: "admin", id: 5},
+                       style: :deep_object
+                     )
+                   ]
+                 },
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url =~ "filter%5Brole%5D=admin"
+      assert env.url =~ "filter%5Bid%5D=5"
+    end
+
+    test "omits empty arrays and objects" do
+      assert_url(
+        [
+          QueryParam.new!("empty_array", []),
+          QueryParam.new!("empty_form_object", %{}),
+          QueryParam.new!("empty_object", []),
+          QueryParam.new!("empty_map", %{}, style: :deep_object),
+          QueryParam.new!("present", 1)
+        ],
+        "/colors?present=1"
+      )
+    end
+
+    test "omits empty arrays and objects for delimited styles" do
+      assert_url(
+        [
+          QueryParam.new!("empty_space_array", [], style: :space_delimited),
+          QueryParam.new!("empty_space_object", %{}, style: :space_delimited),
+          QueryParam.new!("empty_pipe_array", [], style: :pipe_delimited),
+          QueryParam.new!("empty_pipe_object", %{}, style: :pipe_delimited),
+          QueryParam.new!("present", 1)
+        ],
+        "/colors?present=1"
+      )
+    end
+  end
+
+  defp assert_url(%QueryParam{} = param, expected_url) do
+    assert_url([param], expected_url)
+  end
+
+  defp assert_url(params, expected_url) when is_list(params) do
+    assert_url(params, expected_url, "/colors")
+  end
+
+  defp assert_url(%QueryParam{} = param, expected_url, url) do
+    assert_url([param], expected_url, url)
+  end
+
+  defp assert_url(params, expected_url, url) when is_list(params) do
+    assert {:ok, env} = Query.call(%Env{url: url, query: params}, [], mode: :modern)
+
+    assert env.url == expected_url
+  end
+end

--- a/test/tesla/middleware/query_test.exs
+++ b/test/tesla/middleware/query_test.exs
@@ -9,6 +9,11 @@ defmodule Tesla.Middleware.QueryTest do
     assert env.query == [page: 1]
   end
 
+  test "ignores nil default query params" do
+    assert {:ok, env} = @middleware.call(%Env{query: [page: 1]}, [], nil)
+    assert env.query == [page: 1]
+  end
+
   test "should not override existing key" do
     assert {:ok, env} = @middleware.call(%Env{query: [page: 1]}, [], page: 5)
     assert env.query == [page: 1, page: 5]

--- a/test/tesla/path_param_test.exs
+++ b/test/tesla/path_param_test.exs
@@ -69,7 +69,7 @@ defmodule Tesla.PathParamTest do
   end
 
   test "rejects non-path style atoms" do
-    for style <- [:form, :spaceDelimited, :pipeDelimited, :deepObject, :cookie] do
+    for style <- [:form, :space_delimited, :pipe_delimited, :deep_object, :cookie] do
       assert_raise ArgumentError, ~r/expected :simple, :matrix, or :label/, fn ->
         PathParam.new!("color", "blue", style: style)
       end

--- a/test/tesla/query_param_test.exs
+++ b/test/tesla/query_param_test.exs
@@ -1,0 +1,105 @@
+defmodule Tesla.QueryParamTest do
+  use ExUnit.Case
+
+  alias Tesla.QueryParam
+
+  test "builds a form query parameter by default" do
+    assert %QueryParam{
+             name: "id",
+             value: 42,
+             style: :form,
+             explode: true,
+             allow_reserved: false
+           } = QueryParam.new!("id", 42)
+  end
+
+  test "defaults explode to false for non-form styles" do
+    assert %QueryParam{explode: false} = QueryParam.new!("ids", [1, 2], style: :pipe_delimited)
+    assert %QueryParam{explode: false} = QueryParam.new!("ids", [1, 2], style: :space_delimited)
+    assert %QueryParam{explode: false} = QueryParam.new!("filter", [id: 1], style: :deep_object)
+  end
+
+  test "accepts nil values" do
+    assert %QueryParam{name: "filter", value: nil} = QueryParam.new!("filter", nil)
+  end
+
+  test "derives inspect without the value" do
+    inspected = inspect(QueryParam.new!("token", "secret"))
+
+    assert inspected =~ "#Tesla.QueryParam<"
+    refute inspected =~ "secret"
+  end
+
+  test "rejects non-string names" do
+    assert_raise ArgumentError, ~r/expected query parameter name to be a string/, fn ->
+      QueryParam.new!(:id, 42)
+    end
+  end
+
+  test "rejects non-keyword options" do
+    assert_raise ArgumentError, ~r/expected query parameter options to be a keyword list/, fn ->
+      QueryParam.new!("id", 42, %{style: :form})
+    end
+  end
+
+  test "rejects string option keys" do
+    assert_raise ArgumentError, ~r/expected a keyword list/, fn ->
+      QueryParam.new!("id", 42, [{"style", :form}])
+    end
+  end
+
+  test "rejects unknown option keys" do
+    assert_raise ArgumentError, ~r/unknown keys/, fn ->
+      QueryParam.new!("id", 42, style: :form, future_field: true)
+    end
+  end
+
+  test "rejects unknown styles" do
+    assert_raise ArgumentError, ~r/unknown query parameter style :matrix/, fn ->
+      QueryParam.new!("id", 42, style: :matrix)
+    end
+  end
+
+  test "rejects string styles" do
+    assert_raise ArgumentError, ~r/unknown query parameter style "form"/, fn ->
+      QueryParam.new!("id", 42, style: "form")
+    end
+  end
+
+  test "rejects non-boolean explode" do
+    assert_raise ArgumentError, ~r/expected query parameter :explode to be a boolean/, fn ->
+      QueryParam.new!("id", 42, explode: "true")
+    end
+  end
+
+  test "rejects non-boolean allow_reserved" do
+    assert_raise ArgumentError,
+                 ~r/expected query parameter :allow_reserved to be a boolean/,
+                 fn ->
+                   QueryParam.new!("id", 42, allow_reserved: "true")
+                 end
+  end
+
+  test "encodes names with default query-name encoding" do
+    assert QueryParam.encode_name("filter[role]") == "filter%5Brole%5D"
+  end
+
+  test "encodes values against the unreserved set by default" do
+    param = QueryParam.new!("q", nil)
+
+    assert QueryParam.encode_value(param, "a/b c#d|") == "a%2Fb%20c%23d%7C"
+  end
+
+  test "preserves reserved values and percent triples when allow_reserved is true" do
+    param = QueryParam.new!("q", nil, allow_reserved: true)
+
+    assert QueryParam.encode_value(param, "a/b?c#d%2Fe %zz|") ==
+             "a/b?c#d%2Fe%20%25zz%7C"
+  end
+
+  test "preserves lowercase percent triples and escapes incomplete percent sequences" do
+    param = QueryParam.new!("q", nil, allow_reserved: true)
+
+    assert QueryParam.encode_value(param, "%2f%") == "%2f%25"
+  end
+end


### PR DESCRIPTION
- Make OpenAPI-style query serialization an explicit opt-in path without changing legacy query merging.\n- Keep generated and hand-written clients on the same structured parameter contract.