### PR TITLE
feat: support OpenAPI-friendly cookie params

### DIFF
--- a/lib/tesla/cookie_param.ex
+++ b/lib/tesla/cookie_param.ex
@@ -1,0 +1,260 @@
+defmodule Tesla.CookieParam do
+  @moduledoc """
+  A cookie parameter with explicit serialization settings.
+
+  `Tesla.CookieParam` is a Tesla-native value object for cookie parameters whose
+  serialization needs to be controlled explicitly. Its serialization options
+  follow the OpenAPI cookie parameter style semantics, while keeping the public
+  API focused on the cookie use case.
+
+  Convert cookie parameters to the raw `Cookie` header tuple accepted by Tesla:
+
+      alias Tesla.CookieParam
+
+      cookies = [
+        CookieParam.new!("session_id", "abc123"),
+        CookieParam.new!("theme", "dark")
+      ]
+
+      CookieParam.to_header(cookies)
+
+  ## Options
+
+  `new!/3` accepts a keyword list using Elixir atoms for hand-written Tesla
+  code:
+
+    * `:style` - one of `:form` or `:cookie`. Defaults to `:form`, matching
+      the OpenAPI compatibility default for cookie parameters.
+    * `:explode` - boolean. Defaults to `true` when the style is `:form`,
+      and `false` for all other styles.
+    * `:allow_reserved` - boolean. Defaults to `false`.
+
+  [oas-style]: https://spec.openapis.org/oas/latest.html#style-values
+
+  ## Encoding
+
+  `Tesla.CookieParam.to_header/1` serializes values using the
+  [OpenAPI cookie parameter rules][oas-style] for the `form` and `cookie`
+  styles.
+
+  The `cookie` style follows `Cookie` header syntax by separating name-value
+  pairs with `"; "`. Values are passed through unchanged after converting each
+  part with `to_string/1`; URI percent-encoding is not applied.
+
+  The `form` style follows the OpenAPI compatibility behavior for cookie
+  parameters and applies URI percent-encoding by default. With
+  `allow_reserved: true`, reserved characters and already-encoded percent
+  triples in values are preserved.
+
+  ## Object Value Ordering
+
+  Object values may be passed as maps, structs, or keyword lists. Keyword lists
+  preserve insertion order; map iteration order is intrinsic and not guaranteed
+  across Elixir versions. Pass an ordered keyword list when the exact
+  serialized order matters.
+  """
+
+  alias Tesla.Param
+
+  @derive {Inspect, except: [:value]}
+  @enforce_keys [:name, :value, :style, :explode, :allow_reserved]
+  defstruct [:name, :value, :style, :explode, :allow_reserved]
+
+  @type style :: :form | :cookie
+  @opaque t :: %__MODULE__{
+            name: String.t(),
+            value: term(),
+            style: style(),
+            explode: boolean(),
+            allow_reserved: boolean()
+          }
+
+  @styles [:form, :cookie]
+  @expected_styles ":form or :cookie"
+
+  @spec new!(String.t(), term(), keyword()) :: t()
+  def new!(name, value, opts \\ []) do
+    name = Param.validate_name!(:cookie, name)
+    opts = Param.validate_opts!(:cookie, opts)
+    opts = Keyword.validate!(opts, [:style, :explode, :allow_reserved])
+
+    style =
+      opts
+      |> Keyword.get(:style, :form)
+      |> validate_style!()
+
+    explode = Keyword.get(opts, :explode, default_explode(style))
+    allow_reserved = Keyword.get(opts, :allow_reserved, false)
+
+    %__MODULE__{
+      name: name,
+      value: value,
+      style: style,
+      explode: Param.validate_explode!(:cookie, explode),
+      allow_reserved: Param.validate_allow_reserved!(:cookie, allow_reserved)
+    }
+  end
+
+  defp validate_style!(style) do
+    Param.validate_style!(style, @styles, :cookie, @expected_styles)
+  end
+
+  defp default_explode(:form) do
+    true
+  end
+
+  defp default_explode(_style) do
+    false
+  end
+
+  @spec to_header(t() | [t()]) :: {String.t(), String.t()}
+  def to_header(%__MODULE__{} = param) do
+    {"cookie", serialize(param)}
+  end
+
+  def to_header(params) when is_list(params) do
+    {"cookie", Enum.map_join(params, "; ", &serialize_param!/1)}
+  end
+
+  def to_header(param) do
+    raise ArgumentError,
+          "expected cookie header to be a #{inspect(__MODULE__)} struct or a list of #{inspect(__MODULE__)} structs; got #{inspect(param)}"
+  end
+
+  defp serialize_param!(%__MODULE__{} = param) do
+    serialize(param)
+  end
+
+  defp serialize_param!(param) do
+    raise ArgumentError,
+          "expected cookie header to be a #{inspect(__MODULE__)} struct; got #{inspect(param)}"
+  end
+
+  defp serialize(%__MODULE__{style: :form} = param) do
+    param
+    |> value_type()
+    |> serialize_form(param)
+  end
+
+  defp serialize(%__MODULE__{style: :cookie} = param) do
+    param
+    |> value_type()
+    |> serialize_cookie(param)
+  end
+
+  defp serialize_form(:undefined, param) do
+    serialize_form_empty(param)
+  end
+
+  defp serialize_form({:primitive, value}, param) do
+    serialize_form_named_value(param, value)
+  end
+
+  defp serialize_form({:array, []}, param) do
+    serialize_form_empty(param)
+  end
+
+  defp serialize_form({:array, items}, %__MODULE__{explode: false} = param) do
+    serialize_form_name(param) <> "=" <> join_encoded_values(items, ",", param)
+  end
+
+  defp serialize_form({:array, items}, %__MODULE__{explode: true} = param) do
+    Enum.map_join(items, "&", &serialize_form_named_value(param, &1))
+  end
+
+  defp serialize_form({:object, []}, param) do
+    serialize_form_empty(param)
+  end
+
+  defp serialize_form({:object, pairs}, %__MODULE__{explode: false} = param) do
+    serialize_form_name(param) <>
+      "=" <>
+      (pairs
+       |> Param.flatten_pairs()
+       |> join_encoded_values(",", param))
+  end
+
+  defp serialize_form({:object, pairs}, %__MODULE__{explode: true} = param) do
+    Enum.map_join(pairs, "&", &serialize_form_pair(&1, param))
+  end
+
+  defp serialize_cookie(:undefined, param) do
+    serialize_cookie_empty(param)
+  end
+
+  defp serialize_cookie({:primitive, value}, param) do
+    serialize_cookie_named_value(param, value)
+  end
+
+  defp serialize_cookie({:array, []}, param) do
+    serialize_cookie_empty(param)
+  end
+
+  defp serialize_cookie({:array, items}, %__MODULE__{explode: false} = param) do
+    param.name <> "=" <> Enum.map_join(items, ",", &to_string/1)
+  end
+
+  defp serialize_cookie({:array, items}, %__MODULE__{explode: true} = param) do
+    Enum.map_join(items, "; ", &serialize_cookie_named_value(param, &1))
+  end
+
+  defp serialize_cookie({:object, []}, param) do
+    serialize_cookie_empty(param)
+  end
+
+  defp serialize_cookie({:object, pairs}, %__MODULE__{explode: false} = param) do
+    param.name <>
+      "=" <>
+      (pairs
+       |> Param.flatten_pairs()
+       |> Enum.map_join(",", &to_string/1))
+  end
+
+  defp serialize_cookie({:object, pairs}, %__MODULE__{explode: true}) do
+    Enum.map_join(pairs, "; ", &serialize_cookie_pair/1)
+  end
+
+  defp serialize_form_empty(param) do
+    serialize_form_name(param) <> "="
+  end
+
+  defp serialize_form_named_value(param, value) do
+    serialize_form_name(param) <> "=" <> encode_form_value(param, value)
+  end
+
+  defp serialize_form_pair({key, value}, param) do
+    Param.encode_unreserved(key) <> "=" <> encode_form_value(param, value)
+  end
+
+  defp serialize_cookie_empty(param) do
+    param.name <> "="
+  end
+
+  defp serialize_cookie_named_value(param, value) do
+    param.name <> "=" <> to_string(value)
+  end
+
+  defp serialize_cookie_pair({key, value}) do
+    "#{key}=#{value}"
+  end
+
+  defp serialize_form_name(param) do
+    Param.encode_unreserved(param.name)
+  end
+
+  defp join_encoded_values(values, separator, param) do
+    Enum.map_join(values, separator, &encode_form_value(param, &1))
+  end
+
+  defp encode_form_value(%__MODULE__{allow_reserved: false}, value) do
+    Param.encode_unreserved(value)
+  end
+
+  defp encode_form_value(%__MODULE__{allow_reserved: true}, value) do
+    Param.encode_reserved_query(value)
+  end
+
+  defp value_type(%__MODULE__{value: value}) do
+    Param.value_type(value)
+  end
+end

