### PR TITLE
feat: support OpenAPI-friendly query strings

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -432,9 +432,20 @@ defmodule Tesla do
   When query params are passed as maps, the encoded parameter order is
   unspecified. Pass an ordered list of pairs if the exact query string order
   matters.
+
+  Pass `t:Tesla.QueryString.t/0` as the query when the entire query string is
+  already serialized as one value:
+
+      iex> query = Tesla.QueryString.raw!("foo=a+%2B+b&bar=true")
+      iex> Tesla.build_url("https://api.example.com", query)
+      "https://api.example.com?foo=a+%2B+b&bar=true"
   """
   @spec build_url(Tesla.Env.url(), Tesla.Env.query(), encoding_strategy) :: binary
   def build_url(url, query, encoding \\ :www_form)
+
+  def build_url(url, %Tesla.QueryString{} = query_string, _encoding) do
+    Tesla.QueryString.append_to_url(query_string, url)
+  end
 
   def build_url(url, [], _encoding), do: url
   def build_url(url, query, _encoding) when map_size(query) == 0, do: url
@@ -458,6 +469,10 @@ defmodule Tesla do
 
   @spec encode_query(Tesla.Env.query(), encoding_strategy) :: binary
   def encode_query(query, encoding \\ :www_form)
+
+  def encode_query(%Tesla.QueryString{} = query_string, _encoding) do
+    Tesla.QueryString.to_query(query_string)
+  end
 
   def encode_query(query, fun) when is_function(fun, 1), do: fun.(query)
 

--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -45,6 +45,7 @@ defmodule Tesla.Env do
   @type query_pair :: {query_key, param}
   @type query_list :: [query_pair]
   @type query_param :: Tesla.QueryParam.t()
+  @type query_string :: Tesla.QueryString.t()
   @type param :: query_scalar | query_scalar_list | query_list | %{optional(query_key) => param}
 
   @typedoc """
@@ -58,8 +59,11 @@ defmodule Tesla.Env do
 
   Map query params do not guarantee encoded parameter order. Pass an ordered list
   of pairs if the exact query string order matters.
