### PR TITLE
feat(path-params): separate definitions from values

### DIFF
--- a/lib/tesla/middleware/path_params.ex
+++ b/lib/tesla/middleware/path_params.ex
@@ -11,8 +11,8 @@ defmodule Tesla.Middleware.PathParams do
   protocol and produce `{key, value}` tuples when enumerated.
 
   By default, this middleware preserves legacy string substitution. Pass
-  `mode: :modern` to require a list of `Tesla.PathParam` values and
-  use their explicit serialization settings.
+  `mode: :modern` to read `Tesla.PathParams` definitions from request private
+  data and use their explicit serialization settings.
 
   ## Precompiled OpenAPI Path Templates
 
@@ -23,10 +23,16 @@ defmodule Tesla.Middleware.PathParams do
 
   ```elixir
   template = Tesla.PathTemplate.new!("/users/{id}")
+  path_params = Tesla.PathParams.new!([Tesla.PathParam.new!("id")])
+
+  private =
+    %{}
+    |> Tesla.PathTemplate.put_private(template)
+    |> Tesla.PathParams.put_private(path_params)
 
   Tesla.get(client, template.path,
-    opts: [path_params: [Tesla.PathParam.new!("id", 42)]],
-    private: Tesla.PathTemplate.put_private(template)
+    opts: [path_params: %{"id" => 42}],
+    private: private
   )
   ```
 

--- a/lib/tesla/middleware/path_params/modern.ex
+++ b/lib/tesla/middleware/path_params/modern.ex
@@ -4,6 +4,7 @@ defmodule Tesla.Middleware.PathParams.Modern do
   alias Tesla.Env
   alias Tesla.Param
   alias Tesla.PathParam
+  alias Tesla.PathParams
   alias Tesla.PathTemplate
 
   def call(%Env{opts: opts} = env, next) do
@@ -15,81 +16,87 @@ defmodule Tesla.Middleware.PathParams.Modern do
     env.url
   end
 
-  defp build_url(%Env{} = env, params) when is_list(params) do
-    case PathTemplate.fetch_private(env.private) do
-      {:ok, template} ->
-        build_url(env.url, template, params)
+  defp build_url(%Env{} = env, values) when is_map(values) do
+    case PathParams.fetch_private(env.private) do
+      {:ok, path_params} ->
+        build_url(env, path_params, values)
 
       :error ->
-        build_url(env.url, params)
+        raise ArgumentError,
+              "expected #{inspect(PathParams)} private data when using path_params in modern mode"
     end
   end
 
-  defp build_url(%Env{} = env, params) do
-    build_url(env.url, params)
+  defp build_url(%Env{} = _env, values) do
+    raise ArgumentError,
+          "expected path_params to be a map of request values in modern mode; got #{inspect(values)}"
   end
 
-  defp build_url(url, params) when is_list(params) do
-    params = path_params_by_name!(params)
+  defp build_url(%Env{} = env, path_params, values) do
+    case PathTemplate.fetch_private(env.private) do
+      {:ok, template} ->
+        build_url(env.url, template, path_params, values)
 
-    Regex.replace(~r/[{]([^{}]+)[}]/, url, &replace_placeholder(params, &1, &2))
+      :error ->
+        build_url(env.url, path_params, values)
+    end
   end
 
-  defp build_url(url, _params) do
-    url
+  defp build_url(url, path_params, values) do
+    Regex.replace(~r/[{]([^{}]+)[}]/, url, &replace_placeholder(path_params, values, &1, &2))
   end
 
-  defp build_url(url, template, params) do
-    params = path_params_by_name!(params)
+  defp build_url(url, template, path_params, values) do
+    render_context = {path_params, values}
 
-    case PathTemplate.render(template, url, params, &render_template_expression/3) do
+    case PathTemplate.render(template, url, render_context, &render_template_expression/3) do
       {:ok, rendered_url} ->
         rendered_url
 
       {:error, :path_mismatch} ->
-        Regex.replace(~r/[{]([^{}]+)[}]/, url, &replace_placeholder(params, &1, &2))
+        build_url(url, path_params, values)
     end
   end
 
-  defp render_template_expression(name, expression, params) do
-    params
-    |> Map.get(name)
-    |> replace_param(expression)
+  defp render_template_expression(name, expression, {path_params, values}) do
+    replace_param(path_params, values, name, expression)
   end
 
-  defp path_params_by_name!(params) do
-    Enum.reduce(params, %{}, &put_path_param_by_name!/2)
+  defp replace_placeholder(path_params, values, match, name) do
+    replace_param(path_params, values, name, match)
   end
 
-  defp put_path_param_by_name!(%PathParam{name: name} = param, params) do
-    case Map.has_key?(params, name) do
-      true ->
-        raise ArgumentError, "duplicate path parameter #{inspect(name)} in modern mode"
+  defp replace_param(path_params, values, name, match) do
+    case fetch_param(path_params, values, name) do
+      {:ok, _path_param, nil} ->
+        match
 
-      false ->
-        Map.put(params, name, param)
+      {:ok, path_param, value} ->
+        serialize_value(path_param, value)
+
+      :error ->
+        match
     end
   end
 
