### PR TITLE
chore: share parameter helpers

### DIFF
--- a/lib/tesla/header_param.ex
+++ b/lib/tesla/header_param.ex
@@ -39,6 +39,8 @@ defmodule Tesla.HeaderParam do
   serialized order matters.
   """
 
+  alias Tesla.Param
+
   @derive {Inspect, except: [:value]}
   @enforce_keys [:name, :value, :style, :explode]
   defstruct [:name, :value, :style, :explode]
@@ -51,54 +53,30 @@ defmodule Tesla.HeaderParam do
             explode: boolean()
           }
 
+  @styles [:simple]
+  @expected_styles ":simple"
+
   @spec new!(String.t(), term(), keyword()) :: t()
-  def new!(name, value, opts \\ [])
-
-  def new!(name, value, opts) when is_binary(name) and is_list(opts) do
-    build!(opts, name, value)
-  end
-
-  def new!(name, _value, _opts) when not is_binary(name) do
-    raise ArgumentError, "expected header parameter name to be a string; got #{inspect(name)}"
-  end
-
-  def new!(_name, _value, opts) do
-    raise ArgumentError,
-          "expected header parameter options to be a keyword list; got #{inspect(opts)}"
-  end
-
-  @spec to_header(t()) :: {String.t(), String.t()}
-  def to_header(%__MODULE__{} = param) do
-    {param.name, serialize(param)}
-  end
-
-  defp build!(opts, name, value) do
+  def new!(name, value, opts \\ []) do
+    name = Param.validate_name!(:header, name)
+    opts = Param.validate_opts!(:header, opts)
     opts = Keyword.validate!(opts, style: :simple, explode: false)
 
     %__MODULE__{
       name: name,
       value: value,
-      style: opts[:style] |> validate_style!(),
-      explode: validate_boolean!(:explode, opts[:explode])
+      style: validate_style!(opts[:style]),
+      explode: Param.validate_explode!(:header, opts[:explode])
     }
   end
 
-  defp validate_style!(:simple) do
-    :simple
-  end
-
   defp validate_style!(style) do
-    raise ArgumentError,
-          "unknown header parameter style #{inspect(style)}; expected :simple"
+    Param.validate_style!(style, @styles, :header, @expected_styles)
   end
 
-  defp validate_boolean!(_key, value) when is_boolean(value) do
-    value
-  end
-
-  defp validate_boolean!(key, value) do
-    raise ArgumentError,
-          "expected header parameter #{inspect(key)} to be a boolean; got #{inspect(value)}"
+  @spec to_header(t()) :: {String.t(), String.t()}
+  def to_header(%__MODULE__{} = param) do
+    {param.name, serialize(param)}
   end
 
   defp serialize(param) do
@@ -121,7 +99,7 @@ defmodule Tesla.HeaderParam do
 
   defp serialize_simple({:object, pairs}, %__MODULE__{explode: false}) do
     pairs
-    |> flatten_pairs()
+    |> Param.flatten_pairs()
     |> Enum.map_join(",", &to_string/1)
   end
 
@@ -133,54 +111,7 @@ defmodule Tesla.HeaderParam do
     "#{key}=#{value}"
   end
 
-  defp flatten_pairs(pairs) do
-    Enum.flat_map(pairs, &pair_values/1)
-  end
-
-  defp pair_values({key, value}) do
-    [key, value]
-  end
-
   defp classify_param(%__MODULE__{value: value}) do
-    classify_value(value)
-  end
-
-  defp classify_value(nil) do
-    :undefined
-  end
-
-  defp classify_value(value) when is_struct(value) do
-    classify_value(Map.from_struct(value))
-  end
-
-  defp classify_value(value) when is_map(value) do
-    {:object, value |> Map.to_list() |> Enum.map(&stringify_pair/1)}
-  end
-
-  defp classify_value([]) do
-    {:array, []}
-  end
-
-  defp classify_value(value) when is_list(value) do
-    case Enum.all?(value, &object_pair?/1) do
-      true -> {:object, Enum.map(value, &stringify_pair/1)}
-      false -> {:array, value}
-    end
-  end
-
-  defp classify_value(value) do
-    {:primitive, value}
-  end
-
-  defp stringify_pair({key, value}) do
-    {to_string(key), value}
-  end
-
-  defp object_pair?({key, _value}) when is_atom(key) or is_binary(key) do
-    true
-  end
-
-  defp object_pair?(_value) do
-    false
+    Param.classify_value(value)
   end
 end

--- a/lib/tesla/middleware/path_params/modern.ex
+++ b/lib/tesla/middleware/path_params/modern.ex
@@ -1,6 +1,7 @@
 defmodule Tesla.Middleware.PathParams.Modern do
   @moduledoc false
 
+  alias Tesla.Param
   alias Tesla.PathParam
 
   def call(env, next) do
@@ -105,7 +106,7 @@ defmodule Tesla.Middleware.PathParams.Modern do
 
   defp serialize_simple({:object, pairs}, %PathParam{explode: false} = param) do
     pairs
-    |> flatten_pairs()
+    |> Param.flatten_pairs()
     |> join_encoded_values(",", param)
   end
 
@@ -141,7 +142,7 @@ defmodule Tesla.Middleware.PathParams.Modern do
       PathParam.encode_value(param, param.name) <>
       "=" <>
       (pairs
-       |> flatten_pairs()
+       |> Param.flatten_pairs()
        |> join_encoded_values(",", param))
   end
 
@@ -172,7 +173,7 @@ defmodule Tesla.Middleware.PathParams.Modern do
   defp serialize_label({:object, pairs}, %PathParam{explode: false} = param) do
     "." <>
       (pairs
-       |> flatten_pairs()
+       |> Param.flatten_pairs()
        |> join_encoded_values(",", param))
   end
 
@@ -193,54 +194,11 @@ defmodule Tesla.Middleware.PathParams.Modern do
     "#{PathParam.encode_value(param, key)}=#{PathParam.encode_value(param, value)}"
   end
 
-  defp flatten_pairs(pairs) do
-    Enum.flat_map(pairs, &pair_values/1)
-  end
-
-  defp pair_values({key, value}) do
-    [key, value]
-  end
-
   defp join_encoded_values(values, separator, param) do
     Enum.map_join(values, separator, &PathParam.encode_value(param, &1))
   end
 
   defp classify_param(%PathParam{value: value}) do
-    classify_value(value)
-  end
-
-  defp classify_value(value) when is_struct(value) do
-    classify_value(Map.from_struct(value))
-  end
-
-  defp classify_value(value) when is_map(value) do
-    {:object, value |> Map.to_list() |> Enum.map(&stringify_pair/1)}
-  end
-
-  defp classify_value([]) do
-    {:array, []}
-  end
-
-  defp classify_value(value) when is_list(value) do
-    case Enum.all?(value, &object_pair?/1) do
-      true -> {:object, Enum.map(value, &stringify_pair/1)}
-      false -> {:array, value}
-    end
-  end
-
-  defp classify_value(value) do
-    {:primitive, value}
-  end
-
-  defp stringify_pair({key, value}) do
-    {to_string(key), value}
-  end
-
-  defp object_pair?({key, _value}) when is_atom(key) or is_binary(key) do
-    true
-  end
-
-  defp object_pair?(_value) do
-    false
+    Param.classify_value(value)
   end
 end

--- a/lib/tesla/middleware/query/modern.ex
+++ b/lib/tesla/middleware/query/modern.ex
@@ -1,6 +1,7 @@
 defmodule Tesla.Middleware.Query.Modern do
   @moduledoc false
 
+  alias Tesla.Param
   alias Tesla.QueryParam
 
   def call(env, next) do
@@ -104,7 +105,7 @@ defmodule Tesla.Middleware.Query.Modern do
       QueryParam.encode_name(param.name) <>
         "=" <>
         (pairs
-         |> flatten_pairs()
+         |> Param.flatten_pairs()
          |> join_encoded_values(",", param))
     ]
   end
@@ -131,7 +132,7 @@ defmodule Tesla.Middleware.Query.Modern do
       QueryParam.encode_name(param.name) <>
         "=" <>
         (pairs
-         |> flatten_pairs()
+         |> Param.flatten_pairs()
          |> join_encoded_values("%20", param))
     ]
   end
@@ -163,7 +164,7 @@ defmodule Tesla.Middleware.Query.Modern do
       QueryParam.encode_name(param.name) <>
         "=" <>
         (pairs
-         |> flatten_pairs()
+         |> Param.flatten_pairs()
          |> join_encoded_values("%7C", param))
     ]
   end
@@ -203,58 +204,11 @@ defmodule Tesla.Middleware.Query.Modern do
       "%5B" <> QueryParam.encode_name(key) <> "%5D=" <> QueryParam.encode_value(param, value)
   end
 
-  defp flatten_pairs(pairs) do
-    Enum.flat_map(pairs, &pair_values/1)
-  end
-
-  defp pair_values({key, value}) do
-    [key, value]
-  end
-
   defp join_encoded_values(values, separator, param) do
     Enum.map_join(values, separator, &QueryParam.encode_value(param, &1))
   end
 
   defp classify_param(%QueryParam{value: value}) do
-    classify_value(value)
-  end
-
-  defp classify_value(nil) do
-    :undefined
-  end
-
-  defp classify_value(value) when is_struct(value) do
-    classify_value(Map.from_struct(value))
-  end
-
-  defp classify_value(value) when is_map(value) do
-    {:object, value |> Map.to_list() |> Enum.map(&stringify_pair/1)}
-  end
-
-  defp classify_value([]) do
-    {:array, []}
-  end
-
-  defp classify_value(value) when is_list(value) do
-    case Enum.all?(value, &object_pair?/1) do
-      true -> {:object, Enum.map(value, &stringify_pair/1)}
-      false -> {:array, value}
-    end
-  end
-
-  defp classify_value(value) do
-    {:primitive, value}
-  end
-
-  defp stringify_pair({key, value}) do
-    {to_string(key), value}
-  end
-
-  defp object_pair?({key, _value}) when is_atom(key) or is_binary(key) do
-    true
-  end
-
-  defp object_pair?(_value) do
-    false
+    Param.classify_value(value)
   end
 end

--- a/lib/tesla/param.ex
+++ b/lib/tesla/param.ex
@@ -1,0 +1,198 @@
+defmodule Tesla.Param do
+  @moduledoc false
+
+  @query_reserved ~c":/?#[]@!$&'()*+,;="
+  @path_reserved [?!, ?$, ?&, ?', ?(, ?), ?*, ?+, ?,, ?;, ?=, ?:, ?@]
+
+  def validate_name!(_kind, name) when is_binary(name) do
+    name
+  end
+
+  def validate_name!(kind, name) do
+    raise ArgumentError, "expected #{kind} parameter name to be a string; got #{inspect(name)}"
+  end
+
+  def validate_opts!(_kind, opts) when is_list(opts) do
+    opts
+  end
+
+  def validate_opts!(kind, opts) do
+    raise ArgumentError,
+          "expected #{kind} parameter options to be a keyword list; got #{inspect(opts)}"
+  end
+
+  def validate_style!(style, styles, kind, expected) do
+    case style in styles do
+      true ->
+        style
+
+      false ->
+        raise ArgumentError,
+              "unknown #{kind} parameter style #{inspect(style)}; expected #{expected}"
+    end
+  end
+
+  def validate_explode!(kind, value) do
+    validate_option_boolean!(kind, :explode, value)
+  end
+
+  def validate_allow_reserved!(kind, value) do
+    validate_option_boolean!(kind, :allow_reserved, value)
+  end
+
+  defp validate_option_boolean!(_kind, _key, value) when is_boolean(value) do
+    value
+  end
+
+  defp validate_option_boolean!(:path, key, value) do
+    raise ArgumentError, "expected #{inspect(key)} to be a boolean; got #{inspect(value)}"
+  end
+
+  defp validate_option_boolean!(kind, key, value) do
+    raise ArgumentError,
+          "expected #{kind} parameter #{inspect(key)} to be a boolean; got #{inspect(value)}"
+  end
+
+  def classify_value(nil) do
+    :undefined
+  end
+
+  def classify_value(value) when is_struct(value) do
+    value
+    |> Map.from_struct()
+    |> classify_value()
+  end
+
+  def classify_value(value) when is_map(value) do
+    {:object, value |> Map.to_list() |> Enum.map(&stringify_pair/1)}
+  end
+
+  def classify_value([]) do
+    {:array, []}
+  end
+
+  def classify_value(value) when is_list(value) do
+    case Enum.all?(value, &object_pair?/1) do
+      true -> {:object, Enum.map(value, &stringify_pair/1)}
+      false -> {:array, value}
+    end
+  end
+
+  def classify_value(value) do
+    {:primitive, value}
+  end
+
+  def flatten_pairs(pairs) do
+    Enum.flat_map(pairs, &pair_values/1)
+  end
+
+  def encode_unreserved(value) do
+    value
+    |> to_string()
+    |> URI.encode(&unreserved?/1)
+  end
+
+  def encode_reserved_query(value) do
+    value
+    |> to_string()
+    |> encode_reserved(&query_reserved?/1)
+  end
+
+  def encode_reserved_path(value) do
+    value
+    |> to_string()
+    |> encode_reserved(&path_reserved?/1)
+  end
+
+  defp stringify_pair({key, value}) do
+    {to_string(key), value}
+  end
+
+  defp object_pair?({key, _value}) when is_atom(key) or is_binary(key) do
+    true
+  end
+
+  defp object_pair?(_value) do
+    false
+  end
+
+  defp pair_values({key, value}) do
+    [key, value]
+  end
+
+  defp encode_reserved(<<>>, _allowed?) do
+    ""
+  end
+
+  defp encode_reserved(<<"%", high, low, rest::binary>>, allowed?) do
+    case hex?(high) and hex?(low) do
+      true ->
+        "%" <> <<high, low>> <> encode_reserved(rest, allowed?)
+
+      false ->
+        "%25" <> encode_reserved(<<high, low, rest::binary>>, allowed?)
+    end
+  end
+
+  defp encode_reserved(<<"%", rest::binary>>, allowed?) do
+    "%25" <> encode_reserved(rest, allowed?)
+  end
+
+  defp encode_reserved(<<byte, rest::binary>>, allowed?) do
+    case allowed?.(byte) do
+      true ->
+        <<byte>> <> encode_reserved(rest, allowed?)
+
+      false ->
+        percent_encode_byte(byte) <> encode_reserved(rest, allowed?)
+    end
+  end
+
+  defp percent_encode_byte(byte) do
+    "%" <> Base.encode16(<<byte>>)
+  end
+
+  defp hex?(byte) when byte in ?0..?9 do
+    true
+  end
+
+  defp hex?(byte) when byte in ?A..?F do
+    true
+  end
+
+  defp hex?(byte) when byte in ?a..?f do
+    true
+  end
+
+  defp hex?(_byte) do
+    false
+  end
+
+  defp query_reserved?(byte) do
+    unreserved?(byte) or byte in @query_reserved
+  end
+
+  defp path_reserved?(byte) do
+    unreserved?(byte) or byte in @path_reserved
+  end
+
+  defp unreserved?(byte) when byte in ?A..?Z do
+    true
+  end
+
+  defp unreserved?(byte) when byte in ?a..?z do
+    true
+  end
+
+  defp unreserved?(byte) when byte in ?0..?9 do
+    true
+  end
+
+  defp unreserved?(byte) when byte in [?-, ?_, ?., ?~] do
+    true
+  end
+
+  defp unreserved?(_byte) do
+    false
+  end
+end

--- a/lib/tesla/path_param.ex
+++ b/lib/tesla/path_param.ex
@@ -60,6 +60,8 @@ defmodule Tesla.PathParam do
   "undefined" column for the selected style.
   """
 
