### PR TITLE
feat(path-params): support precompiled path templates

### DIFF
--- a/lib/tesla/middleware/path_params.ex
+++ b/lib/tesla/middleware/path_params.ex
@@ -14,6 +14,22 @@ defmodule Tesla.Middleware.PathParams do
   `mode: :modern` to require a list of `Tesla.PathParam` values and
   use their explicit serialization settings.
 
+  ## Precompiled OpenAPI Path Templates
+
+  Generated clients can precompile OpenAPI Path Templating strings with
+  `Tesla.PathTemplate` and pass the template through request private data.
+  This keeps `env.url` as a string while letting `mode: :modern` skip parsing
+  the same template on every request.
+
+  ```elixir
+  template = Tesla.PathTemplate.new!("/users/{id}")
+
+  Tesla.get(client, template.path,
+    opts: [path_params: [Tesla.PathParam.new!("id", 42)]],
+    private: Tesla.PathTemplate.put_private(template)
+  )
+  ```
+
   ## Parameter Name Restrictions
 
   Phoenix style parameters may contain letters, numbers, or underscores,
@@ -21,13 +37,18 @@ defmodule Tesla.Middleware.PathParams do
 
     :[a-zA-Z][_a-zA-Z0-9]*\b
 
-  OpenAPI style parameters may contain letters, numbers, underscores, or
-  hyphens (`-`), matching this regular expression:
+  In legacy substitution mode, OpenAPI-style placeholders may contain letters,
+  numbers, underscores, or hyphens (`-`), matching this regular expression:
 
     \{[a-zA-Z][-_a-zA-Z0-9]*\}
 
-  In either case, parameters that begin with underscores (`_`), hyphens (`-`),
-  or numbers (`0-9`) are ignored and left as-is.
+  In legacy substitution mode, parameters that begin with underscores (`_`),
+  hyphens (`-`), or numbers (`0-9`) are ignored and left as-is.
+
+  In `mode: :modern`, OpenAPI-style placeholders are matched as `{name}` where
+  `name` is any non-empty value between balanced braces. When using
+  `Tesla.PathTemplate`, template expression names follow OpenAPI Path
+  Templating syntax instead of the legacy substitution regex.
 
   ## Examples
 

--- a/lib/tesla/middleware/path_params/modern.ex
+++ b/lib/tesla/middleware/path_params/modern.ex
@@ -1,20 +1,36 @@
 defmodule Tesla.Middleware.PathParams.Modern do
   @moduledoc false
 
+  alias Tesla.Env
   alias Tesla.Param
   alias Tesla.PathParam
+  alias Tesla.PathTemplate
 
-  def call(env, next) do
-    url = build_url(env.url, env.opts[:path_params])
+  def call(%Env{opts: opts} = env, next) do
+    url = build_url(env, opts[:path_params])
     Tesla.run(%{env | url: url}, next)
   end
 
-  defp build_url(url, nil) do
-    url
+  defp build_url(%Env{} = env, nil) do
+    env.url
+  end
+
+  defp build_url(%Env{} = env, params) when is_list(params) do
+    case PathTemplate.fetch_private(env.private) do
+      {:ok, template} ->
+        build_url(env.url, template, params)
+
+      :error ->
+        build_url(env.url, params)
+    end
+  end
+
+  defp build_url(%Env{} = env, params) do
+    build_url(env.url, params)
   end
 
   defp build_url(url, params) when is_list(params) do
-    params = index_params!(params)
+    params = path_params_by_name!(params)
 
     Regex.replace(~r/[{]([^{}]+)[}]/, url, &replace_placeholder(params, &1, &2))
   end
@@ -23,11 +39,29 @@ defmodule Tesla.Middleware.PathParams.Modern do
     url
   end
 
-  defp index_params!(params) do
-    Enum.reduce(params, %{}, &index_param!/2)
+  defp build_url(url, template, params) do
+    params = path_params_by_name!(params)
+
+    case PathTemplate.render(template, url, params, &render_template_expression/3) do
+      {:ok, rendered_url} ->
+        rendered_url
+
+      {:error, :path_mismatch} ->
+        Regex.replace(~r/[{]([^{}]+)[}]/, url, &replace_placeholder(params, &1, &2))
+    end
   end
 