-  defp put_path_param_by_name!(value, _params) do
-    raise ArgumentError,
-          "expected path_params to be a list of #{inspect(PathParam)} structs in modern mode; got #{inspect(value)}"
+  defp fetch_param(path_params, values, name) do
+    case PathParams.fetch(path_params, name) do
+      {:ok, path_param} ->
+        fetch_value(path_param, values, name)
+
+      :error ->
+        :error
+    end
   end
 
-  defp replace_placeholder(params, match, name) when is_map(params) do
-    replace_param(Map.get(params, name), match)
-  end
+  defp fetch_value(path_param, values, name) do
+    case Map.fetch(values, name) do
+      {:ok, value} ->
+        {:ok, path_param, value}
 
-  defp replace_param(%PathParam{value: nil}, match) do
-    match
-  end
-
-  defp replace_param(%PathParam{} = param, _match) do
-    serialize_value(param)
-  end
-
-  defp replace_param(nil, match) do
-    match
+      :error ->
+        :error
+    end
   end
 
   defp serialize_undefined(:simple, _param) do
@@ -104,21 +111,21 @@ defmodule Tesla.Middleware.PathParams.Modern do
     "."
   end
 
-  defp serialize_value(%PathParam{style: :simple} = param) do
-    param
-    |> value_type()
+  defp serialize_value(%PathParam{style: :simple} = param, value) do
+    value
+    |> Param.value_type()
     |> serialize_simple(param)
   end
 
-  defp serialize_value(%PathParam{style: :matrix} = param) do
-    param
-    |> value_type()
+  defp serialize_value(%PathParam{style: :matrix} = param, value) do
+    value
+    |> Param.value_type()
     |> serialize_matrix(param)
   end
 
-  defp serialize_value(%PathParam{style: :label} = param) do
-    param
-    |> value_type()
+  defp serialize_value(%PathParam{style: :label} = param, value) do
+    value
+    |> Param.value_type()
     |> serialize_label(param)
   end
 
@@ -234,9 +241,5 @@ defmodule Tesla.Middleware.PathParams.Modern do
 
   defp join_encoded_values(values, separator, param) do
     Enum.map_join(values, separator, &PathParam.encode_value(param, &1))
-  end
-
-  defp value_type(%PathParam{value: value}) do
-    Param.value_type(value)
   end
 end