+  alias Tesla.Param
+
   @derive {Inspect, except: [:value]}
   @enforce_keys [:name, :value, :style, :explode, :allow_reserved]
   defstruct [:name, :value, :style, :explode, :allow_reserved]
@@ -73,115 +75,35 @@ defmodule Tesla.PathParam do
             allow_reserved: boolean()
           }
 
+  @styles [:simple, :matrix, :label]
+  @expected_styles ":simple, :matrix, or :label"
+
   @spec new!(String.t(), term(), keyword()) :: t()
-  def new!(name, value, opts \\ [])
-
-  def new!(name, value, opts) when is_binary(name) and is_list(opts) do
-    build!(opts, name, value)
-  end
-
-  def new!(name, _value, _opts) when not is_binary(name) do
-    raise ArgumentError, "expected path parameter name to be a string; got #{inspect(name)}"
-  end
-
-  def new!(_name, _value, opts) do
-    raise ArgumentError,
-          "expected path parameter options to be a keyword list; got #{inspect(opts)}"
-  end
-
-  @doc false
-  @spec encode_value(%__MODULE__{}, term()) :: String.t()
-  def encode_value(%__MODULE__{allow_reserved: false}, value) do
-    value |> to_string() |> URI.encode(&unreserved?/1)
-  end
-
-  def encode_value(%__MODULE__{allow_reserved: true}, value) do
-    value |> to_string() |> encode_reserved_path()
-  end
-
-  defp build!(opts, name, value) do
+  def new!(name, value, opts \\ []) do
+    name = Param.validate_name!(:path, name)
+    opts = Param.validate_opts!(:path, opts)
     opts = Keyword.validate!(opts, style: :simple, explode: false, allow_reserved: false)
 
     %__MODULE__{
       name: name,
       value: value,
-      style: opts[:style] |> validate_style!(),
-      explode: validate_boolean!(:explode, opts[:explode]),
-      allow_reserved: validate_boolean!(:allow_reserved, opts[:allow_reserved])
+      style: validate_style!(opts[:style]),
+      explode: Param.validate_explode!(:path, opts[:explode]),
+      allow_reserved: Param.validate_allow_reserved!(:path, opts[:allow_reserved])
     }
   end
 