-  defp index_param!(%PathParam{name: name} = param, params) do
+  defp render_template_expression(name, expression, params) do
+    params
+    |> Map.get(name)
+    |> replace_param(expression)
+  end
+
+  defp path_params_by_name!(params) do
+    Enum.reduce(params, %{}, &put_path_param_by_name!/2)
+  end
+
+  defp put_path_param_by_name!(%PathParam{name: name} = param, params) do
     case Map.has_key?(params, name) do
       true ->
         raise ArgumentError, "duplicate path parameter #{inspect(name)} in modern mode"
@@ -37,7 +71,7 @@ defmodule Tesla.Middleware.PathParams.Modern do
     end
   end
 
-  defp index_param!(value, _params) do
+  defp put_path_param_by_name!(value, _params) do
     raise ArgumentError,
           "expected path_params to be a list of #{inspect(PathParam)} structs in modern mode; got #{inspect(value)}"
   end

--- a/lib/tesla/path_template.ex
+++ b/lib/tesla/path_template.ex
@@ -1,0 +1,240 @@
+defmodule Tesla.PathTemplate do
+  @moduledoc """
+  A precompiled OpenAPI Path Templating path.
+
+  `Tesla.PathTemplate` keeps the request path as a string while carrying a
+  compiled representation that `Tesla.Middleware.PathParams` can use to avoid
+  parsing the same path template on every request.
+
+      alias Tesla.PathTemplate
+
+      template = PathTemplate.new!("/items/{id}")
+
+      Tesla.get(client, template.path,
+        opts: [path_params: [Tesla.PathParam.new!("id", id)]],
+        private: PathTemplate.put_private(template)
+      )
+
+  Path templates follow the [OpenAPI Path Templating][oas-path-templating]
+  syntax for `{name}` template expressions.
+
+  [oas-path-templating]: https://spec.openapis.org/oas/latest.html#path-templating
+  """
+
+  @derive {Inspect, except: [:parts]}
+  @enforce_keys [:path, :parts]
+  defstruct [:path, :parts]
+
+  @typep expression_part ::
+           {:expr, name :: String.t(), expression :: String.t()}
+  @typep part :: String.t() | expression_part()
+  @typep renderer :: (String.t(), String.t(), map() -> iodata())
+  @opaque t :: %__MODULE__{
+            path: String.t(),
+            parts: [part()]
+          }
+
+  @private_key :tesla_path_template
+
+  @spec new!(String.t()) :: t()
+  def new!(path) when is_binary(path) do
+    parts =
+      path
+      |> compile()
+      |> validate_unique_names!()
+
+    %__MODULE__{path: validate_path!(path), parts: parts}
+  end
+
+  @doc """
+  Adds the compiled path template to Tesla request private data.
+
+      template = Tesla.PathTemplate.new!("/items/{id}")
+
+      Tesla.get(client, template.path,
+        opts: [path_params: [Tesla.PathParam.new!("id", id)]],
+        private: Tesla.PathTemplate.put_private(template)
+      )
+  """
+  @spec put_private(t(), Tesla.Env.private()) :: Tesla.Env.private()
+  def put_private(%__MODULE__{} = template, private \\ %{}) when is_map(private) do
+    Map.put(private, @private_key, template)
+  end
+
+  @doc false
+  @spec fetch_private(Tesla.Env.private()) :: {:ok, t()} | :error
+  def fetch_private(private) when is_map(private) do
+    case Map.fetch(private, @private_key) do
+      {:ok, %__MODULE__{} = template} ->
+        {:ok, template}
+
+      {:ok, _value} ->
+        :error
+
+      :error ->
+        :error
+    end
+  end
+
+  @doc false
+  @spec render(t(), String.t(), map(), renderer()) ::
+          {:ok, String.t()} | {:error, :path_mismatch}
+  def render(%__MODULE__{} = template, path, params, renderer)
+      when is_binary(path) and is_map(params) and is_function(renderer, 3) do
+    case template.path == path do
+      true ->
+        rendered_path =
+          template.parts
+          |> render_parts(params, renderer, [])
+          |> IO.iodata_to_binary()
+
+        {:ok, rendered_path}
+
+      false ->
+        {:error, :path_mismatch}
+    end
+  end
+
+  defp render_parts([], _params, _renderer, parts) do
+    :lists.reverse(parts)
+  end
+
+  defp render_parts([{:expr, name, expression} | rest], params, renderer, parts) do
+    part = renderer.(name, expression, params)
+
+    render_parts(rest, params, renderer, [part | parts])
+  end
+
+  defp render_parts([literal | rest], params, renderer, parts) do
+    render_parts(rest, params, renderer, [literal | parts])
+  end
+
+  defp validate_path!("") do
+    raise ArgumentError, "expected path template path to start with /"
+  end
+
+  defp validate_path!("/" <> _path = path) do
+    path
+  end
+
+  defp validate_path!(_path) do
+    raise ArgumentError, "expected path template path to start with /"
+  end
+
+  defp compile(path) do
+    path
+    |> compile_parts(0, [])
+    |> :lists.reverse()
+  end
+
+  defp compile_parts(path, offset, parts) do
+    case match_template_delimiter(path, offset) do
+      :nomatch ->
+        add_literal!(parts, binary_part(path, offset, byte_size(path) - offset))
+
+      {index, ?}} ->
+        raise ArgumentError,
+              "unexpected closing } in path template #{inspect(path)} at byte #{index}"
+
+      {open_index, ?{} ->
+        compile_template_expression(path, open_index, parts, offset)
+    end
+  end
+
+  defp compile_template_expression(path, open_index, parts, offset) do
+    close_offset = open_index + 1
+
+    case match_template_delimiter(path, close_offset) do
+      :nomatch ->
+        raise ArgumentError, "unclosed template expression in path template #{inspect(path)}"
+
+      {_index, ?{} ->
+        raise ArgumentError,
+              "nested template expressions are not valid in path template #{inspect(path)}"
+
+      {close_index, ?}} ->
+        compile_closed_template_expression(path, open_index, close_index, parts, offset)
+    end
+  end
+
+  defp compile_closed_template_expression(path, open_index, close_index, _parts, _offset)
+       when close_index == open_index + 1 do
+    raise ArgumentError, "empty template expression in path template #{inspect(path)}"
+  end
+
+  defp compile_closed_template_expression(path, open_index, close_index, parts, offset) do
+    name_length = close_index - open_index - 1
+    name = binary_part(path, open_index + 1, name_length)
+    expression = binary_part(path, open_index, close_index - open_index + 1)
+    literal = binary_part(path, offset, open_index - offset)
+    parts = [{:expr, name, expression} | add_literal!(parts, literal)]
+
+    compile_parts(path, close_index + 1, parts)
+  end
+
+  defp match_template_delimiter(path, offset) when offset < byte_size(path) do
+    size = byte_size(path)
+
+    case :binary.match(path, ["{", "}"], scope: {offset, size - offset}) do
+      {index, 1} -> {index, :binary.at(path, index)}
+      :nomatch -> :nomatch
+    end
+  end
+
+  defp match_template_delimiter(_path, _offset) do
+    :nomatch
+  end
+
+  defp add_literal!(parts, "") do
+    parts
+  end
+
+  defp add_literal!(parts, literal) do
+    case :binary.match(literal, ["?", "#"]) do
+      :nomatch ->
+        [literal | parts]
+
+      _match ->
+        raise ArgumentError, "expected path template path not to include query or fragment"
+    end
+  end
+
+  defp validate_unique_names!(parts) do
+    {_names, duplicates} =
+      Enum.reduce(parts, {MapSet.new(), MapSet.new()}, &track_name/2)
+
+    raise_duplicate_names!(duplicates)
+
+    parts
+  end
+
+  defp track_name({:expr, name, _expression}, {names, duplicates}) do
+    case MapSet.member?(names, name) do
+      true ->
+        {names, MapSet.put(duplicates, name)}
+
+      false ->
+        {MapSet.put(names, name), duplicates}
+    end
+  end
+
+  defp track_name(_literal, acc) do
+    acc
+  end
+
+  defp raise_duplicate_names!(duplicates) do
+    names =
+      duplicates
+      |> MapSet.to_list()
+      |> Enum.sort()
+
+    case names do
+      [] ->
+        :ok
+
+      names ->
+        raise ArgumentError,
+              "duplicate template expressions #{inspect(names)} in path template"
+    end
+  end
+end

--- a/test/tesla/middleware/path_params/modern_test.exs
+++ b/test/tesla/middleware/path_params/modern_test.exs
@@ -3,6 +3,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
 
   alias Tesla.Env
   alias Tesla.PathParam
+  alias Tesla.PathTemplate
 
   @middleware Tesla.Middleware.PathParams
 
@@ -14,6 +15,10 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
   defp path_param(name, value) when is_binary(name), do: PathParam.new!(name, value)
   defp path_param(value, opts) when is_list(opts), do: PathParam.new!("id", value, opts)
   defp path_param(name, value, opts), do: PathParam.new!(name, value, opts)
+
+  defp path_template_private(template) do
+    PathTemplate.put_private(template)
+  end
 
   describe "mode: :modern — simple style" do
     test "primitive (explode false) renders raw value" do
@@ -454,6 +459,85 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
                )
 
       assert env.url == "/users/{}"