--- a/test/tesla/cookie_param_test.exs
+++ b/test/tesla/cookie_param_test.exs
@@ -1,0 +1,260 @@
+defmodule Tesla.CookieParamTest do
+  use ExUnit.Case, async: true
+
+  alias Tesla.CookieParam
+
+  defmodule TestFilter do
+    defstruct [:role, :id]
+  end
+
+  test "uses OpenAPI compatibility defaults" do
+    assert %CookieParam{
+             name: "color",
+             value: "blue",
+             style: :form,
+             explode: true,
+             allow_reserved: false
+           } = CookieParam.new!("color", "blue")
+  end
+
+  test "defaults explode to false for cookie style" do
+    assert %CookieParam{explode: false} = CookieParam.new!("color", "blue", style: :cookie)
+  end
+
+  test "accepts explicit serialization options" do
+    assert %CookieParam{
+             name: "color",
+             value: [R: 100],
+             style: :form,
+             explode: false,
+             allow_reserved: true
+           } =
+             CookieParam.new!("color", [R: 100],
+               style: :form,
+               explode: false,
+               allow_reserved: true
+             )
+  end
+
+  test "does not inspect runtime values" do
+    inspected = inspect(CookieParam.new!("session_id", "secret-token"))
+
+    refute inspected =~ "secret-token"
+    assert inspected =~ ~s(name: "session_id")
+    assert inspected =~ "style: :form"
+  end
+
+  describe "OpenAPI form style examples" do
+    test "form style with explode false" do
+      assert CookieParam.new!("color", nil, explode: false) |> CookieParam.to_header() ==
+               {"cookie", "color="}
+
+      assert CookieParam.new!("color", "blue", explode: false) |> CookieParam.to_header() ==
+               {"cookie", "color=blue"}
+
+      assert CookieParam.new!("color", ["blue", "black", "brown"], explode: false)
+             |> CookieParam.to_header() ==
+               {"cookie", "color=blue,black,brown"}
+
+      assert CookieParam.new!("color", [R: 100, G: 200, B: 150], explode: false)
+             |> CookieParam.to_header() ==
+               {"cookie", "color=R,100,G,200,B,150"}
+    end
+
+    test "form style with explode true" do
+      assert CookieParam.new!("color", nil) |> CookieParam.to_header() ==
+               {"cookie", "color="}
+
+      assert CookieParam.new!("color", "blue") |> CookieParam.to_header() ==
+               {"cookie", "color=blue"}
+
+      assert CookieParam.new!("color", ["blue", "black", "brown"]) |> CookieParam.to_header() ==
+               {"cookie", "color=blue&color=black&color=brown"}
+
+      assert CookieParam.new!("color", R: 100, G: 200, B: 150) |> CookieParam.to_header() ==
+               {"cookie", "R=100&G=200&B=150"}
+    end
+  end
+
+  describe "OpenAPI cookie style examples" do
+    test "cookie style with explode false" do
+      param = CookieParam.new!("color", nil, style: :cookie, explode: false)
+      assert CookieParam.to_header(param) == {"cookie", "color="}
+
+      param = CookieParam.new!("color", "blue", style: :cookie, explode: false)
+      assert CookieParam.to_header(param) == {"cookie", "color=blue"}
+
+      param =
+        CookieParam.new!("color", ["blue", "black", "brown"],
+          style: :cookie,
+          explode: false
+        )
+
+      assert CookieParam.to_header(param) == {"cookie", "color=blue,black,brown"}
+
+      param =
+        CookieParam.new!("color", [R: 100, G: 200, B: 150],
+          style: :cookie,
+          explode: false
+        )
+
+      assert CookieParam.to_header(param) == {"cookie", "color=R,100,G,200,B,150"}
+    end
+
+    test "cookie style with explode true" do
+      param = CookieParam.new!("color", nil, style: :cookie, explode: true)
+      assert CookieParam.to_header(param) == {"cookie", "color="}
+
+      param = CookieParam.new!("color", "blue", style: :cookie, explode: true)
+      assert CookieParam.to_header(param) == {"cookie", "color=blue"}
+
+      param =
+        CookieParam.new!("color", ["blue", "black", "brown"],
+          style: :cookie,
+          explode: true
+        )
+
+      expected = {"cookie", "color=blue; color=black; color=brown"}
+      assert CookieParam.to_header(param) == expected
+
+      param =
+        CookieParam.new!("color", [R: 100, G: 200, B: 150],
+          style: :cookie,
+          explode: true
+        )
+
+      assert CookieParam.to_header(param) == {"cookie", "R=100; G=200; B=150"}
+    end
+  end
+
+  test "converts multiple parameters to a raw Tesla cookie header tuple" do
+    params = [
+      CookieParam.new!("session_id", "abc123", style: :cookie, explode: true),
+      CookieParam.new!("theme", "dark", style: :cookie, explode: true)
+    ]
+
+    expected = {"cookie", "session_id=abc123; theme=dark"}
+    assert CookieParam.to_header(params) == expected
+  end
+
+  test "cookie style does not percent-encode names or values" do
+    assert CookieParam.new!("raw name", "a/b c#d%zz|é", style: :cookie)
+           |> CookieParam.to_header() ==
+             {"cookie", "raw name=a/b c#d%zz|é"}
+  end
+
+  test "form style percent-encodes names and values" do
+    assert CookieParam.new!("greeting name", "Hello, world!", style: :form)
+           |> CookieParam.to_header() ==
+             {"cookie", "greeting%20name=Hello%2C%20world%21"}
+  end
+
+  test "form style preserves reserved values and percent triples when allow_reserved is true" do
+    assert CookieParam.new!("filter", "a/b?c#d%2B%", style: :form, allow_reserved: true)
+           |> CookieParam.to_header() ==
+             {"cookie", "filter=a/b?c#d%2B%25"}
+  end
+
+  test "supports struct values as objects" do
+    header =
+      CookieParam.new!("filter", %TestFilter{role: "admin", id: 5},
+        style: :cookie,
+        explode: true
+      )
+      |> CookieParam.to_header()
+
+    assert header in [
+             {"cookie", "id=5; role=admin"},
+             {"cookie", "role=admin; id=5"}
+           ]
+  end
+
+  test "serializes empty arrays and objects as empty cookie values" do
+    assert CookieParam.new!("empty_array", []) |> CookieParam.to_header() ==
+             {"cookie", "empty_array="}
+
+    assert CookieParam.new!("empty_object", %{}) |> CookieParam.to_header() ==
+             {"cookie", "empty_object="}
+  end
+
+  test "accepts nil values" do
+    assert %CookieParam{name: "session_id", value: nil} = CookieParam.new!("session_id", nil)
+  end
+
+  test "rejects document location as a hand-written option" do
+    assert_raise ArgumentError, ~r/unknown keys \[:in\]/, fn ->
+      CookieParam.new!("session_id", "abc123", in: :cookie)
+    end
+  end
+
+  test "rejects string styles in hand-written keyword options" do
+    assert_raise ArgumentError, ~r/expected :form or :cookie/, fn ->
+      CookieParam.new!("session_id", "abc123", style: "cookie")
+    end
+  end
+
+  test "rejects non-cookie style atoms" do
+    for style <- [
+          :matrix,
+          :label,
+          :simple,
+          :space_delimited,
+          :pipe_delimited,
+          :deep_object
+        ] do
+      assert_raise ArgumentError, ~r/expected :form or :cookie/, fn ->
+        CookieParam.new!("session_id", "abc123", style: style)
+      end
+    end
+  end
+
+  test "rejects non-string names" do
+    assert_raise ArgumentError, ~r/expected cookie parameter name to be a string/, fn ->
+      CookieParam.new!(:session_id, "abc123")
+    end
+  end
+
+  test "rejects non-boolean explode option" do
+    assert_raise ArgumentError, ~r/expected cookie parameter :explode to be a boolean/, fn ->
+      CookieParam.new!("session_id", "abc123", explode: "true")
+    end
+  end
+
+  test "rejects non-boolean allow_reserved option" do
+    assert_raise ArgumentError,
+                 ~r/expected cookie parameter :allow_reserved to be a boolean/,
+                 fn ->
+                   CookieParam.new!("session_id", "abc123", allow_reserved: "true")
+                 end
+  end
+
+  test "rejects atom-keyed maps as options" do
+    assert_raise ArgumentError, ~r/expected cookie parameter options to be a keyword list/, fn ->
+      CookieParam.new!("session_id", "abc123", %{style: :cookie})
+    end
+  end
+
+  test "rejects string-keyed maps as options" do
+    assert_raise ArgumentError, ~r/expected cookie parameter options to be a keyword list/, fn ->
+      CookieParam.new!("session_id", "abc123", %{"style" => :cookie})
+    end
+  end
+
+  test "rejects non-keyword lists as options" do
+    assert_raise ArgumentError, ~r/expected a keyword list/, fn ->
+      CookieParam.new!("session_id", "abc123", [:cookie])
+    end
+  end
+
+  test "rejects non-cookie parameter values in header lists" do
+    assert_raise ArgumentError, ~r/expected cookie header to be a Tesla.CookieParam struct/, fn ->
+      CookieParam.to_header([CookieParam.new!("session_id", "abc123"), {"theme", "dark"}])
+    end
+  end
+
+  test "rejects non-cookie parameter header input" do
+    assert_raise ArgumentError, ~r/expected cookie header to be a Tesla.CookieParam struct/, fn ->
+      CookieParam.to_header(%{session_id: "abc123"})
+    end
+  end
+end


### PR DESCRIPTION
- Cookie parameters need the same explicit value-object boundary as the other OpenAPI-inspired parameter locations.
- The cookie-specific style closes the remaining header-backed request-parameter gap without expanding middleware responsibilities.