--- a/lib/tesla/path_param.ex
+++ b/lib/tesla/path_param.ex
@@ -1,30 +1,34 @@
 defmodule Tesla.PathParam do
   @moduledoc """
-  A path parameter with explicit serialization settings.
+  A path parameter definition with explicit serialization settings.
 
-  `Tesla.PathParam` is a Tesla-native value object for path parameters whose
-  serialization needs to be controlled explicitly. Its serialization options
-  follow the OpenAPI path parameter style semantics, while keeping the public
-  API focused on the path use case.
+  `Tesla.PathParam` is a Tesla-native value object for path parameter metadata
+  whose serialization needs to be controlled explicitly. Its serialization
+  options follow the OpenAPI path parameter style semantics, while keeping the
+  public API focused on the path use case.
 
-  In `Tesla.Middleware.PathParams` `:modern` mode, wrap each path parameter
-  explicitly, even when the default path serialization is enough:
+  In `Tesla.Middleware.PathParams` `:modern` mode, define path parameters once
+  and pass them through request private data with `Tesla.PathParams`:
 
-      opts: [path_params: [PathParam.new!("id", 42)]]
+      path_params = Tesla.PathParams.new!([PathParam.new!("id")])
+      private = Tesla.PathParams.put_private(path_params)
+
+      Tesla.get(client, "/items/{id}",
+        opts: [path_params: %{"id" => 42}],
+        private: private
+      )
 
   Pass options when a value needs non-default path serialization:
 
       alias Tesla.PathParam
 
-      opts: [
-        path_params: [
-          PathParam.new!("coords", ["blue", "black"], style: :matrix, explode: true)
-        ]
-      ]
+      Tesla.PathParams.new!([
+        PathParam.new!("coords", style: :matrix, explode: true)
+      ])
 
   ## Options
 
-  `new!/3` accepts a keyword list using Elixir atoms for hand-written Tesla
+  `new!/2` accepts a keyword list using Elixir atoms for hand-written Tesla
   code:
 
     * `:style` — one of `:simple`, `:matrix`, `:label`. Defaults to `:simple`.
@@ -35,7 +39,7 @@ defmodule Tesla.PathParam do
 
   ## Encoding
 
-  `Tesla.Middleware.PathParams` serializes `Tesla.PathParam` values using the
+  `Tesla.Middleware.PathParams` serializes values using the
   [OpenAPI path parameter rules][oas-style] for the `simple`, `matrix`, and
   `label` styles. Serialized values are percent-encoded against the RFC 3986
   unreserved set (`A-Z`, `a-z`, `0-9`, `-`, `_`, `.`, `~`); spaces become
@@ -62,14 +66,12 @@ defmodule Tesla.PathParam do
 
   alias Tesla.Param
 
-  @derive {Inspect, except: [:value]}
-  @enforce_keys [:name, :value, :style, :explode, :allow_reserved]
-  defstruct [:name, :value, :style, :explode, :allow_reserved]
+  @enforce_keys [:name, :style, :explode, :allow_reserved]
+  defstruct [:name, :style, :explode, :allow_reserved]
 
   @type style :: :simple | :matrix | :label
   @opaque t :: %__MODULE__{
             name: String.t(),
-            value: term(),
             style: style(),
             explode: boolean(),
             allow_reserved: boolean()
@@ -78,15 +80,14 @@ defmodule Tesla.PathParam do
   @styles [:simple, :matrix, :label]
   @expected_styles ":simple, :matrix, or :label"
 
-  @spec new!(String.t(), term(), keyword()) :: t()
-  def new!(name, value, opts \\ []) do
+  @spec new!(String.t(), keyword()) :: t()
+  def new!(name, opts \\ []) do
     name = Param.validate_name!(:path, name)
     opts = Param.validate_opts!(:path, opts)
     opts = Keyword.validate!(opts, style: :simple, explode: false, allow_reserved: false)
 
     %__MODULE__{
       name: name,
-      value: value,
       style: validate_style!(opts[:style]),
       explode: Param.validate_explode!(:path, opts[:explode]),
       allow_reserved: Param.validate_allow_reserved!(:path, opts[:allow_reserved])

--- a/lib/tesla/path_params.ex
+++ b/lib/tesla/path_params.ex
@@ -1,0 +1,101 @@
+defmodule Tesla.PathParams do
+  @moduledoc """
+  Precompiled path parameter definitions for `Tesla.Middleware.PathParams`.
+
+  `Tesla.PathParams` keeps static path parameter metadata separate from
+  per-request values. Generated clients can build it once, store it in request
+  private data, and pass only the dynamic values through `opts[:path_params]`.
+
+      alias Tesla.{PathParam, PathParams}
+
+      path_params =
+        PathParams.new!([
+          PathParam.new!("id"),
+          PathParam.new!("coords", style: :matrix, explode: true)
+        ])
+
+      private = PathParams.put_private(path_params)
+
+      Tesla.get(client, "/items/{id}{coords}",
+        opts: [path_params: %{"id" => 5, "coords" => ["blue", "black"]}],
+        private: private
+      )
+  """
+
+  alias Tesla.PathParam
+
+  @enforce_keys [:definitions]
+  defstruct [:definitions]
+
+  @opaque t :: %__MODULE__{
+            definitions: %{String.t() => PathParam.t()}
+          }
+
+  @private_key :tesla_path_params
+
+  @spec new!([PathParam.t()]) :: t()
+  def new!(definitions) when is_list(definitions) do
+    %__MODULE__{definitions: by_name!(definitions)}
+  end
+
+  @doc """
+  Adds path parameter definitions to Tesla request private data.
+
+      path_params = Tesla.PathParams.new!([Tesla.PathParam.new!("id")])
+      private = Tesla.PathParams.put_private(path_params)
+
+      Tesla.get(client, "/items/{id}",
+        opts: [path_params: %{"id" => 42}],
+        private: private
+      )
+  """
+  @spec put_private(t()) :: Tesla.Env.private()
+  def put_private(%__MODULE__{} = path_params) do
+    put_private(%{}, path_params)
+  end
+
+  @spec put_private(Tesla.Env.private(), t()) :: Tesla.Env.private()
+  def put_private(private, %__MODULE__{} = path_params) when is_map(private) do
+    Map.put(private, @private_key, path_params)
+  end
+
+  @doc false
+  @spec fetch_private(Tesla.Env.private()) :: {:ok, t()} | :error
+  def fetch_private(private) when is_map(private) do
+    case Map.fetch(private, @private_key) do
+      {:ok, %__MODULE__{} = path_params} ->
+        {:ok, path_params}
+
+      {:ok, _value} ->
+        :error
+
+      :error ->
+        :error
+    end
+  end
+
+  @doc false
+  @spec fetch(t(), String.t()) :: {:ok, %PathParam{}} | :error
+  def fetch(%__MODULE__{definitions: definitions}, name) when is_binary(name) do
+    Map.fetch(definitions, name)
+  end
+
+  defp by_name!(definitions) do
+    Enum.reduce(definitions, %{}, &put_definition_by_name!/2)
+  end
+
+  defp put_definition_by_name!(%PathParam{name: name} = path_param, definitions) do
+    case Map.has_key?(definitions, name) do
+      true ->
+        raise ArgumentError, "duplicate path parameter #{inspect(name)}"
+
+      false ->
+        Map.put(definitions, name, path_param)
+    end
+  end
+
+  defp put_definition_by_name!(value, _definitions) do
+    raise ArgumentError,
+          "expected path parameter definitions to be #{inspect(PathParam)} structs; got #{inspect(value)}"
+  end
+end

--- a/lib/tesla/path_template.ex
+++ b/lib/tesla/path_template.ex
@@ -9,10 +9,16 @@ defmodule Tesla.PathTemplate do
       alias Tesla.PathTemplate
 
       template = PathTemplate.new!("/items/{id}")
+      path_params = Tesla.PathParams.new!([Tesla.PathParam.new!("id")])
+
+      private =
+        %{}
+        |> PathTemplate.put_private(template)
+        |> Tesla.PathParams.put_private(path_params)
 
       Tesla.get(client, template.path,
-        opts: [path_params: [Tesla.PathParam.new!("id", id)]],
-        private: PathTemplate.put_private(template)
+        opts: [path_params: %{"id" => id}],
+        private: private
       )
 
   Path templates follow the [OpenAPI Path Templating][oas-path-templating]
@@ -28,7 +34,7 @@ defmodule Tesla.PathTemplate do
   @typep expression_part ::
            {:expr, name :: String.t(), expression :: String.t()}
   @typep part :: String.t() | expression_part()
-  @typep renderer :: (String.t(), String.t(), map() -> iodata())
+  @typep renderer :: (String.t(), String.t(), term() -> iodata())
   @opaque t :: %__MODULE__{
             path: String.t(),
             parts: [part()]
@@ -50,14 +56,25 @@ defmodule Tesla.PathTemplate do
   Adds the compiled path template to Tesla request private data.
 
       template = Tesla.PathTemplate.new!("/items/{id}")
+      path_params = Tesla.PathParams.new!([Tesla.PathParam.new!("id")])
+
+      private =
+        %{}
+        |> Tesla.PathTemplate.put_private(template)
+        |> Tesla.PathParams.put_private(path_params)
 
       Tesla.get(client, template.path,
-        opts: [path_params: [Tesla.PathParam.new!("id", id)]],
-        private: Tesla.PathTemplate.put_private(template)
+        opts: [path_params: %{"id" => id}],
+        private: private
       )
   """