+
+  A `t:Tesla.QueryString.t/0` value represents the entire URL query string and
+  must not be mixed with normal query params.
   """
-  @type query :: [query_pair] | [query_param] | %{optional(query_key) => param}
+  @type query :: [query_pair] | [query_param] | query_string | %{optional(query_key) => param}
   @type headers :: [{binary, binary}]
 
   @type body :: any

--- a/lib/tesla/middleware/query.ex
+++ b/lib/tesla/middleware/query.ex
@@ -18,6 +18,8 @@ defmodule Tesla.Middleware.Query do
   @behaviour Tesla.Middleware
 
   alias Tesla.Middleware.Query.Modern
+  alias Tesla.QueryString
+  alias Tesla.QueryStringError
 
   @impl Tesla.Middleware
   def call(env, next, mode: :modern), do: Modern.call(env, next)
@@ -34,12 +36,35 @@ defmodule Tesla.Middleware.Query do
     Map.update!(env, :query, &merge_query_params(&1, query))
   end
 
+  defp merge_query_params(%QueryString{} = existing, query) do
+    case empty_query?(query) do
+      true -> existing
+      false -> raise_mixed_query_string!(query)
+    end
+  end
+
+  defp merge_query_params(existing, %QueryString{} = query) do
+    case empty_query?(existing) do
+      true -> query
+      false -> raise_mixed_query_string!(existing)
+    end
+  end
+
   defp merge_query_params(existing, query) when is_map(existing) and is_map(query) do
     Map.merge(query, existing)
   end
 
   defp merge_query_params(existing, query) do
     to_query_list(existing) ++ to_query_list(query)
+  end
+
+  defp empty_query?(nil), do: true
+  defp empty_query?([]), do: true
+  defp empty_query?(query) when is_map(query), do: map_size(query) == 0
+  defp empty_query?(_query), do: false
+
+  defp raise_mixed_query_string!(query) do
+    raise QueryStringError, reason: :mixed_query_params, query: query
   end
 
   defp to_query_list(query) when is_map(query), do: Map.to_list(query)

--- a/lib/tesla/query_string.ex
+++ b/lib/tesla/query_string.ex
@@ -1,0 +1,147 @@
+defmodule Tesla.QueryString do
+  @moduledoc """
+  A whole URL query string with explicit serialization.
+
+  `Tesla.QueryString` is a Tesla-native value object for requests where the
+  entire query string is serialized as one value. It is useful for OpenAPI 3.2
+  [`in: "querystring"` parameters][oas-parameter-locations], where the query
+  string is content-based and does not behave like a normal named query
+  parameter.
+
+  Pass a query string value directly as the request `:query`:
+
+      alias Tesla.QueryString
+
+      Tesla.get(client, "/search",
+        query: QueryString.form!(foo: "a + b", bar: true)
+      )
+
+  The encoded query string is resolved before the adapter sends the request.
+
+  ## Constructors
+
+    * `raw!/2` - accepts an already-serialized query string, without the leading
+      `?`.
+    * `form!/1` - serializes structured params as
+      `application/x-www-form-urlencoded` using Tesla's default query encoder.
+
+  [oas-parameter-locations]: https://spec.openapis.org/oas/latest.html#parameter-locations
+  """
+
+  alias Tesla.QueryStringError
+
+  @derive {Inspect, except: [:encoded]}
+  @enforce_keys [:encoded, :content_type]
+  defstruct [:encoded, :content_type]
+
+  @type content_type :: String.t()
+  @opaque t :: %__MODULE__{
+            encoded: String.t(),
+            content_type: content_type()
+          }
+
+  @form_content_type "application/x-www-form-urlencoded"
+
+  @spec raw!(String.t(), keyword()) :: t()
+  def raw!(encoded, opts \\ []) do
+    opts = validate_options!(opts)
+
+    %__MODULE__{
+      encoded: validate_encoded!(encoded),
+      content_type: validate_content_type!(opts[:content_type])
+    }
+  end
+
+  @spec form!(Tesla.Env.query()) :: t()
+  def form!(params) do
+    %__MODULE__{
+      encoded: Tesla.encode_query(params),
+      content_type: @form_content_type
+    }
+  end
+
+  @doc false
+  @spec append_to_url(%__MODULE__{}, Tesla.Env.url()) :: Tesla.Env.url()
+  def append_to_url(%__MODULE__{} = query_string, url) do
+    case :binary.match(url, ["?", "#"]) do
+      {index, 1} ->
+        append_after_marker(url, query_string, index)
+
+      :nomatch ->
+        append_query(url, query_string)
+    end
+  end
+
+  @doc false
+  @spec to_query(%__MODULE__{}) :: String.t()
+  def to_query(%__MODULE__{encoded: encoded}) do
+    encoded
+  end
+
+  defp append_after_marker(url, query_string, index) do
+    case :binary.at(url, index) do
+      ?? ->
+        raise QueryStringError, reason: :existing_query_string, url: url
+
+      ?# ->
+        append_query_before_fragment(url, query_string, index)
+    end
+  end
+
+  defp append_query_before_fragment(url, %__MODULE__{encoded: ""}, _fragment_index) do
+    url
+  end
+
+  defp append_query_before_fragment(url, query_string, fragment_index) do
+    base = binary_part(url, 0, fragment_index)
+    fragment = binary_part(url, fragment_index, byte_size(url) - fragment_index)
+
+    base <> "?" <> to_query(query_string) <> fragment
+  end
+
+  defp append_query(url, %__MODULE__{encoded: ""}) do
+    url
+  end
+
+  defp append_query(url, query_string) do
+    url <> "?" <> to_query(query_string)
+  end
+
+  defp validate_options!(opts) do
+    Keyword.validate!(opts, content_type: @form_content_type)
+  rescue
+    error in [ArgumentError, FunctionClauseError] ->
+      raise QueryStringError,
+        reason: :invalid_options,
+        value: opts,
+        details: Exception.message(error)
+  end
+
+  defp validate_encoded!(encoded) when is_binary(encoded) do
+    case String.starts_with?(encoded, "?") do
+      true ->
+        raise QueryStringError, reason: :leading_query_delimiter, value: encoded
+
+      false ->
+        encoded
+    end
+  end
+
+  defp validate_encoded!(encoded) do
+    raise QueryStringError, reason: :invalid_query_string, value: encoded
+  end
+
+  defp validate_content_type!(content_type) when is_binary(content_type) do
+    case content_type do
+      "" ->
+        raise QueryStringError, reason: :empty_content_type, value: content_type
+
+      content_type ->
+        content_type
+    end
+  end
+
+  defp validate_content_type!(content_type) do
+    raise QueryStringError, reason: :invalid_content_type, value: content_type
+  end
+end

--- a/lib/tesla/query_string_error.ex
+++ b/lib/tesla/query_string_error.ex
@@ -1,0 +1,51 @@
+defmodule Tesla.QueryStringError do
+  @moduledoc """
+  Raised when a whole `Tesla.QueryString` cannot own the request query string.
+  """
+
+  defexception [:reason, :query, :url, :value, :details]
+
+  @type reason ::
+          :empty_content_type
+          | :existing_query_string
+          | :invalid_content_type
+          | :invalid_options
+          | :invalid_query_string
+          | :leading_query_delimiter
+          | :mixed_query_params
+  @type t :: %__MODULE__{
+          reason: reason(),
+          query: term(),
+          value: term(),
+          details: String.t() | nil,
+          url: String.t() | nil
+        }
+
+  def message(%__MODULE__{reason: :existing_query_string} = _value) do
+    "cannot append #{inspect(Tesla.QueryString)} to a URL that already contains a query string"
+  end
+
+  def message(%__MODULE__{reason: :mixed_query_params} = value) do
+    "cannot merge #{inspect(Tesla.QueryString)} with normal query params; got #{inspect(value.query)}"
+  end
+
+  def message(%__MODULE__{reason: :leading_query_delimiter} = value) do
+    "expected query string not to include a leading ?; got #{inspect(value.value)}"
+  end
+
+  def message(%__MODULE__{reason: :invalid_query_string} = value) do
+    "expected query string to be a string; got #{inspect(value.value)}"
+  end
+
+  def message(%__MODULE__{reason: :empty_content_type} = _value) do
+    "expected query string content type to be a non-empty string"
+  end
+
+  def message(%__MODULE__{reason: :invalid_content_type} = value) do
+    "expected query string content type to be a string; got #{inspect(value.value)}"
+  end
+
+  def message(%__MODULE__{reason: :invalid_options} = value) do
+    "invalid query string options: #{value.details}"
+  end
+end

--- a/test/tesla/middleware/query_test.exs
+++ b/test/tesla/middleware/query_test.exs
@@ -1,6 +1,8 @@
 defmodule Tesla.Middleware.QueryTest do
   use ExUnit.Case
   alias Tesla.Env
+  alias Tesla.QueryString
+  alias Tesla.QueryStringError
 
   @middleware Tesla.Middleware.Query
 
@@ -45,5 +47,46 @@ defmodule Tesla.Middleware.QueryTest do
   test "merges existing list query with map defaults without crashing" do
     assert {:ok, env} = @middleware.call(%Env{query: [page: 1]}, [], %{per_page: 10})
     assert env.query == [page: 1, per_page: 10]
+  end
+
+  test "uses query string defaults when request query is empty" do
+    query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
+
+    assert {:ok, env} = @middleware.call(%Env{query: []}, [], query_string)
+    assert env.query == query_string
+  end
+
+  test "uses query string defaults when request query is nil" do
+    query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
+
+    assert {:ok, env} = @middleware.call(%Env{query: nil}, [], query_string)
+    assert env.query == query_string
+  end
+
+  test "keeps existing query string when defaults are empty" do
+    query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
+
+    assert {:ok, env} = @middleware.call(%Env{query: query_string}, [], [])
+    assert env.query == query_string
+  end
+
+  test "rejects merging existing query string with normal defaults" do
+    query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
+
+    assert_raise QueryStringError,
+                 ~r/cannot merge Tesla.QueryString with normal query params/,
+                 fn ->
+                   @middleware.call(%Env{query: query_string}, [], page: 1)
+                 end
+  end
+
+  test "rejects merging normal request query with query string defaults" do
+    query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
+
+    assert_raise QueryStringError,
+                 ~r/cannot merge Tesla.QueryString with normal query params/,
+                 fn ->
+                   @middleware.call(%Env{query: [page: 1]}, [], query_string)
+                 end
   end
 end

--- a/test/tesla/query_string_test.exs
+++ b/test/tesla/query_string_test.exs
@@ -1,0 +1,133 @@
+defmodule Tesla.QueryStringTest do
+  use ExUnit.Case, async: true
+
+  alias Tesla.QueryString
+  alias Tesla.QueryStringError
+
+  test "raw! builds a query string from already serialized content" do
+    assert %QueryString{
+             content_type: "application/x-www-form-urlencoded"
+           } = query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
+
+    assert QueryString.to_query(query_string) == "foo=a+%2B+b&bar=true"
+  end
+
+  test "raw! accepts an explicit content type" do
+    query_string =
+      QueryString.raw!("%7B%22numbers%22%3A%5B1%2C2%5D%7D",
+        content_type: "application/json"
+      )
+
+    assert %QueryString{content_type: "application/json"} = query_string
+    assert QueryString.to_query(query_string) == "%7B%22numbers%22%3A%5B1%2C2%5D%7D"
+  end
+
+  test "form! serializes structured params as form-urlencoded query content" do
+    query_string = QueryString.form!(foo: "a + b", bar: true)
+
+    assert %QueryString{content_type: "application/x-www-form-urlencoded"} = query_string
+    assert QueryString.to_query(query_string) == "foo=a+%2B+b&bar=true"
+  end
+
+  test "form! supports nested params through Tesla query encoding" do
+    query_string = QueryString.form!(filters: [pagination: [page: 2]])
+
+    assert QueryString.to_query(query_string) == "filters%5Bpagination%5D%5Bpage%5D=2"
+  end
+
+  test "does not inspect encoded query content" do
+    inspected = inspect(QueryString.raw!("token=secret-token"))
+
+    refute inspected =~ "secret-token"
+    assert inspected =~ ~s(content_type: "application/x-www-form-urlencoded")
+  end
+
+  test "appends to a URL without existing query params" do
+    query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
+
+    assert QueryString.append_to_url(query_string, "https://api.example.com/search") ==
+             "https://api.example.com/search?foo=a+%2B+b&bar=true"
+  end
+
+  test "appends before URL fragments" do
+    query_string = QueryString.raw!("foo=bar")
+
+    assert QueryString.append_to_url(query_string, "https://api.example.com/search#section") ==
+             "https://api.example.com/search?foo=bar#section"
+  end
+
+  test "ignores query delimiters inside URL fragments" do
+    query_string = QueryString.raw!("foo=bar")
+
+    assert QueryString.append_to_url(query_string, "https://api.example.com/search#section?x=1") ==
+             "https://api.example.com/search?foo=bar#section?x=1"
+  end
+
+  test "empty query strings leave URLs unchanged" do
+    assert QueryString.raw!("") |> QueryString.append_to_url("https://api.example.com/search") ==
+             "https://api.example.com/search"
+  end
+
+  test "empty query strings still reject URLs with existing query params" do
+    query_string = QueryString.raw!("")
+
+    assert_raise QueryStringError, ~r/already contains a query string/, fn ->
+      QueryString.append_to_url(query_string, "https://api.example.com/search?existing=true")
+    end
+  end
+
+  test "rejects appending to a URL that already contains query params" do
+    query_string = QueryString.raw!("foo=bar")
+
+    assert_raise QueryStringError, ~r/already contains a query string/, fn ->
+      QueryString.append_to_url(query_string, "https://api.example.com/search?existing=true")
+    end
+  end
+
+  test "rejects appending to a URL that already contains query params before a fragment" do
+    query_string = QueryString.raw!("foo=bar")
+
+    assert_raise QueryStringError, ~r/already contains a query string/, fn ->
+      QueryString.append_to_url(
+        query_string,
+        "https://api.example.com/search?existing=true#section"
+      )
+    end
+  end
+
+  test "rejects a leading query delimiter" do
+    assert_raise QueryStringError, ~r/not to include a leading \?/, fn ->
+      QueryString.raw!("?foo=bar")
+    end
+  end
+
+  test "rejects non-string raw query strings" do
+    assert_raise QueryStringError, ~r/expected query string to be a string/, fn ->
+      QueryString.raw!(foo: "bar")
+    end
+  end
+
+  test "rejects non-string content types" do
+    assert_raise QueryStringError, ~r/expected query string content type to be a string/, fn ->
+      QueryString.raw!("foo=bar", content_type: :json)
+    end
+  end
+
+  test "rejects empty content types" do
+    assert_raise QueryStringError, ~r/content type to be a non-empty string/, fn ->
+      QueryString.raw!("foo=bar", content_type: "")
+    end
+  end
+
+  test "rejects document location as a hand-written option" do
+    assert_raise QueryStringError, ~r/unknown keys \[:in\]/, fn ->
+      QueryString.raw!("foo=bar", in: :querystring)
+    end
+  end
+
+  test "rejects non-keyword options" do
+    assert_raise QueryStringError, ~r/invalid query string options/, fn ->
+      QueryString.raw!("foo=bar", %{})
+    end
+  end
+end

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -397,6 +397,34 @@ defmodule TeslaTest do
       assert build_url(@api_url, query_params, &TestSupport.custom_query_encoder/1) ==
                @api_url <> "?name=foo+bar&page=2"
     end
+
+    test "whole query string" do
+      query_string = Tesla.QueryString.raw!("foo=a+%2B+b&bar=true")
+
+      assert build_url(@api_url, query_string) == @api_url <> "?foo=a+%2B+b&bar=true"
+    end
+
+    test "whole form-urlencoded query string" do
+      query_string = Tesla.QueryString.form!(foo: "a + b", bar: true)
+
+      assert build_url(@api_url, query_string) == @api_url <> "?foo=a+%2B+b&bar=true"
+    end
+
+    test "whole query string ignores custom query encoders" do
+      query_string = Tesla.QueryString.raw!("foo=a+%2B+b&bar=true")
+
+      assert build_url(@api_url, query_string, fn _query ->
+               raise "should not be called"
+             end) == @api_url <> "?foo=a+%2B+b&bar=true"
+    end
+
+    test "whole query string rejects URLs with existing query params" do
+      query_string = Tesla.QueryString.raw!("page=2")
+
+      assert_raise Tesla.QueryStringError, ~r/already contains a query string/, fn ->
+        build_url(@api_url <> "?user=3", query_string)
+      end
+    end
   end
 
   describe "build_url/1" do
@@ -421,6 +449,22 @@ defmodule TeslaTest do
         }
 
       assert Tesla.build_url(env) == @api_url <> "?user_name=John+Smith"
+    end
+
+    test "returns URL with whole query string from Tesla.Env struct" do
+      env = %Tesla.Env{url: @api_url, query: Tesla.QueryString.raw!("foo=a+%2B+b&bar=true")}
+
+      assert Tesla.build_url(env) == @api_url <> "?foo=a+%2B+b&bar=true"
+    end
+  end
+
+  describe "encode_query/2" do
+    test "whole query string returns its serialized value" do
+      query_string = Tesla.QueryString.raw!("foo=a+%2B+b&bar=true")
+
+      assert Tesla.encode_query(query_string, fn _query ->
+               raise "should not be called"
+             end) == "foo=a+%2B+b&bar=true"
     end
   end
 end


### PR DESCRIPTION
- Querystring parameters need an explicit value boundary because they own the full URL query string.
- Generated clients need a safe way to preserve that ownership without teaching adapters OpenAPI semantics.