-  defp validate_style!(style) when style in [:simple, :matrix, :label], do: style
-
   defp validate_style!(style) do
-    raise ArgumentError,
-          "unknown path parameter style #{inspect(style)}; expected :simple, :matrix, or :label"
+    Param.validate_style!(style, @styles, :path, @expected_styles)
   end
 
-  defp validate_boolean!(_key, value) when is_boolean(value), do: value
-
-  defp validate_boolean!(key, value) do
-    raise ArgumentError, "expected #{inspect(key)} to be a boolean; got #{inspect(value)}"
+  @doc false
+  @spec encode_value(%__MODULE__{}, term()) :: String.t()
+  def encode_value(%__MODULE__{allow_reserved: false}, value) do
+    Param.encode_unreserved(value)
   end
 
-  defp encode_reserved_path(<<"%", h1, h2, rest::binary>>)
-       when h1 in ?0..?9 or h1 in ?A..?F or h1 in ?a..?f do
-    case hex?(h2) do
-      true -> "%" <> <<h1, h2>> <> encode_reserved_path(rest)
-      false -> "%25" <> encode_reserved_path(<<h1, h2, rest::binary>>)
-    end
-  end
-
-  defp encode_reserved_path(<<c::utf8, rest::binary>>) do
-    char = <<c::utf8>>
-
-    case byte_size(char) == 1 and reserved_path_allowed?(c) do
-      true -> char <> encode_reserved_path(rest)
-      false -> URI.encode(char, &reserved_path_allowed?/1) <> encode_reserved_path(rest)
-    end
-  end
-
-  defp encode_reserved_path("") do
-    ""
-  end
-
-  defp hex?(c) when c in ?0..?9 do
-    true
-  end
-
-  defp hex?(c) when c in ?A..?F do
-    true
-  end
-
-  defp hex?(c) when c in ?a..?f do
-    true
-  end
-
-  defp hex?(_c) do
-    false
-  end
-
-  defp unreserved?(c) when c in ?A..?Z do
-    true
-  end
-
-  defp unreserved?(c) when c in ?a..?z do
-    true
-  end
-
-  defp unreserved?(c) when c in ?0..?9 do
-    true
-  end
-
-  defp unreserved?(c) when c in [?-, ?_, ?., ?~] do
-    true
-  end
-
-  defp unreserved?(_c) do
-    false
-  end
-
-  defp reserved_path_allowed?(c) do
-    unreserved?(c) or c in [?!, ?$, ?&, ?', ?(, ?), ?*, ?+, ?,, ?;, ?=, ?:, ?@]
+  def encode_value(%__MODULE__{allow_reserved: true}, value) do
+    Param.encode_reserved_path(value)
   end
 end

--- a/lib/tesla/query_param.ex
+++ b/lib/tesla/query_param.ex
@@ -59,6 +59,8 @@ defmodule Tesla.QueryParam do
   for `:form`.
   """
 
+  alias Tesla.Param
+
   @derive {Inspect, except: [:value]}
   @enforce_keys [:name, :value, :style, :explode, :allow_reserved]
   defstruct [:name, :value, :style, :explode, :allow_reserved]
@@ -73,77 +75,49 @@ defmodule Tesla.QueryParam do
           }
 
   @styles [:form, :space_delimited, :pipe_delimited, :deep_object]
-  @reserved ~c":/?#[]@!$&'()*+,;="
+  @expected_styles ":form, :space_delimited, :pipe_delimited, or :deep_object"
 
   @spec new!(String.t(), term(), keyword()) :: t()
-  def new!(name, value, opts \\ [])
-
-  def new!(name, value, opts) when is_binary(name) and is_list(opts) do
-    build!(opts, name, value)
-  end
-
-  def new!(name, _value, _opts) when not is_binary(name) do
-    raise ArgumentError, "expected query parameter name to be a string; got #{inspect(name)}"
-  end
-
-  def new!(_name, _value, opts) do
-    raise ArgumentError,
-          "expected query parameter options to be a keyword list; got #{inspect(opts)}"
-  end
-
-  @doc false
-  @spec encode_name(term()) :: String.t()
-  def encode_name(value) do
-    value
-    |> to_string()
-    |> URI.encode(&unreserved?/1)
-  end
-
-  @doc false
-  @spec encode_value(%__MODULE__{}, term()) :: String.t()
-  def encode_value(%__MODULE__{allow_reserved: false}, value) do
-    value
-    |> to_string()
-    |> URI.encode(&unreserved?/1)
-  end
-
-  def encode_value(%__MODULE__{allow_reserved: true}, value) do
-    value
-    |> to_string()
-    |> encode_reserved()
-  end
-
-  defp build!(opts, name, value) do
+  def new!(name, value, opts \\ []) do
+    name = Param.validate_name!(:query, name)
+    opts = Param.validate_opts!(:query, opts)
     opts = Keyword.validate!(opts, [:style, :explode, :allow_reserved])
-    style = opts |> Keyword.get(:style, :form) |> validate_style!()
+
+    style =
+      opts
+      |> Keyword.get(:style, :form)
+      |> validate_style!()
+
+    explode = Keyword.get(opts, :explode, default_explode(style))
+    allow_reserved = Keyword.get(opts, :allow_reserved, false)
 
     %__MODULE__{
       name: name,
       value: value,
       style: style,
-      explode:
-        opts |> Keyword.get(:explode, default_explode(style)) |> validate_boolean!(:explode),
-      allow_reserved:
-        opts |> Keyword.get(:allow_reserved, false) |> validate_boolean!(:allow_reserved)
+      explode: Param.validate_explode!(:query, explode),
+      allow_reserved: Param.validate_allow_reserved!(:query, allow_reserved)
     }
   end
 
-  defp validate_style!(style) when style in @styles do
-    style
-  end
-
   defp validate_style!(style) do
-    raise ArgumentError,
-          "unknown query parameter style #{inspect(style)}; expected :form, :space_delimited, :pipe_delimited, or :deep_object"
+    Param.validate_style!(style, @styles, :query, @expected_styles)
   end
 
-  defp validate_boolean!(value, _key) when is_boolean(value) do
-    value
+  @doc false
+  @spec encode_name(term()) :: String.t()
+  def encode_name(value) do
+    Param.encode_unreserved(value)
   end
 
-  defp validate_boolean!(value, key) do
-    raise ArgumentError,
-          "expected query parameter #{inspect(key)} to be a boolean; got #{inspect(value)}"
+  @doc false
+  @spec encode_value(%__MODULE__{}, term()) :: String.t()
+  def encode_value(%__MODULE__{allow_reserved: false}, value) do
+    Param.encode_unreserved(value)
+  end
+
+  def encode_value(%__MODULE__{allow_reserved: true}, value) do
+    Param.encode_reserved_query(value)
   end
 
   defp default_explode(:form) do
@@ -151,78 +125,6 @@ defmodule Tesla.QueryParam do
   end
 
   defp default_explode(_style) do
-    false
-  end
-
-  defp encode_reserved(<<>>) do
-    ""
-  end
-
-  defp encode_reserved(<<"%", high, low, rest::binary>>) do
-    case hex_digit?(high) and hex_digit?(low) do
-      true ->
-        "%" <> <<high, low>> <> encode_reserved(rest)
-
-      false ->
-        "%25" <> encode_reserved(<<high, low, rest::binary>>)
-    end
-  end
-
-  defp encode_reserved(<<"%", rest::binary>>) do
-    "%25" <> encode_reserved(rest)
-  end
-
-  defp encode_reserved(<<byte, rest::binary>>) do
-    case unreserved_or_reserved?(byte) do
-      true ->
-        <<byte>> <> encode_reserved(rest)
-
-      false ->
-        percent_encode_byte(byte) <> encode_reserved(rest)
-    end
-  end
-
-  defp percent_encode_byte(byte) do
-    "%" <> Base.encode16(<<byte>>)
-  end
-
-  defp hex_digit?(byte) when byte in ?0..?9 do
-    true
-  end
-
-  defp hex_digit?(byte) when byte in ?A..?F do
-    true
-  end
-
-  defp hex_digit?(byte) when byte in ?a..?f do
-    true
-  end
-
-  defp hex_digit?(_byte) do
-    false
-  end
-
-  defp unreserved_or_reserved?(byte) do
-    unreserved?(byte) or byte in @reserved
-  end
-
-  defp unreserved?(byte) when byte in ?A..?Z do
-    true
-  end
-
-  defp unreserved?(byte) when byte in ?a..?z do
-    true
-  end
-
-  defp unreserved?(byte) when byte in ?0..?9 do
-    true
-  end
-
-  defp unreserved?(byte) when byte in [?-, ?_, ?., ?~] do
-    true
-  end
-
-  defp unreserved?(_byte) do
     false
   end
 end


### PR DESCRIPTION
- Keeps OpenAPI-friendly path, query, and header parameter behavior aligned behind one internal implementation point.
- Reduces drift risk as parameter serialization rules continue to evolve.