-  @spec put_private(t(), Tesla.Env.private()) :: Tesla.Env.private()
-  def put_private(%__MODULE__{} = template, private \\ %{}) when is_map(private) do
+  @spec put_private(t()) :: Tesla.Env.private()
+  def put_private(%__MODULE__{} = template) do
+    put_private(%{}, template)
+  end
+
+  @spec put_private(Tesla.Env.private(), t()) :: Tesla.Env.private()
+  def put_private(private, %__MODULE__{} = template) when is_map(private) do
     Map.put(private, @private_key, template)
   end
 
@@ -77,10 +94,10 @@ defmodule Tesla.PathTemplate do
   end
 
   @doc false
-  @spec render(t(), String.t(), map(), renderer()) ::
+  @spec render(t(), String.t(), term(), renderer()) ::
           {:ok, String.t()} | {:error, :path_mismatch}
   def render(%__MODULE__{} = template, path, params, renderer)
-      when is_binary(path) and is_map(params) and is_function(renderer, 3) do
+      when is_binary(path) and is_function(renderer, 3) do
     case template.path == path do
       true ->
         rendered_path =

--- a/test/tesla/middleware/path_params/modern_test.exs
+++ b/test/tesla/middleware/path_params/modern_test.exs
@@ -3,6 +3,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
 
   alias Tesla.Env
   alias Tesla.PathParam
+  alias Tesla.PathParams
   alias Tesla.PathTemplate
 
   @middleware Tesla.Middleware.PathParams
@@ -11,13 +12,79 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
     defstruct [:id]
   end
 
-  defp path_param(value), do: PathParam.new!("id", value)
-  defp path_param(name, value) when is_binary(name), do: PathParam.new!(name, value)
-  defp path_param(value, opts) when is_list(opts), do: PathParam.new!("id", value, opts)
-  defp path_param(name, value, opts), do: PathParam.new!(name, value, opts)
+  defp path_param(value) do
+    path_param("id", value, [])
+  end
+
+  defp path_param(name, value) when is_binary(name) do
+    path_param(name, value, [])
+  end
+
+  defp path_param(value, opts) when is_list(opts) do
+    path_param("id", value, opts)
+  end
+
+  defp path_param(name, value, opts) do
+    {PathParam.new!(name, opts), value}
+  end
 
   defp path_template_private(template) do
-    PathTemplate.put_private(template)
+    PathTemplate.put_private(%{}, template)
+  end
+
+  defp call(%Env{} = env, next, mode: :modern) do
+    env = put_path_params_private(env)
+
+    @middleware.call(env, next, mode: :modern)
+  end
+
+  defp call(%Env{} = env, next, opts) do
+    @middleware.call(env, next, opts)
+  end
+
+  defp put_path_params_private(%Env{opts: opts} = env) do
+    case opts[:path_params] do
+      params when is_list(params) ->
+        put_path_params_private(env, params)
+
+      _params ->
+        env
+    end
+  end
+
+  defp put_path_params_private(%Env{} = env, params) do
+    case Enum.all?(params, &path_param_pair?/1) do
+      true ->
+        definitions =
+          params
+          |> Enum.map(&definition_from_path_param_pair/1)
+          |> PathParams.new!()
+
+        values = Map.new(params, &value_from_path_param_pair/1)
+        private = PathParams.put_private(env.private, definitions)
+        opts = Keyword.put(env.opts, :path_params, values)
+
+        %Env{env | private: private, opts: opts}
+
+      false ->
+        env
+    end
+  end
+
+  defp path_param_pair?({%PathParam{}, _value}) do
+    true
+  end
+
+  defp path_param_pair?(_value) do
+    false
+  end
+
+  defp definition_from_path_param_pair({path_param, _value}) do
+    path_param
+  end
+
+  defp value_from_path_param_pair({%PathParam{name: name}, value}) do
+    {name, value}
   end
 
   describe "mode: :modern — simple style" do