+    end
+  end
+
+  describe "mode: :modern — precompiled OpenAPI path templates" do
+    test "uses a matching path template from private data" do
+      template = PathTemplate.new!("/users/{id}{coords}")
+
+      opts = [
+        path_params: [
+          path_param(5),
+          path_param("coords", ["blue", "black"], style: :matrix, explode: true)
+        ]
+      ]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{
+                   url: template.path,
+                   private: path_template_private(template),
+                   opts: opts
+                 },
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/5;coords=blue;coords=black"
+    end
+
+    test "preserves missing and nil template expressions" do
+      template = PathTemplate.new!("/users/{id}/{missing}")
+      opts = [path_params: [path_param(nil)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{
+                   url: template.path,
+                   private: path_template_private(template),
+                   opts: opts
+                 },
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/{id}/{missing}"
+    end
+
+    test "falls back when private path template does not match the request path" do
+      template = PathTemplate.new!("/other/{id}")
+      opts = [path_params: [path_param(42)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{
+                   url: "/users/{id}",
+                   private: path_template_private(template),
+                   opts: opts
+                 },
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/42"
+    end
+
+    test "falls back when private path template data is invalid" do
+      opts = [path_params: [path_param(42)]]
+
+      assert {:ok, env} =
+               @middleware.call(
+                 %Env{
+                   url: "/users/{id}",
+                   private: %{tesla_path_template: :invalid},
+                   opts: opts
+                 },
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/users/42"
     end
   end
 

--- a/test/tesla/path_template_test.exs
+++ b/test/tesla/path_template_test.exs
@@ -1,0 +1,142 @@
+defmodule Tesla.PathTemplateTest do
+  use ExUnit.Case, async: true
+
+  alias Tesla.PathTemplate
+
+  defp render_expression(name, _expression, params) do
+    Map.fetch!(params, name)
+  end
+
+  test "new! compiles OpenAPI template expressions" do
+    assert %PathTemplate{
+             path: "/items/{id}{coords}",
+             parts: [
+               "/items/",
+               {:expr, "id", "{id}"},
+               {:expr, "coords", "{coords}"}
+             ]
+           } = PathTemplate.new!("/items/{id}{coords}")
+  end
+
+  test "new! keeps literal paths" do
+    assert %PathTemplate{path: "/items", parts: ["/items"]} = PathTemplate.new!("/items")
+  end
+
+  test "new! supports OpenAPI template expression names" do
+    assert %PathTemplate{
+             parts: [
+               "/items/",
+               {:expr, "color.name+shade", "{color.name+shade}"}
+             ]
+           } = PathTemplate.new!("/items/{color.name+shade}")
+  end
+
+  test "new! supports unicode template expression names" do
+    assert %PathTemplate{
+             parts: ["/items/", {:expr, "café", "{café}"}]
+           } = PathTemplate.new!("/items/{café}")
+  end
+
+  test "new! supports delimiter characters inside template expression names" do
+    assert %PathTemplate{
+             parts: [
+               "/items/",
+               {:expr, "filter?sort#page", "{filter?sort#page}"}
+             ]
+           } = PathTemplate.new!("/items/{filter?sort#page}")
+  end
+
+  test "inspect hides compiled parts" do
+    inspected = inspect(PathTemplate.new!("/items/{id}"))
+
+    assert inspected =~ ~s(path: "/items/{id}")
+    refute inspected =~ "expr"
+  end
+
+  test "put_private adds template to request private data" do
+    template = PathTemplate.new!("/items/{id}")
+
+    assert PathTemplate.put_private(template) == %{tesla_path_template: template}
+  end
+
+  test "put_private preserves existing private data" do
+    template = PathTemplate.new!("/items/{id}")
+
+    assert PathTemplate.put_private(template, %{request_id: "abc123"}) == %{
+             request_id: "abc123",
+             tesla_path_template: template
+           }
+  end
+
+  test "fetch_private ignores invalid private data" do
+    assert PathTemplate.fetch_private(%{tesla_path_template: :invalid}) == :error
+  end
+
+  test "render returns rendered path" do
+    template = PathTemplate.new!("/items/{id}")
+
+    assert PathTemplate.render(template, "/items/{id}", %{"id" => "42"}, &render_expression/3) ==
+             {:ok, "/items/42"}
+  end
+
+  test "render returns named error when path does not match template path" do
+    template = PathTemplate.new!("/items/{id}")
+
+    assert PathTemplate.render(template, "/users/{id}", %{"id" => "42"}, &render_expression/3) ==
+             {:error, :path_mismatch}
+  end
+
+  test "rejects paths that do not start with slash" do
+    assert_raise ArgumentError, ~r/start with \//, fn ->
+      PathTemplate.new!("items/{id}")
+    end
+  end
+
+  test "rejects query strings" do
+    assert_raise ArgumentError, ~r/not to include query or fragment/, fn ->
+      PathTemplate.new!("/items/{id}?x=1")
+    end
+  end
+
+  test "rejects fragments" do
+    assert_raise ArgumentError, ~r/not to include query or fragment/, fn ->
+      PathTemplate.new!("/items/{id}#details")
+    end
+  end
+
+  test "rejects unclosed template expression" do
+    assert_raise ArgumentError, ~r/unclosed template expression/, fn ->
+      PathTemplate.new!("/items/{id")
+    end
+  end
+
+  test "rejects unexpected closing delimiter" do
+    assert_raise ArgumentError, ~r/unexpected closing \}/, fn ->
+      PathTemplate.new!("/items/id}")
+    end
+  end
+
+  test "rejects nested template expressions" do
+    assert_raise ArgumentError, ~r/nested template expressions/, fn ->
+      PathTemplate.new!("/items/{i{d}}")
+    end
+  end
+
+  test "rejects empty template expressions" do
+    assert_raise ArgumentError, ~r/empty template expression/, fn ->
+      PathTemplate.new!("/items/{}")
+    end
+  end
+
+  test "rejects duplicate template expressions" do
+    assert_raise ArgumentError, ~r/duplicate template expressions \["id"\]/, fn ->
+      PathTemplate.new!("/items/{id}/related/{id}")
+    end
+  end
+
+  test "rejects duplicate template expressions once" do
+    assert_raise ArgumentError, ~r/duplicate template expressions \["id", "org"\]/, fn ->
+      PathTemplate.new!("/orgs/{org}/items/{id}/related/{id}/{org}")
+    end
+  end
+end


### PR DESCRIPTION
- Generated clients should be able to reuse OpenAPI path templates without reparsing placeholders for every request.
- Existing middleware and adapters should continue receiving a normal request URL while modern path params can use the optimized path.