### PR TITLE
chore: clarify parameter value type

### DIFF
--- a/lib/tesla/header_param.ex
+++ b/lib/tesla/header_param.ex
@@ -81,7 +81,7 @@ defmodule Tesla.HeaderParam do
 
   defp serialize(param) do
     param
-    |> classify_param()
+    |> value_type()
     |> serialize_simple(param)
   end
 
@@ -111,7 +111,7 @@ defmodule Tesla.HeaderParam do
     "#{key}=#{value}"
   end
 
-  defp classify_param(%__MODULE__{value: value}) do
-    Param.classify_value(value)
+  defp value_type(%__MODULE__{value: value}) do
+    Param.value_type(value)
   end
 end

--- a/lib/tesla/middleware/path_params/modern.ex
+++ b/lib/tesla/middleware/path_params/modern.ex
@@ -43,9 +43,7 @@ defmodule Tesla.Middleware.PathParams.Modern do
   end
 
   defp replace_placeholder(params, match, name) when is_map(params) do
-    params
-    |> Map.get(name)
-    |> replace_param(match)
+    replace_param(Map.get(params, name), match)
   end
 
   defp replace_param(%PathParam{value: nil}, match) do
@@ -73,15 +71,21 @@ defmodule Tesla.Middleware.PathParams.Modern do
   end
 
   defp serialize_value(%PathParam{style: :simple} = param) do
-    serialize_simple(classify_param(param), param)
+    param
+    |> value_type()
+    |> serialize_simple(param)
   end
 
   defp serialize_value(%PathParam{style: :matrix} = param) do
-    serialize_matrix(classify_param(param), param)
+    param
+    |> value_type()
+    |> serialize_matrix(param)
   end
 
   defp serialize_value(%PathParam{style: :label} = param) do
-    serialize_label(classify_param(param), param)
+    param
+    |> value_type()
+    |> serialize_label(param)
   end
 
   defp serialize_simple({:primitive, value}, param) do
@@ -198,7 +202,7 @@ defmodule Tesla.Middleware.PathParams.Modern do
     Enum.map_join(values, separator, &PathParam.encode_value(param, &1))
   end
 
-  defp classify_param(%PathParam{value: value}) do
-    Param.classify_value(value)
+  defp value_type(%PathParam{value: value}) do
+    Param.value_type(value)
   end
 end

--- a/lib/tesla/middleware/query/modern.ex
+++ b/lib/tesla/middleware/query/modern.ex
@@ -45,25 +45,25 @@ defmodule Tesla.Middleware.Query.Modern do
 
   defp serialize_param(%QueryParam{style: :form} = param) do
     param
-    |> classify_param()
+    |> value_type()
     |> serialize_form(param)
   end
 
   defp serialize_param(%QueryParam{style: :space_delimited} = param) do
     param
-    |> classify_param()
+    |> value_type()
     |> serialize_space_delimited(param)
   end
 
   defp serialize_param(%QueryParam{style: :pipe_delimited} = param) do
     param
-    |> classify_param()
+    |> value_type()
     |> serialize_pipe_delimited(param)
   end
 
   defp serialize_param(%QueryParam{style: :deep_object} = param) do
     param
-    |> classify_param()
+    |> value_type()
     |> serialize_deep_object(param)
   end
 
@@ -208,7 +208,7 @@ defmodule Tesla.Middleware.Query.Modern do
     Enum.map_join(values, separator, &QueryParam.encode_value(param, &1))
   end
 
-  defp classify_param(%QueryParam{value: value}) do
-    Param.classify_value(value)
+  defp value_type(%QueryParam{value: value}) do
+    Param.value_type(value)
   end
 end

--- a/lib/tesla/param.ex
+++ b/lib/tesla/param.ex
@@ -53,32 +53,32 @@ defmodule Tesla.Param do
           "expected #{kind} parameter #{inspect(key)} to be a boolean; got #{inspect(value)}"
   end
 
-  def classify_value(nil) do
+  def value_type(nil) do
     :undefined
   end
 
-  def classify_value(value) when is_struct(value) do
+  def value_type(value) when is_struct(value) do
     value
     |> Map.from_struct()
-    |> classify_value()
+    |> value_type()
   end
 
-  def classify_value(value) when is_map(value) do
+  def value_type(value) when is_map(value) do
     {:object, Map.to_list(value)}
   end
 
-  def classify_value([]) do
+  def value_type([]) do
     {:array, []}
   end
 
-  def classify_value(value) when is_list(value) do
-    case Enum.all?(value, &object_pair?/1) do
+  def value_type(value) when is_list(value) do
+    case Keyword.keyword?(value) do
       true -> {:object, value}
       false -> {:array, value}
     end
   end
 
-  def classify_value(value) do
+  def value_type(value) do
     {:primitive, value}
   end
 
@@ -102,14 +102,6 @@ defmodule Tesla.Param do
     value
     |> to_string()
     |> encode_reserved(&path_reserved?/1)
-  end
-
-  defp object_pair?({key, _value}) when is_atom(key) or is_binary(key) do
-    true
-  end
-
-  defp object_pair?(_value) do
-    false
   end
 
   defp pair_values({key, value}) do

--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -232,16 +232,19 @@ defmodule Tesla.Adapter.GunTest do
 
     task =
       Task.async(fn ->
-        Tesla.Adapter.Gun.call(request, body_as: :stream, reply_to: reply_to)
+        Tesla.Adapter.Gun.call(request, body_as: :chunks, reply_to: reply_to, timeout: 5_000)
       end)
 
-    assert {:ok, %Env{status: 200, body: body}} = Task.await(task)
-    assert body |> Enum.join() |> byte_size() == 16
+    assert {:ok, %Env{status: 200, body: %{pid: pid, stream: stream}}} =
+             Task.await(task)
 
-    assert_receive {:gun_reply_to, {:gun_response, pid, stream, :nofin, 200, _headers}}
+    assert_receive {:gun_reply_to, {:gun_response, ^pid, ^stream, :nofin, 200, _headers}}
     assert is_pid(pid)
     assert is_reference(stream)
     assert_receive {:gun_reply_to, {:gun_data, ^pid, ^stream, _, _}}
+    assert_receive {:gun_data, ^pid, ^stream, _, _}
+
+    Gun.close(pid)
   end
 
   test "on TLS errors get timeout error from await_up method" do

--- a/test/tesla/middleware/path_params/modern_test.exs
+++ b/test/tesla/middleware/path_params/modern_test.exs
@@ -778,10 +778,10 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       assert env.url == "/users/id=7"
     end
 
-    test "accepts string-keyed object pair lists" do
+    test "accepts quoted atom keyword lists as object values" do
       opts = [
         path_params: [
-          path_param("color", [{"R", 100}, {"G", 200}], style: :simple, explode: false)
+          path_param("color", [R: 100, G: 200], style: :simple, explode: false)
         ]
       ]
 


### PR DESCRIPTION
- Makes the shared parameter helper describe the OpenAPI serialization shape it returns instead of sounding like generic type classification.