@@ -25,7 +92,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param(5, style: :simple, explode: false)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -38,7 +105,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param(5, style: :simple, explode: true)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -51,7 +118,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param([3, 4, 5], style: :simple, explode: false)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -64,7 +131,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param([3, 4, 5], style: :simple, explode: true)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -81,7 +148,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -98,7 +165,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -113,7 +180,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param(5, style: :matrix, explode: false)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -126,7 +193,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param([3, 4, 5], style: :matrix, explode: false)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -139,7 +206,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param([3, 4, 5], style: :matrix, explode: true)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -156,7 +223,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -173,7 +240,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -188,7 +255,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param(5, style: :label, explode: false)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -201,7 +268,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param([3, 4, 5], style: :label, explode: false)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -214,7 +281,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param([3, 4, 5], style: :label, explode: true)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -231,7 +298,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -248,7 +315,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -301,7 +368,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
         ]
 
         assert {:ok, env} =
-                 @middleware.call(
+                 call(
                    %Env{url: "/users/{color}", opts: opts},
                    [],
                    mode: :modern
@@ -340,7 +407,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
         ]
 
         assert {:ok, env} =
-                 @middleware.call(
+                 call(
                    %Env{url: "/users/{color}", opts: opts},
                    [],
                    mode: :modern
@@ -356,7 +423,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param("1color", "blue")]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{1color}", opts: opts},
                  [],
                  mode: :modern
@@ -369,7 +436,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param("_color", "blue")]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{_color}", opts: opts},
                  [],
                  mode: :modern
@@ -382,7 +449,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param("-color", "blue")]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{-color}", opts: opts},
                  [],
                  mode: :modern
@@ -395,7 +462,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param("color.name+shade", "blue")]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{color.name+shade}", opts: opts},
                  [],
                  mode: :modern
@@ -413,7 +480,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}/{Id}/{ID}", opts: opts},
                  [],
                  mode: :modern
@@ -426,7 +493,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param("id", "blue")]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}/related/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -439,7 +506,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param("color name", "blue", style: :matrix)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{color name}", opts: opts},
                  [],
                  mode: :modern
@@ -452,7 +519,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param("", "blue")]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{}", opts: opts},
                  [],
                  mode: :modern
@@ -474,7 +541,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{
                    url: template.path,
                    private: path_template_private(template),
@@ -492,7 +559,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param(nil)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{
                    url: template.path,
                    private: path_template_private(template),
@@ -510,7 +577,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param(42)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{
                    url: "/users/{id}",
                    private: path_template_private(template),
@@ -527,7 +594,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param(42)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{
                    url: "/users/{id}",
                    private: %{tesla_path_template: :invalid},
@@ -564,7 +631,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
         opts = [path_params: [path_param("username", unquote(value))]]
 
         assert {:ok, env} =
-                 @middleware.call(
+                 call(
                    %Env{url: "/users/{username}", opts: opts},
                    [],
                    mode: :modern
@@ -585,7 +652,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
         opts = [path_params: [path_param("color", "", style: unquote(style))]]
 
         assert {:ok, env} =
-                 @middleware.call(
+                 call(
                    %Env{url: "/users/{color}", opts: opts},
                    [],
                    mode: :modern
@@ -599,7 +666,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param("color", "a/b?c#d")]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{color}", opts: opts},
                  [],
                  mode: :modern
@@ -612,7 +679,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param("color", ["blue,green", "black"], style: :simple)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{color}", opts: opts},
                  [],
                  mode: :modern
@@ -629,7 +696,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{color}", opts: opts},
                  [],
                  mode: :modern
@@ -644,7 +711,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{color}", opts: opts},
                  [],
                  mode: :modern
@@ -659,7 +726,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{color}", opts: opts},
                  [],
                  mode: :modern
@@ -674,7 +741,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{color}", opts: opts},
                  [],
                  mode: :modern
@@ -689,7 +756,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{color}", opts: opts},
                  [],
                  mode: :modern
@@ -704,7 +771,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{color}", opts: opts},
                  [],
                  mode: :modern
@@ -717,7 +784,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
   describe "mode: :modern — encoding & edge cases" do
     test "leaves URL untouched when no path_params are provided" do
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}"},
                  [],
                  mode: :modern
@@ -730,7 +797,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param("a/b c#d")]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -743,7 +810,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param("John Smith")]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -756,7 +823,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param("other", 1)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -765,11 +832,11 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       assert env.url == "/users/{id}"
     end
 
-    test "leaves placeholder when PathParam value is nil" do
+    test "leaves placeholder when request value is nil" do
       opts = [path_params: [path_param(nil)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -782,7 +849,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param([])]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -795,7 +862,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param(%{})]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -804,11 +871,11 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       assert env.url == "/users/"
     end
 
-    test "PathParam value uses defaults (style: :simple, explode: false)" do
+    test "path parameter definition uses defaults (style: :simple, explode: false)" do
       opts = [path_params: [path_param(42)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -817,11 +884,11 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       assert env.url == "/users/42"
     end
 
-    test "PathParam opts default :explode to false when omitted" do
+    test "path parameter opts default :explode to false when omitted" do
       opts = [path_params: [path_param([3, 4, 5], style: :matrix)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -830,11 +897,11 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       assert env.url == "/users/;id=3,4,5"
     end
 
-    test "PathParam opts default :style to :simple when omitted" do
+    test "path parameter opts default :style to :simple when omitted" do
       opts = [path_params: [path_param([3, 4, 5], explode: false)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -853,7 +920,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param(%TestUser{id: 7}, style: :simple, explode: true)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -870,7 +937,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{color}", opts: opts},
                  [],
                  mode: :modern
@@ -887,7 +954,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{color}", opts: opts},
                  [],
                  mode: :modern
@@ -896,7 +963,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       assert env.url == "/users/R=100"
     end
 
-    test "supports list-shaped path_params" do
+    test "supports multiple path parameter definitions" do
       opts = [
         path_params: [
           path_param(5),
@@ -905,7 +972,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/items/{id}{coords}", opts: opts},
                  [],
                  mode: :modern
@@ -914,11 +981,11 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       assert env.url == "/items/5;coords=blue;coords=black"
     end
 
-    test "supports named PathParam structs" do
+    test "supports named path parameter definitions" do
       opts = [path_params: [path_param(42)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -927,11 +994,11 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       assert env.url == "/users/42"
     end
 
-    test "raises on duplicate PathParam names" do
+    test "raises on duplicate path parameter definitions" do
       opts = [path_params: [path_param(1), path_param(2)]]
 
-      assert_raise ArgumentError, ~r/duplicate path parameter "id" in modern mode/, fn ->
-        @middleware.call(
+      assert_raise ArgumentError, ~r/duplicate path parameter "id"/, fn ->
+        call(
           %Env{url: "/users/{id}", opts: opts},
           [],
           mode: :modern
@@ -939,37 +1006,35 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       end
     end
 
-    test "does not treat maps as modern path_params" do
+    test "raises when request values are provided without private path params" do
       opts = [path_params: %{"id" => path_param(42)}]
 
-      assert {:ok, env} =
-               @middleware.call(
-                 %Env{url: "/users/{id}", opts: opts},
-                 [],
-                 mode: :modern
-               )
-
-      assert env.url == "/users/{id}"
+      assert_raise ArgumentError, ~r/expected Tesla.PathParams private data/, fn ->
+        call(
+          %Env{url: "/users/{id}", opts: opts},
+          [],
+          mode: :modern
+        )
+      end
     end
 
-    test "ignores struct-shaped outer containers" do
+    test "requires private path params for struct-shaped request values" do
       opts = [path_params: %TestUser{id: path_param(7)}]
 
-      assert {:ok, env} =
-               @middleware.call(
-                 %Env{url: "/users/{id}", opts: opts},
-                 [],
-                 mode: :modern
-               )
-
-      assert env.url == "/users/{id}"
+      assert_raise ArgumentError, ~r/expected Tesla.PathParams private data/, fn ->
+        call(
+          %Env{url: "/users/{id}", opts: opts},
+          [],
+          mode: :modern
+        )
+      end
     end
 
     test "leaves Phoenix-style placeholders untouched" do
       opts = [path_params: [path_param([3, 4, 5], style: :matrix, explode: true)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/:id", opts: opts},
                  [],
                  mode: :modern
@@ -994,7 +1059,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       ]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/items/{id}{coords}{tags}", opts: opts},
                  [],
                  mode: :modern
@@ -1003,26 +1068,27 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       assert env.url == "/items/5;coords=blue;coords=black.a,b,c"
     end
 
-    test "leaves URL untouched when path_params is an unsupported type" do
+    test "raises when path_params is an unsupported type" do
       opts = [path_params: 42]
 
-      assert {:ok, env} =
-               @middleware.call(
-                 %Env{url: "/users/{id}", opts: opts},
-                 [],
-                 mode: :modern
-               )
-
-      assert env.url == "/users/{id}"
+      assert_raise ArgumentError,
+                   ~r/expected path_params to be a map of request values in modern mode/,
+                   fn ->
+                     call(
+                       %Env{url: "/users/{id}", opts: opts},
+                       [],
+                       mode: :modern
+                     )
+                   end
     end
 
-    test "raises when list entries are not PathParam structs" do
+    test "raises when path_params is a keyword list" do
       opts = [path_params: [id: path_param(42)]]
 
       assert_raise ArgumentError,
-                   ~r/expected path_params to be a list of Tesla.PathParam structs in modern mode/,
+                   ~r/expected path_params to be a map of request values in modern mode/,
                    fn ->
-                     @middleware.call(
+                     call(
                        %Env{url: "/users/{id}", opts: opts},
                        [],
                        mode: :modern
@@ -1030,13 +1096,13 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
                    end
     end
 
-    test "raises when modern path_params value is not a PathParam" do
+    test "raises when path_params is a list of raw values" do
       opts = [path_params: [42]]
 
       assert_raise ArgumentError,
-                   ~r/expected path_params to be a list of Tesla.PathParam structs in modern mode/,
+                   ~r/expected path_params to be a map of request values in modern mode/,
                    fn ->
-                     @middleware.call(
+                     call(
                        %Env{url: "/users/{id}", opts: opts},
                        [],
                        mode: :modern
@@ -1044,13 +1110,13 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
                    end
     end
 
-    test "raises when modern path_params value is an option map instead of a PathParam" do
+    test "raises when path_params is a list of option maps" do
       opts = [path_params: [%{style: :simple}]]
 
       assert_raise ArgumentError,
-                   ~r/expected path_params to be a list of Tesla.PathParam structs in modern mode/,
+                   ~r/expected path_params to be a map of request values in modern mode/,
                    fn ->
-                     @middleware.call(
+                     call(
                        %Env{url: "/users/{id}", opts: opts},
                        [],
                        mode: :modern
@@ -1058,13 +1124,13 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
                    end
     end
 
-    test "raises when modern path_params value is a struct instead of a PathParam" do
+    test "raises when path_params is a list of structs" do
       opts = [path_params: [%TestUser{id: 7}]]
 
       assert_raise ArgumentError,
-                   ~r/expected path_params to be a list of Tesla.PathParam structs in modern mode/,
+                   ~r/expected path_params to be a map of request values in modern mode/,
                    fn ->
-                     @middleware.call(
+                     call(
                        %Env{url: "/users/{id}", opts: opts},
                        [],
                        mode: :modern
@@ -1076,7 +1142,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param([], style: :matrix, explode: false)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -1089,7 +1155,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param(%{}, style: :matrix, explode: true)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -1102,7 +1168,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param([], style: :label, explode: true)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -1115,7 +1181,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param(%{}, style: :label, explode: false)]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -1128,7 +1194,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       opts = [path_params: [path_param("a-b_c.d~e")]]
 
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: opts},
                  [],
                  mode: :modern
@@ -1139,7 +1205,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
 
     test "uses legacy behavior unless modern mode is matched" do
       assert {:ok, env} =
-               @middleware.call(
+               call(
                  %Env{url: "/users/{id}", opts: [path_params: [id: 1]]},
                  [],
                  mode: :foo

--- a/test/tesla/path_param_test.exs
+++ b/test/tesla/path_param_test.exs
@@ -3,52 +3,51 @@ defmodule Tesla.PathParamTest do
 
   alias Tesla.Env
   alias Tesla.PathParam
+  alias Tesla.PathParams
 
   @middleware Tesla.Middleware.PathParams
 
   test "uses default serialization options" do
     assert %PathParam{
              name: "id",
-             value: 42,
              style: :simple,
              explode: false,
              allow_reserved: false
-           } = PathParam.new!("id", 42)
+           } = PathParam.new!("id")
   end
 
   test "accepts explicit serialization options" do
     assert %PathParam{
              name: "id",
-             value: ["blue", "black"],
              style: :label,
              explode: true,
              allow_reserved: true
            } =
-             PathParam.new!("id", ["blue", "black"],
+             PathParam.new!("id",
                style: :label,
                explode: true,
                allow_reserved: true
              )
   end
 
-  test "does not inspect runtime values" do
-    inspected = inspect(PathParam.new!("token", "secret-token", style: :matrix))
+  test "inspects static metadata" do
+    inspected = inspect(PathParam.new!("token", style: :matrix))
 
-    refute inspected =~ "secret-token"
     assert inspected =~ ~s(name: "token")
     assert inspected =~ "style: :matrix"
   end
 
   test "serializes a path parameter with explicit keyword options" do
-    opts = [
-      path_params: [
-        PathParam.new!("coords", ["blue", "black"], style: :matrix, explode: true)
-      ]
-    ]
+    path_params = PathParams.new!([PathParam.new!("coords", style: :matrix, explode: true)])
+    opts = [path_params: %{"coords" => ["blue", "black"]}]
 
     assert {:ok, env} =
              @middleware.call(
-               %Env{url: "/items/{coords}", opts: opts},
+               %Env{
+                 url: "/items/{coords}",
+                 opts: opts,
+                 private: PathParams.put_private(path_params)
+               },
                [],
                mode: :modern
              )
@@ -58,74 +57,69 @@ defmodule Tesla.PathParamTest do
 
   test "rejects document location as a hand-written option" do
     assert_raise ArgumentError, ~r/unknown keys \[:in\]/, fn ->
-      PathParam.new!("color", "blue", in: :path)
+      PathParam.new!("color", in: :path)
     end
   end
 
   test "rejects string styles in hand-written keyword options" do
     assert_raise ArgumentError, ~r/expected :simple, :matrix, or :label/, fn ->
-      PathParam.new!("color", "blue", style: "matrix")
+      PathParam.new!("color", style: "matrix")
     end
   end
 
   test "rejects non-path style atoms" do
     for style <- [:form, :space_delimited, :pipe_delimited, :deep_object, :cookie] do
       assert_raise ArgumentError, ~r/expected :simple, :matrix, or :label/, fn ->
-        PathParam.new!("color", "blue", style: style)
+        PathParam.new!("color", style: style)
       end
     end
   end
 
   test "rejects non-string names" do
     assert_raise ArgumentError, ~r/expected path parameter name to be a string/, fn ->
-      PathParam.new!(:color, "blue")
+      PathParam.new!(:color)
     end
   end
 
   test "rejects non-boolean explode option" do
     assert_raise ArgumentError, ~r/expected :explode to be a boolean/, fn ->
-      PathParam.new!("color", "blue", explode: "true")
+      PathParam.new!("color", explode: "true")
     end
   end
 
   test "rejects non-boolean allow_reserved option" do
     assert_raise ArgumentError, ~r/expected :allow_reserved to be a boolean/, fn ->
-      PathParam.new!("color", "blue", allow_reserved: 1)
+      PathParam.new!("color", allow_reserved: 1)
     end
   end
 
   test "rejects atom-keyed maps as options" do
     assert_raise ArgumentError, ~r/expected path parameter options to be a keyword list/, fn ->
-      PathParam.new!("color", "blue", %{style: :matrix})
+      PathParam.new!("color", %{style: :matrix})
     end
   end
 
   test "rejects string-keyed maps as options" do
     assert_raise ArgumentError, ~r/expected path parameter options to be a keyword list/, fn ->
-      PathParam.new!("color", "blue", %{"style" => :matrix})
+      PathParam.new!("color", %{"style" => :matrix})
     end
   end
 
   test "rejects non-keyword lists as options" do
     assert_raise ArgumentError, ~r/expected a keyword list/, fn ->
-      PathParam.new!("color", "blue", [:matrix])
+      PathParam.new!("color", [:matrix])
     end
   end
 
-  test "accepts nil values" do
-    assert %PathParam{name: "color", value: nil, style: :matrix} =
-             PathParam.new!("color", nil, style: :matrix)
-  end
-
   test "encodes values with the unreserved set by default" do
-    param = PathParam.new!("id", nil)
+    param = PathParam.new!("id")
 
     assert PathParam.encode_value(param, "AZaz09-_.~") == "AZaz09-_.~"
     assert PathParam.encode_value(param, "a b/c?d#é%") == "a%20b%2Fc%3Fd%23%C3%A9%25"
   end
 
   test "encodes values while preserving allowed reserved path characters" do
-    param = PathParam.new!("id", nil, allow_reserved: true)
+    param = PathParam.new!("id", allow_reserved: true)
 
     assert PathParam.encode_value(param, "!$&'()*+,;=:@") == "!$&'()*+,;=:@"
     assert PathParam.encode_value(param, "/?#[] é") == "%2F%3F%23%5B%5D%20%C3%A9"
@@ -133,7 +127,7 @@ defmodule Tesla.PathParamTest do
   end
 
   test "preserves valid percent triplets and escapes invalid ones when reserved are allowed" do
-    param = PathParam.new!("id", nil, allow_reserved: true)
+    param = PathParam.new!("id", allow_reserved: true)
 
     assert PathParam.encode_value(param, "%20%2F%AF%af") == "%20%2F%AF%af"
     assert PathParam.encode_value(param, "%2G%zz%") == "%252G%25zz%25"

--- a/test/tesla/path_params_test.exs
+++ b/test/tesla/path_params_test.exs
@@ -1,0 +1,51 @@
+defmodule Tesla.PathParamsTest do
+  use ExUnit.Case, async: true
+
+  alias Tesla.PathParam
+  alias Tesla.PathParams
+
+  test "indexes path parameter definitions by name" do
+    path_params =
+      PathParams.new!([
+        PathParam.new!("id"),
+        PathParam.new!("coords", style: :matrix, explode: true)
+      ])
+
+    assert {:ok, %PathParam{name: "id", style: :simple}} = PathParams.fetch(path_params, "id")
+
+    assert {:ok, %PathParam{name: "coords", style: :matrix}} =
+             PathParams.fetch(path_params, "coords")
+
+    assert PathParams.fetch(path_params, "missing") == :error
+  end
+
+  test "stores and fetches path params from request private data" do
+    path_params = PathParams.new!([PathParam.new!("id")])
+    private = PathParams.put_private(%{existing: true}, path_params)
+
+    assert private.existing
+    assert PathParams.fetch_private(private) == {:ok, path_params}
+  end
+
+  test "ignores invalid private path params data" do
+    assert PathParams.fetch_private(%{tesla_path_params: :invalid}) == :error
+    assert PathParams.fetch_private(%{}) == :error
+  end
+
+  test "raises on duplicate path parameter definitions" do
+    assert_raise ArgumentError, ~r/duplicate path parameter "id"/, fn ->
+      PathParams.new!([
+        PathParam.new!("id"),
+        PathParam.new!("id", style: :matrix)
+      ])
+    end
+  end
+
+  test "raises when definitions are not path params" do
+    assert_raise ArgumentError,
+                 ~r/expected path parameter definitions to be Tesla.PathParam structs/,
+                 fn ->
+                   PathParams.new!([%{name: "id"}])
+                 end
+  end
+end

--- a/test/tesla/path_template_test.exs
+++ b/test/tesla/path_template_test.exs
@@ -62,7 +62,7 @@ defmodule Tesla.PathTemplateTest do
   test "put_private preserves existing private data" do
     template = PathTemplate.new!("/items/{id}")
 
-    assert PathTemplate.put_private(template, %{request_id: "abc123"}) == %{
+    assert PathTemplate.put_private(%{request_id: "abc123"}, template) == %{
              request_id: "abc123",
              tesla_path_template: template
            }


### PR DESCRIPTION
- Keep generated clients from rebuilding path parameter metadata for every request.
- Preserve a clear boundary between OpenAPI-style parameter definitions and dynamic request values.
- Give the precompiled path template path a matching precompiled parameter definition path before this API ships.