### PR TITLE
feat(query-params): separate definitions from values

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Check out the following sections to learn more about `Tesla`:
 
 - `Tesla.Middleware.BaseUrl` - set base URL.
 - `Tesla.Middleware.Headers` - set request headers.
-- `Tesla.Middleware.Query` - set query parameters.
+- `Tesla.Middleware.Query` - set query parameters, including OpenAPI-style
+  query serialization in modern mode.
 - `Tesla.Middleware.Opts` - set request options.
 - `Tesla.Middleware.FollowRedirects` - follow HTTP 3xx redirects.
 - `Tesla.Middleware.MethodOverride` - set `X-Http-Method-Override` header.

--- a/guides/explanations/4.openapi.md
+++ b/guides/explanations/4.openapi.md
@@ -14,7 +14,7 @@ serialization options where they apply.
 | OpenAPI location | Tesla API |
 | --- | --- |
 | `path` | `Tesla.PathTemplate`, `Tesla.PathParam`, `Tesla.PathParams`, and `Tesla.Middleware.PathParams` in `:modern` mode |
-| `query` | `Tesla.QueryParam` and `Tesla.Middleware.Query` in `:modern` mode |
+| `query` | `Tesla.QueryParam`, `Tesla.QueryParams`, and `Tesla.Middleware.Query` in `:modern` mode |
 | `querystring` | `Tesla.QueryString` passed directly as the request `:query` |
 | `header` | `Tesla.HeaderParam.to_header/1` |
 | `cookie` | `Tesla.CookieParam.to_header/1` |
@@ -22,6 +22,16 @@ serialization options where they apply.
 `path` and `query` parameters use middleware because they are transformed into
 the final request URL. `header` and `cookie` parameters produce raw header
 tuples before the request enters the middleware stack.
+
+In `Tesla.Middleware.Query` `:modern` mode, values matching
+`Tesla.QueryParams` definitions use OpenAPI query serialization. Other query
+params remain normal Tesla query params.
+
+OpenAPI does not define a global operation flag for rejecting unknown query
+parameter names. When a query parameter schema uses `additionalProperties`,
+keep that as an object-valued `Tesla.QueryParam` value. If a generated client
+needs a closed set of top-level query names, validate that in the generated
+operation module before calling Tesla.
 
 `querystring` is separate from `query` because OpenAPI treats it as the entire
 query string value. It must not be mixed with normal query parameters.
@@ -53,8 +63,8 @@ end
 
 Use `Tesla.QueryString.raw!/2` when the OpenAPI media type already produced the
 exact query string. Do not send `Tesla.QueryString` through
-`Tesla.Middleware.Query` in `:modern` mode, which expects a list of
-`Tesla.QueryParam` structs.
+`Tesla.Middleware.Query` as a normal query map in `:modern` mode, which expects
+request values backed by `Tesla.QueryParams` private data.
 
 ## Mapping OpenAPI fields
 
@@ -74,6 +84,9 @@ OpenAPI style names that do not belong to a parameter location are not accepted
 by the corresponding Tesla value object. Tesla options use Elixir atoms and
 snake case, so OpenAPI `pipeDelimited`, `deepObject`, and `allowReserved` become
 `:pipe_delimited`, `:deep_object`, and `:allow_reserved`.
+
+`schema.additionalProperties` affects the value a generated client accepts for
+an object parameter. It does not become a `Tesla.QueryParam` option.
 
 For a generated-operation walkthrough, see
 [Working with OpenAPI parameters](../howtos/openapi-parameters.md).

--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -90,34 +90,42 @@ The static OpenAPI path metadata for those names will use `Tesla.PathParam`,
 
 ## Build the query module
 
-For `in: "query"`, return `Tesla.QueryParam` structs for
-`Tesla.Middleware.Query` in `:modern` mode:
+Start with the operation-owned value module for `in: "query"` request values.
+The final operation module will pass this map to `Tesla.Middleware.Query` in
+`:modern` mode:
 
 ```elixir
 defmodule MyApi.Operation.GetItem.Query do
-  alias Tesla.QueryParam
-
   @type t :: %__MODULE__{
+          :"$additional" => map() | nil,
           color: [String.t()],
           filter: keyword()
         }
 
-  defstruct [:color, :filter]
+  defstruct color: nil, filter: nil, "$additional": %{}
 
-  def to_query(nil), do: []
+  def to_query(nil), do: %{}
 
   def to_query(%__MODULE__{} = query) do
-    [
-      QueryParam.new!("color", query.color, style: :pipe_delimited),
-      QueryParam.new!("filter", query.filter, style: :deep_object)
-    ]
+    additional = query."$additional" || %{}
+
+    Map.merge(additional, %{
+      "color" => query.color,
+      "filter" => query.filter
+    })
   end
 end
 ```
 
 `Tesla.QueryParam` supports the OpenAPI query styles `:form`,
 `:space_delimited`, `:pipe_delimited`, and `:deep_object`. Omit optional query
-parameters from the returned list when they should not be sent.
+parameters from the returned map when they should not be sent. The static
+OpenAPI query metadata for those names will use `Tesla.QueryParam` and
+`Tesla.QueryParams` when the operation module is built.
+
+Other top-level query params can share the same request query map and remain
+normal Tesla query params. This example keeps those values in a generated
+`:"$additional"` field.
 
 ## Build the header module
 
@@ -222,7 +230,7 @@ defmodule MyApi.Operation.GetItem do
   alias MyApi.Client
   alias MyApi.Operation.GetItem.{Cookie, Header, Path, Query}
   alias MyApi.Response
-  alias Tesla.{PathParam, PathParams, PathTemplate}
+  alias Tesla.{PathParam, PathParams, PathTemplate, QueryParam, QueryParams}
 
   defstruct path: nil,
             query: nil,
@@ -248,10 +256,16 @@ defmodule MyApi.Operation.GetItem do
                  PathParam.new!("coords", style: :matrix, explode: true)
                ])
 
-  @private Map.merge(
+  @query_params QueryParams.new!([
+                  QueryParam.new!("color", style: :pipe_delimited),
+                  QueryParam.new!("filter", style: :deep_object)
+                ])
+
+  @private Tesla.Env.merge_private([
              PathTemplate.put_private(@path_template),
-             PathParams.put_private(@path_params)
-           )
+             PathParams.put_private(@path_params),
+             QueryParams.put_private(@query_params)
+           ])
 
   def new(attrs) when is_map(attrs) do
     %__MODULE__{
@@ -294,7 +308,7 @@ end
 Use `Tesla.Middleware.PathParams` in `:modern` mode when generated operations
 pass `Tesla.PathParams` through request private data. Use
 `Tesla.Middleware.Query` in `:modern` mode when generated operations pass
-`Tesla.QueryParam` values:
+`Tesla.QueryParams` through request private data:
 
 ```elixir
 defmodule MyApi.Client do
@@ -347,7 +361,11 @@ alias MyApi.Operation.GetItem.{Cookie, Header, Path, Query}
 operation =
   GetItem.new(%{
     path: %Path{id: 42, coords: ["blue", "black"]},
-    query: %Query{color: ["blue", "black"], filter: [role: "admin"]},
+    query: %Query{
+      :"$additional" => %{"debug" => true},
+      color: ["blue", "black"],
+      filter: [role: "admin"]
+    },
     headers: %Header{request_id: "req-123"},
     cookies: %Cookie{session_id: "abc123"}
   })

--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -44,7 +44,6 @@ defmodule Tesla.Env do
   @type query_scalar_list :: [query_scalar]
   @type query_pair :: {query_key, param}
   @type query_list :: [query_pair]
-  @type query_param :: Tesla.QueryParam.t()
   @type query_string :: Tesla.QueryString.t()
   @type param :: query_scalar | query_scalar_list | query_list | %{optional(query_key) => param}
 
@@ -57,13 +56,15 @@ defmodule Tesla.Env do
   - `%{filters: %{page: 1}}` will be translated to `?filters%5Bpage%5D=1`
     (that is, `filters[page]` with brackets percent-encoded by default).
 
-  Map query params do not guarantee encoded parameter order. Pass an ordered list
-  of pairs if the exact query string order matters.
+  Map query params do not guarantee encoded parameter order when Tesla's default
+  URL builder encodes them directly. In `Tesla.Middleware.Query` `:modern` mode,
+  values matching `Tesla.QueryParams` definitions are encoded in definition
+  order.
 
   A `t:Tesla.QueryString.t/0` value represents the entire URL query string and
   must not be mixed with normal query params.
   """
-  @type query :: [query_pair] | [query_param] | query_string | %{optional(query_key) => param}
+  @type query :: query_list | query_string | %{optional(query_key) => param}
   @type headers :: [{binary, binary}]
 
   @type body :: any
@@ -102,4 +103,25 @@ defmodule Tesla.Env do
             private: %{},
             __module__: nil,
             __client__: nil
+
+  @doc """
+  Merges request private data maps from left to right.
+
+  This is useful for generated clients that precompute several Tesla private
+  values as module attributes:
+
+      @private Tesla.Env.merge_private([
+                 Tesla.PathTemplate.put_private(@path_template),
+                 Tesla.PathParams.put_private(@path_params),
+                 Tesla.QueryParams.put_private(@query_params)
+               ])
+  """
+  @spec merge_private([private]) :: private
+  def merge_private(privates) when is_list(privates) do
+    Enum.reduce(privates, %{}, &merge_private/2)
+  end
+
+  defp merge_private(private, merged) when is_map(private) do
+    Map.merge(merged, private)
+  end
 end

--- a/lib/tesla/middleware/query.ex
+++ b/lib/tesla/middleware/query.ex
@@ -1,8 +1,11 @@
 defmodule Tesla.Middleware.Query do
   @moduledoc """
-  Set default query params for all requests
+  Set default query params or serialize OpenAPI-style query values.
 
-  ## Examples
+  ## Default Query Params
+
+  Pass a keyword list or map as the middleware argument to merge default query
+  params into every request:
 
   ```elixir
   defmodule MyClient do
@@ -13,6 +16,39 @@ defmodule Tesla.Middleware.Query do
     end
   end
   ```
+
+  ## Modern OpenAPI Query Params
+
+  Use `mode: :modern` with `Tesla.QueryParams` when generated clients need the
+  OpenAPI query parameter styles `:form`, `:space_delimited`,
+  `:pipe_delimited`, or `:deep_object`. Store the static parameter definitions
+  in request private data, then pass request values as a map. Other query params
+  remain normal Tesla query params:
+
+  ```elixir
+  query_params =
+    Tesla.QueryParams.new!([
+      Tesla.QueryParam.new!("filter"),
+      Tesla.QueryParam.new!("ids", style: :pipe_delimited)
+    ])
+
+  private = Tesla.QueryParams.put_private(query_params)
+
+  client = Tesla.client([{Tesla.Middleware.Query, mode: :modern}])
+
+  Tesla.get(client, "/items",
+    query: %{
+      "filter" => [status: "open", owner: "yordis"],
+      "ids" => [1, 2, 3],
+      "debug" => true
+    },
+    private: private
+  )
+  ```
+
+  Object-valued query params cover OpenAPI schemas with `additionalProperties`.
+  Unknown top-level query params, such as `"debug"` above, pass through as
+  normal Tesla query params.
   """
 
   @behaviour Tesla.Middleware

--- a/lib/tesla/middleware/query/modern.ex
+++ b/lib/tesla/middleware/query/modern.ex
@@ -1,28 +1,55 @@
 defmodule Tesla.Middleware.Query.Modern do
   @moduledoc false
 
+  alias Tesla.Env
   alias Tesla.Param
   alias Tesla.QueryParam
+  alias Tesla.QueryParams
+  alias Tesla.QueryString
 
-  def call(env, next) do
+  def call(%Env{} = env, next) do
     env
     |> build_url()
     |> Tesla.run(next)
   end
 
-  defp build_url(%{query: nil} = env) do
+  defp build_url(%Env{query: nil} = env) do
     %{env | query: []}
   end
 
-  defp build_url(%{query: params} = env) when is_list(params) do
-    parts = Enum.flat_map(params, &serialize_param/1)
-
-    %{env | url: append_query(env.url, parts), query: []}
+  defp build_url(%Env{query: []} = env) do
+    env
   end
 
-  defp build_url(%{query: params}) do
+  defp build_url(%Env{query: %QueryString{}} = env) do
+    env
+  end
+
+  defp build_url(%Env{query: values} = env) when is_map(values) do
+    case map_size(values) do
+      0 ->
+        %{env | query: []}
+
+      _size ->
+        build_url_with_query_params(env, values)
+    end
+  end
+
+  defp build_url(%Env{query: values}) do
     raise ArgumentError,
-          "expected query to be a list of #{inspect(QueryParam)} structs in modern mode; got #{inspect(params)}"
+          "expected query to be a map of request values in modern mode; got #{inspect(values)}"
+  end
+
+  defp build_url_with_query_params(%Env{private: private} = env, values) do
+    case QueryParams.fetch_private(private) do
+      {:ok, query_params} ->
+        {parts, extra_values} = serialize_params(query_params, values)
+
+        %{env | url: append_query(env.url, parts), query: extra_values}
+
+      :error ->
+        env
+    end
   end
 
   defp append_query(url, []) do
@@ -43,33 +70,55 @@ defmodule Tesla.Middleware.Query.Modern do
     end
   end
 
-  defp serialize_param(%QueryParam{style: :form} = param) do
-    param
+  defp serialize_params(query_params, values) do
+    {parts, extra_values} =
+      query_params
+      |> QueryParams.definitions()
+      |> Enum.reduce({[], values}, &serialize_defined_param/2)
+
+    {Enum.reverse(parts), normalize_extra_values(extra_values)}
+  end
+
+  defp serialize_defined_param(%QueryParam{name: name} = param, {parts, values}) do
+    case Map.fetch(values, name) do
+      {:ok, value} ->
+        param_parts = serialize_param(param, value)
+
+        {Enum.reverse(param_parts, parts), Map.delete(values, name)}
+
+      :error ->
+        {parts, values}
+    end
+  end
+
+  defp normalize_extra_values(values) when map_size(values) == 0 do
+    []
+  end
+
+  defp normalize_extra_values(values), do: values
+
+  defp serialize_param(%QueryParam{style: :form} = param, value) do
+    value
     |> value_type()
     |> serialize_form(param)
   end
 
-  defp serialize_param(%QueryParam{style: :space_delimited} = param) do
-    param
+  defp serialize_param(%QueryParam{style: :space_delimited} = param, value) do
+    value
     |> value_type()
     |> serialize_space_delimited(param)
   end
 
-  defp serialize_param(%QueryParam{style: :pipe_delimited} = param) do
-    param
+  defp serialize_param(%QueryParam{style: :pipe_delimited} = param, value) do
+    value
     |> value_type()
     |> serialize_pipe_delimited(param)
   end
 
-  defp serialize_param(%QueryParam{style: :deep_object} = param) do
-    param
+  defp serialize_param(%QueryParam{style: :deep_object} = param, value) do
+    value
     |> value_type()
     |> serialize_deep_object(param)
-  end
-
-  defp serialize_param(param) do
-    raise ArgumentError,
-          "expected query to be a list of #{inspect(QueryParam)} structs in modern mode; got #{inspect(param)}"
   end
 
   defp serialize_form(:undefined, param) do
@@ -208,7 +257,7 @@ defmodule Tesla.Middleware.Query.Modern do
     Enum.map_join(values, separator, &QueryParam.encode_value(param, &1))
   end
 
-  defp value_type(%QueryParam{value: value}) do
+  defp value_type(value) do
     Param.value_type(value)
   end
 end

--- a/lib/tesla/query_param.ex
+++ b/lib/tesla/query_param.ex
@@ -1,28 +1,36 @@
 defmodule Tesla.QueryParam do
   @moduledoc """
-  A query parameter with explicit serialization settings.
+  A query parameter definition with explicit serialization settings.
 
-  `Tesla.QueryParam` is a Tesla-native value object for query parameters whose
-  serialization needs to be controlled explicitly. Its serialization options
-  follow the OpenAPI query parameter style semantics, while keeping the public
-  API focused on the query use case.
+  `Tesla.QueryParam` is a Tesla-native value object for query parameter
+  metadata whose serialization needs to be controlled explicitly. Its
+  serialization options follow the OpenAPI query parameter style semantics,
+  while keeping the public API focused on the query use case.
 
-  In `Tesla.Middleware.Query` `:modern` mode, wrap each query parameter
-  explicitly, even when the default query serialization is enough:
+  In `Tesla.Middleware.Query` `:modern` mode, define query parameters once and
+  pass them through request private data with `Tesla.QueryParams`:
 
-      query: [QueryParam.new!("id", 42)]
+      alias Tesla.{QueryParam, QueryParams}
 
-  Pass options when a value needs non-default query serialization:
+      query_params = QueryParams.new!([QueryParam.new!("id")])
+      private = QueryParams.put_private(query_params)
+
+      Tesla.get(client, "/items",
+        query: %{"id" => 42},
+        private: private
+      )
+
+  Pass options when a query value needs non-default serialization:
 
       alias Tesla.QueryParam
 
-      query: [
-        QueryParam.new!("ids", [1, 2, 3], style: :pipe_delimited)
-      ]
+      Tesla.QueryParams.new!([
+        QueryParam.new!("ids", style: :pipe_delimited)
+      ])
 
   ## Options
 
-  `new!/3` accepts a keyword list using Elixir atoms for hand-written Tesla
+  `new!/2` accepts a keyword list using Elixir atoms for hand-written Tesla
   code:
 
     * `:style` - one of `:form`, `:space_delimited`, `:pipe_delimited`, or
@@ -35,8 +43,8 @@ defmodule Tesla.QueryParam do
 
   ## Encoding
 
-  `Tesla.Middleware.Query` serializes `Tesla.QueryParam` values using the
-  [OpenAPI query parameter rules][oas-style] for the `form`, `space_delimited`,
+  `Tesla.Middleware.Query` serializes values using the [OpenAPI query
+  parameter rules][oas-style] for the `form`, `space_delimited`,
   `pipe_delimited`, and `deep_object` styles. Serialized names and values are
   percent-encoded against the RFC 3986 unreserved set (`A-Z`, `a-z`, `0-9`,
   `-`, `_`, `.`, `~`); spaces become `%20` (not `+`).
@@ -52,23 +60,33 @@ defmodule Tesla.QueryParam do
   across Elixir versions. Pass an ordered keyword list when the exact
   serialized order matters.
 
+  ## OpenAPI additionalProperties
+
+  OpenAPI `additionalProperties` belongs to the schema of an object-valued
+  parameter. Model that parameter with `Tesla.QueryParam` and pass the dynamic
+  properties as the request value:
+
+      query_params = Tesla.QueryParams.new!([Tesla.QueryParam.new!("filter")])
+      query = %{"filter" => [status: "open", owner: "yordis"]}
+
+  In `:form` style with `explode: true`, this serializes to
+  `?status=open&owner=yordis`.
+
   ## Missing And Empty Values
 
-  Skip a query parameter by leaving it out of `env.query`. A `nil` value
-  represents the OpenAPI "undefined" value and only has a defined serialization
-  for `:form`.
+  Skip a query parameter by leaving it out of `env.query`. A present `nil`
+  value represents the OpenAPI "undefined" value and only has a defined
+  serialization for `:form`.
   """
 
   alias Tesla.Param
 
-  @derive {Inspect, except: [:value]}
-  @enforce_keys [:name, :value, :style, :explode, :allow_reserved]
-  defstruct [:name, :value, :style, :explode, :allow_reserved]
+  @enforce_keys [:name, :style, :explode, :allow_reserved]
+  defstruct [:name, :style, :explode, :allow_reserved]
 
   @type style :: :form | :space_delimited | :pipe_delimited | :deep_object
   @opaque t :: %__MODULE__{
             name: String.t(),
-            value: term(),
             style: style(),
             explode: boolean(),
             allow_reserved: boolean()
@@ -77,8 +95,8 @@ defmodule Tesla.QueryParam do
   @styles [:form, :space_delimited, :pipe_delimited, :deep_object]
   @expected_styles ":form, :space_delimited, :pipe_delimited, or :deep_object"
 
-  @spec new!(String.t(), term(), keyword()) :: t()
-  def new!(name, value, opts \\ []) do
+  @spec new!(String.t(), keyword()) :: t()
+  def new!(name, opts \\ []) do
     name = Param.validate_name!(:query, name)
     opts = Param.validate_opts!(:query, opts)
     opts = Keyword.validate!(opts, [:style, :explode, :allow_reserved])
@@ -93,7 +111,6 @@ defmodule Tesla.QueryParam do
 
     %__MODULE__{
       name: name,
-      value: value,
       style: style,
       explode: Param.validate_explode!(:query, explode),
       allow_reserved: Param.validate_allow_reserved!(:query, allow_reserved)

--- a/lib/tesla/query_params.ex
+++ b/lib/tesla/query_params.ex
@@ -1,0 +1,112 @@
+defmodule Tesla.QueryParams do
+  @moduledoc """
+  Precompiled query parameter definitions for `Tesla.Middleware.Query`.
+
+  `Tesla.QueryParams` keeps static query parameter metadata separate from
+  per-request values. Generated clients can build it once, store it in request
+  private data, and pass only dynamic values through `env.query`.
+
+      alias Tesla.{QueryParam, QueryParams}
+
+      query_params =
+        QueryParams.new!([
+          QueryParam.new!("filter"),
+          QueryParam.new!("ids", style: :pipe_delimited)
+        ])
+
+      private = QueryParams.put_private(query_params)
+
+      Tesla.get(client, "/items",
+        query: %{
+          "filter" => [status: "open", owner: "yordis"],
+          "ids" => [10, 20],
+          "debug" => true
+        },
+        private: private
+      )
+  """
+
+  alias Tesla.QueryParam
+
+  @enforce_keys [:definitions, :by_name]
+  defstruct [:definitions, :by_name]
+
+  @opaque t :: %__MODULE__{
+            definitions: [QueryParam.t()],
+            by_name: %{String.t() => QueryParam.t()}
+          }
+
+  @private_key :tesla_query_params
+
+  @spec new!([QueryParam.t()]) :: t()
+  def new!(definitions) when is_list(definitions) do
+    %__MODULE__{definitions: definitions, by_name: by_name!(definitions)}
+  end
+
+  @doc """
+  Adds query parameter definitions to Tesla request private data.
+
+      query_params = Tesla.QueryParams.new!([Tesla.QueryParam.new!("page")])
+      private = Tesla.QueryParams.put_private(query_params)
+
+      Tesla.get(client, "/items",
+        query: %{"page" => 2},
+        private: private
+      )
+  """
+  @spec put_private(t()) :: Tesla.Env.private()
+  def put_private(%__MODULE__{} = query_params) do
+    put_private(%{}, query_params)
+  end
+
+  @spec put_private(Tesla.Env.private(), t()) :: Tesla.Env.private()
+  def put_private(private, %__MODULE__{} = query_params) when is_map(private) do
+    Map.put(private, @private_key, query_params)
+  end
+
+  @doc false
+  @spec fetch_private(Tesla.Env.private()) :: {:ok, t()} | :error
+  def fetch_private(private) when is_map(private) do
+    case Map.fetch(private, @private_key) do
+      {:ok, %__MODULE__{} = query_params} ->
+        {:ok, query_params}
+
+      {:ok, _value} ->
+        :error
+
+      :error ->
+        :error
+    end
+  end
+
+  @doc false
+  @spec definitions(t()) :: [QueryParam.t()]
+  def definitions(%__MODULE__{definitions: definitions}) do
+    definitions
+  end
+
+  @doc false
+  @spec fetch(t(), String.t()) :: {:ok, %QueryParam{}} | :error
+  def fetch(%__MODULE__{by_name: by_name}, name) when is_binary(name) do
+    Map.fetch(by_name, name)
+  end
+
+  defp by_name!(definitions) do
+    Enum.reduce(definitions, %{}, &put_by_name!/2)
+  end
+
+  defp put_by_name!(%QueryParam{name: name} = query_param, by_name) do
+    case Map.has_key?(by_name, name) do
+      true ->
+        raise ArgumentError, "duplicate query parameter #{inspect(name)}"
+
+      false ->
+        Map.put(by_name, name, query_param)
+    end
+  end
+
+  defp put_by_name!(value, _by_name) do
+    raise ArgumentError,
+          "expected query parameter definitions to be #{inspect(QueryParam)} structs; got #{inspect(value)}"
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -120,6 +120,17 @@ defmodule Tesla.Mixfile do
           Tesla.Adapter,
           Tesla.Middleware
         ],
+        "OpenAPI Parameters": [
+          Tesla.CookieParam,
+          Tesla.HeaderParam,
+          Tesla.PathParam,
+          Tesla.PathParams,
+          Tesla.PathTemplate,
+          Tesla.QueryParam,
+          Tesla.QueryParams,
+          Tesla.QueryString,
+          Tesla.QueryStringError
+        ],
         Adapters: [~r/Tesla.Adapter./],
         Middlewares: [~r/Tesla.Middleware./],
         TestSupport: [~r/Tesla.TestSupport./]

--- a/test/tesla/env_test.exs
+++ b/test/tesla/env_test.exs
@@ -1,0 +1,17 @@
+defmodule Tesla.EnvTest do
+  use ExUnit.Case, async: true
+
+  alias Tesla.Env
+
+  test "merges private data maps from left to right" do
+    assert Env.merge_private([
+             %{tesla_path_template: :template},
+             %{tesla_path_params: :path_params},
+             %{tesla_query_params: :query_params, tesla_path_params: :override}
+           ]) == %{
+             tesla_path_template: :template,
+             tesla_path_params: :override,
+             tesla_query_params: :query_params
+           }
+  end
+end

--- a/test/tesla/middleware/query/modern_test.exs
+++ b/test/tesla/middleware/query/modern_test.exs
@@ -4,6 +4,8 @@ defmodule Tesla.Middleware.Query.ModernTest do
   alias Tesla.Env
   alias Tesla.Middleware.Query
   alias Tesla.QueryParam
+  alias Tesla.QueryParams
+  alias Tesla.QueryString
 
   defmodule TestFilter do
     defstruct [:role, :id]
@@ -11,62 +13,62 @@ defmodule Tesla.Middleware.Query.ModernTest do
 
   describe "OpenAPI style examples" do
     test "form style with explode false" do
-      assert_url(QueryParam.new!("color", nil, explode: false), "/colors?color=")
-      assert_url(QueryParam.new!("color", "blue", explode: false), "/colors?color=blue")
+      assert_url(query_param("color", nil, explode: false), "/colors?color=")
+      assert_url(query_param("color", "blue", explode: false), "/colors?color=blue")
 
       assert_url(
-        QueryParam.new!("color", ["blue", "black", "brown"], explode: false),
+        query_param("color", ["blue", "black", "brown"], explode: false),
         "/colors?color=blue,black,brown"
       )
 
       assert_url(
-        QueryParam.new!("color", [R: 100, G: 200, B: 150], explode: false),
+        query_param("color", [R: 100, G: 200, B: 150], explode: false),
         "/colors?color=R,100,G,200,B,150"
       )
     end
 
     test "form style with explode true" do
-      assert_url(QueryParam.new!("color", nil), "/colors?color=")
-      assert_url(QueryParam.new!("color", "blue"), "/colors?color=blue")
+      assert_url(query_param("color", nil), "/colors?color=")
+      assert_url(query_param("color", "blue"), "/colors?color=blue")
 
       assert_url(
-        QueryParam.new!("color", ["blue", "black", "brown"]),
+        query_param("color", ["blue", "black", "brown"]),
         "/colors?color=blue&color=black&color=brown"
       )
 
       assert_url(
-        QueryParam.new!("color", R: 100, G: 200, B: 150),
+        query_param("color", R: 100, G: 200, B: 150),
         "/colors?R=100&G=200&B=150"
       )
     end
 
     test "space_delimited style with explode false" do
       assert_url(
-        QueryParam.new!("color", ["blue", "black", "brown"], style: :space_delimited),
+        query_param("color", ["blue", "black", "brown"], style: :space_delimited),
         "/colors?color=blue%20black%20brown"
       )
 
       assert_url(
-        QueryParam.new!("color", [R: 100, G: 200, B: 150], style: :space_delimited),
+        query_param("color", [R: 100, G: 200, B: 150], style: :space_delimited),
         "/colors?color=R%20100%20G%20200%20B%20150"
       )
     end
 
     test "pipe_delimited style with explode false" do
       assert_url(
-        QueryParam.new!("color", ["blue", "black", "brown"], style: :pipe_delimited),
+        query_param("color", ["blue", "black", "brown"], style: :pipe_delimited),
         "/colors?color=blue%7Cblack%7Cbrown"
       )
 
       assert_url(
-        QueryParam.new!("color", [R: 100, G: 200, B: 150], style: :pipe_delimited),
+        query_param("color", [R: 100, G: 200, B: 150], style: :pipe_delimited),
         "/colors?color=R%7C100%7CG%7C200%7CB%7C150"
       )
     end
 
     test "deep_object style" do
       assert_url(
-        QueryParam.new!("color", [R: 100, G: 200, B: 150], style: :deep_object),
+        query_param("color", [R: 100, G: 200, B: 150], style: :deep_object),
         "/colors?color%5BR%5D=100&color%5BG%5D=200&color%5BB%5D=150"
       )
     end
@@ -76,28 +78,156 @@ defmodule Tesla.Middleware.Query.ModernTest do
     test "serializes a representative multi-style query" do
       assert_url(
         [
-          QueryParam.new!("page", 1),
-          QueryParam.new!("tags", ["blue", "black"]),
-          QueryParam.new!("ids", [1, 2, 3], style: :pipe_delimited),
-          QueryParam.new!("filter", [role: "admin"], style: :deep_object)
+          query_param("page", 1),
+          query_param("tags", ["blue", "black"]),
+          query_param("ids", [1, 2, 3], style: :pipe_delimited),
+          query_param("filter", [role: "admin"], style: :deep_object)
         ],
         "/colors?page=1&tags=blue&tags=black&ids=1%7C2%7C3&filter%5Brole%5D=admin"
       )
     end
 
     test "appends to an existing query string" do
-      assert_url(QueryParam.new!("page", 2), "/colors?existing=1&page=2", "/colors?existing=1")
+      assert_url(query_param("page", 2), "/colors?existing=1&page=2", "/colors?existing=1")
+    end
+
+    test "serializes values in definition order" do
+      assert_url(
+        [
+          query_param("b", 2),
+          query_param("a", 1)
+        ],
+        "/colors?b=2&a=1"
+      )
     end
 
     test "clears env.query so downstream URL builders do not encode twice" do
+      query_params = QueryParams.new!([QueryParam.new!("page")])
+
       assert {:ok, env} =
                Query.call(
-                 %Env{url: "/colors", query: [QueryParam.new!("page", 1)]},
+                 %Env{
+                   url: "/colors",
+                   query: %{"page" => 1},
+                   private: QueryParams.put_private(query_params)
+                 },
                  [],
                  mode: :modern
                )
 
       assert env.query == []
+    end
+
+    test "leaves additional query params for downstream URL builders" do
+      query_params =
+        QueryParams.new!([
+          QueryParam.new!("ids", style: :pipe_delimited)
+        ])
+
+      assert {:ok, env} =
+               Query.call(
+                 %Env{
+                   url: "/colors",
+                   query: %{
+                     "ids" => [1, 2],
+                     "debug" => true,
+                     "page" => 2
+                   },
+                   private: QueryParams.put_private(query_params)
+                 },
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/colors?ids=1%7C2"
+      assert env.query == %{"debug" => true, "page" => 2}
+    end
+
+    test "additional query params use normal Tesla query encoding downstream" do
+      query_params =
+        QueryParams.new!([
+          QueryParam.new!("ids", style: :pipe_delimited)
+        ])
+
+      assert {:ok, env} =
+               Query.call(
+                 %Env{
+                   url: "/colors",
+                   query: %{
+                     "ids" => [1, 2],
+                     "debug" => true,
+                     "q" => "John Smith"
+                   },
+                   private: QueryParams.put_private(query_params)
+                 },
+                 [],
+                 mode: :modern
+               )
+
+      query = URI.parse(Tesla.build_url(env)).query
+
+      assert String.starts_with?(query, "ids=1%7C2&")
+      assert String.contains?(query, "debug=true")
+      assert String.contains?(query, "q=John+Smith")
+    end
+
+    test "additional query params respect normal Tesla query encoding options downstream" do
+      query_params =
+        QueryParams.new!([
+          QueryParam.new!("ids", style: :pipe_delimited)
+        ])
+
+      assert {:ok, env} =
+               Query.call(
+                 %Env{
+                   url: "/colors",
+                   query: %{
+                     "ids" => [1, 2],
+                     "q" => "John Smith"
+                   },
+                   opts: [query_encoding: :rfc3986],
+                   private: QueryParams.put_private(query_params)
+                 },
+                 [],
+                 mode: :modern
+               )
+
+      query = URI.parse(Tesla.build_url(env)).query
+
+      assert String.starts_with?(query, "ids=1%7C2&")
+      assert String.contains?(query, "q=John%20Smith")
+    end
+
+    test "serializes additionalProperties object values and leaves unrelated query params" do
+      query_params =
+        QueryParams.new!([
+          QueryParam.new!("filter")
+        ])
+
+      assert {:ok, env} =
+               Query.call(
+                 %Env{
+                   url: "/colors",
+                   query: %{
+                     "filter" => [status: "open", owner: "yordis"],
+                     "debug" => true
+                   },
+                   private: QueryParams.put_private(query_params)
+                 },
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/colors?status=open&owner=yordis"
+      assert env.query == %{"debug" => true}
+    end
+
+    test "leaves normal query maps alone without query params private data" do
+      assert {:ok, env} =
+               Query.call(%Env{url: "/colors", query: %{"page" => 1}}, [], mode: :modern)
+
+      assert env.url == "/colors"
+      assert env.query == %{"page" => 1}
     end
 
     test "leaves URL untouched when query is empty" do
@@ -114,30 +244,40 @@ defmodule Tesla.Middleware.Query.ModernTest do
       assert env.query == []
     end
 
-    test "requires query to be a list of QueryParam structs" do
+    test "lets whole-query-string values pass through" do
+      query_string = QueryString.form!(q: "blue")
+
+      assert {:ok, env} =
+               Query.call(%Env{url: "/colors", query: query_string}, [], mode: :modern)
+
+      assert env.url == "/colors"
+      assert env.query == query_string
+    end
+
+    test "requires query to be a map of request values" do
       assert_raise ArgumentError,
-                   ~r/expected query to be a list of Tesla.QueryParam structs/,
+                   ~r/expected query to be a map of request values/,
                    fn ->
                      Query.call(%Env{url: "/colors", query: [id: 1]}, [], mode: :modern)
                    end
     end
 
-    test "rejects map-shaped query params" do
-      assert_raise ArgumentError,
-                   ~r/expected query to be a list of Tesla.QueryParam structs/,
-                   fn ->
-                     Query.call(%Env{url: "/colors", query: %{id: 1}}, [], mode: :modern)
-                   end
-    end
+    test "leaves query maps alone when definitions do not match any names" do
+      query_params = QueryParams.new!([QueryParam.new!("id")])
 
-    test "rejects tuple-style rich values from the old PR shape" do
-      assert_raise ArgumentError,
-                   ~r/expected query to be a list of Tesla.QueryParam structs/,
-                   fn ->
-                     Query.call(%Env{url: "/colors", query: [id: {1, style: :form}]}, [],
-                       mode: :modern
-                     )
-                   end
+      assert {:ok, env} =
+               Query.call(
+                 %Env{
+                   url: "/colors",
+                   query: %{"unknown" => 1},
+                   private: QueryParams.put_private(query_params)
+                 },
+                 [],
+                 mode: :modern
+               )
+
+      assert env.url == "/colors"
+      assert env.query == %{"unknown" => 1}
     end
   end
 
@@ -151,7 +291,7 @@ defmodule Tesla.Middleware.Query.ModernTest do
       test "#{style} with explode false rejects #{label}" do
         assert_raise ArgumentError, fn ->
           assert_url(
-            QueryParam.new!("color", unquote(Macro.escape(value)), style: unquote(style)),
+            query_param("color", unquote(Macro.escape(value)), style: unquote(style)),
             "/colors"
           )
         end
@@ -171,7 +311,7 @@ defmodule Tesla.Middleware.Query.ModernTest do
       test "#{style} with explode true rejects #{label}" do
         assert_raise ArgumentError, fn ->
           assert_url(
-            QueryParam.new!("color", unquote(Macro.escape(value)),
+            query_param("color", unquote(Macro.escape(value)),
               style: unquote(style),
               explode: true
             ),
@@ -189,7 +329,7 @@ defmodule Tesla.Middleware.Query.ModernTest do
       test "deep_object rejects #{label}" do
         assert_raise ArgumentError, fn ->
           assert_url(
-            QueryParam.new!("color", unquote(Macro.escape(value)), style: :deep_object),
+            query_param("color", unquote(Macro.escape(value)), style: :deep_object),
             "/colors"
           )
         end
@@ -199,7 +339,7 @@ defmodule Tesla.Middleware.Query.ModernTest do
     test "space_delimited does not define explode true" do
       assert_raise ArgumentError, ~r/:space_delimited style does not define explode: true/, fn ->
         assert_url(
-          QueryParam.new!("color", ["blue"], style: :space_delimited, explode: true),
+          query_param("color", ["blue"], style: :space_delimited, explode: true),
           "/colors?color=blue"
         )
       end
@@ -210,7 +350,7 @@ defmodule Tesla.Middleware.Query.ModernTest do
                    ~r/:space_delimited style requires an array or object value/,
                    fn ->
                      assert_url(
-                       QueryParam.new!("color", "blue", style: :space_delimited),
+                       query_param("color", "blue", style: :space_delimited),
                        "/colors?color=blue"
                      )
                    end
@@ -219,7 +359,7 @@ defmodule Tesla.Middleware.Query.ModernTest do
     test "pipe_delimited does not define explode true" do
       assert_raise ArgumentError, ~r/:pipe_delimited style does not define explode: true/, fn ->
         assert_url(
-          QueryParam.new!("color", ["blue"], style: :pipe_delimited, explode: true),
+          query_param("color", ["blue"], style: :pipe_delimited, explode: true),
           "/colors?color=blue"
         )
       end
@@ -230,7 +370,7 @@ defmodule Tesla.Middleware.Query.ModernTest do
                    ~r/:pipe_delimited style requires an array or object value/,
                    fn ->
                      assert_url(
-                       QueryParam.new!("color", "blue", style: :pipe_delimited),
+                       query_param("color", "blue", style: :pipe_delimited),
                        "/colors?color=blue"
                      )
                    end
@@ -238,18 +378,18 @@ defmodule Tesla.Middleware.Query.ModernTest do
 
     test "deep_object requires an object" do
       assert_raise ArgumentError, ~r/:deep_object style requires an object value/, fn ->
-        assert_url(QueryParam.new!("color", ["blue"], style: :deep_object), "/colors?color=blue")
+        assert_url(query_param("color", ["blue"], style: :deep_object), "/colors?color=blue")
       end
     end
 
     test "deep_object ignores explode" do
       assert_url(
-        QueryParam.new!("color", [R: 100], style: :deep_object, explode: true),
+        query_param("color", [R: 100], style: :deep_object, explode: true),
         "/colors?color%5BR%5D=100"
       )
 
       assert_url(
-        QueryParam.new!("color", [R: 100], style: :deep_object, explode: false),
+        query_param("color", [R: 100], style: :deep_object, explode: false),
         "/colors?color%5BR%5D=100"
       )
     end
@@ -257,24 +397,24 @@ defmodule Tesla.Middleware.Query.ModernTest do
 
   describe "encoding" do
     test "percent-encodes reserved characters by default" do
-      assert_url(QueryParam.new!("q", "a/b c#d"), "/colors?q=a%2Fb%20c%23d")
+      assert_url(query_param("q", "a/b c#d"), "/colors?q=a%2Fb%20c%23d")
     end
 
     test "keeps reserved characters in values when allow_reserved is true" do
-      assert_url(QueryParam.new!("q", "a/b c#d", allow_reserved: true), "/colors?q=a/b%20c#d")
+      assert_url(query_param("q", "a/b c#d", allow_reserved: true), "/colors?q=a/b%20c#d")
     end
 
     test "spaces become percent-encoded spaces, not plus signs" do
-      assert_url(QueryParam.new!("q", "John Smith"), "/colors?q=John%20Smith")
+      assert_url(query_param("q", "John Smith"), "/colors?q=John%20Smith")
     end
 
     test "unreserved characters stay as-is" do
-      assert_url(QueryParam.new!("q", "a-b_c.d~e"), "/colors?q=a-b_c.d~e")
+      assert_url(query_param("q", "a-b_c.d~e"), "/colors?q=a-b_c.d~e")
     end
 
     test "query names are encoded even when allow_reserved is true" do
       assert_url(
-        QueryParam.new!("filter[role]", "admin", allow_reserved: true),
+        query_param("filter[role]", "admin", allow_reserved: true),
         "/colors?filter%5Brole%5D=admin"
       )
     end
@@ -282,15 +422,14 @@ defmodule Tesla.Middleware.Query.ModernTest do
 
   describe "object values" do
     test "supports struct values as objects" do
+      query_params = QueryParams.new!([QueryParam.new!("filter", style: :deep_object)])
+
       assert {:ok, env} =
                Query.call(
                  %Env{
                    url: "/colors",
-                   query: [
-                     QueryParam.new!("filter", %TestFilter{role: "admin", id: 5},
-                       style: :deep_object
-                     )
-                   ]
+                   query: %{"filter" => %TestFilter{role: "admin", id: 5}},
+                   private: QueryParams.put_private(query_params)
                  },
                  [],
                  mode: :modern
@@ -303,11 +442,11 @@ defmodule Tesla.Middleware.Query.ModernTest do
     test "omits empty arrays and objects" do
       assert_url(
         [
-          QueryParam.new!("empty_array", []),
-          QueryParam.new!("empty_form_object", %{}),
-          QueryParam.new!("empty_object", []),
-          QueryParam.new!("empty_map", %{}, style: :deep_object),
-          QueryParam.new!("present", 1)
+          query_param("empty_array", []),
+          query_param("empty_form_object", %{}),
+          query_param("empty_object", []),
+          query_param("empty_map", %{}, style: :deep_object),
+          query_param("present", 1)
         ],
         "/colors?present=1"
       )
@@ -316,18 +455,22 @@ defmodule Tesla.Middleware.Query.ModernTest do
     test "omits empty arrays and objects for delimited styles" do
       assert_url(
         [
-          QueryParam.new!("empty_space_array", [], style: :space_delimited),
-          QueryParam.new!("empty_space_object", %{}, style: :space_delimited),
-          QueryParam.new!("empty_pipe_array", [], style: :pipe_delimited),
-          QueryParam.new!("empty_pipe_object", %{}, style: :pipe_delimited),
-          QueryParam.new!("present", 1)
+          query_param("empty_space_array", [], style: :space_delimited),
+          query_param("empty_space_object", %{}, style: :space_delimited),
+          query_param("empty_pipe_array", [], style: :pipe_delimited),
+          query_param("empty_pipe_object", %{}, style: :pipe_delimited),
+          query_param("present", 1)
         ],
         "/colors?present=1"
       )
     end
   end
 
-  defp assert_url(%QueryParam{} = param, expected_url) do
+  defp query_param(name, value, opts \\ []) do
+    {QueryParam.new!(name, opts), value}
+  end
+
+  defp assert_url({%QueryParam{}, _value} = param, expected_url) do
     assert_url([param], expected_url)
   end
 
@@ -335,13 +478,33 @@ defmodule Tesla.Middleware.Query.ModernTest do
     assert_url(params, expected_url, "/colors")
   end
 
-  defp assert_url(%QueryParam{} = param, expected_url, url) do
+  defp assert_url({%QueryParam{}, _value} = param, expected_url, url) do
     assert_url([param], expected_url, url)
   end
 
   defp assert_url(params, expected_url, url) when is_list(params) do
-    assert {:ok, env} = Query.call(%Env{url: url, query: params}, [], mode: :modern)
+    query_params = QueryParams.new!(Enum.map(params, &definition/1))
+    values = Map.new(params, &query_value/1)
+
+    assert {:ok, env} =
+             Query.call(
+               %Env{
+                 url: url,
+                 query: values,
+                 private: QueryParams.put_private(query_params)
+               },
+               [],
+               mode: :modern
+             )
 
     assert env.url == expected_url
+  end
+
+  defp definition({%QueryParam{} = query_param, _value}) do
+    query_param
+  end
+
+  defp query_value({%QueryParam{name: name}, value}) do
+    {name, value}
   end
 end

--- a/test/tesla/query_param_test.exs
+++ b/test/tesla/query_param_test.exs
@@ -6,69 +6,64 @@ defmodule Tesla.QueryParamTest do
   test "builds a form query parameter by default" do
     assert %QueryParam{
              name: "id",
-             value: 42,
              style: :form,
              explode: true,
              allow_reserved: false
-           } = QueryParam.new!("id", 42)
+           } = QueryParam.new!("id")
   end
 
   test "defaults explode to false for non-form styles" do
-    assert %QueryParam{explode: false} = QueryParam.new!("ids", [1, 2], style: :pipe_delimited)
-    assert %QueryParam{explode: false} = QueryParam.new!("ids", [1, 2], style: :space_delimited)
-    assert %QueryParam{explode: false} = QueryParam.new!("filter", [id: 1], style: :deep_object)
+    assert %QueryParam{explode: false} = QueryParam.new!("ids", style: :pipe_delimited)
+    assert %QueryParam{explode: false} = QueryParam.new!("ids", style: :space_delimited)
+    assert %QueryParam{explode: false} = QueryParam.new!("filter", style: :deep_object)
   end
 
-  test "accepts nil values" do
-    assert %QueryParam{name: "filter", value: nil} = QueryParam.new!("filter", nil)
-  end
+  test "inspects static metadata" do
+    inspected = inspect(QueryParam.new!("token", style: :deep_object))
 
-  test "derives inspect without the value" do
-    inspected = inspect(QueryParam.new!("token", "secret"))
-
-    assert inspected =~ "#Tesla.QueryParam<"
-    refute inspected =~ "secret"
+    assert inspected =~ ~s(name: "token")
+    assert inspected =~ "style: :deep_object"
   end
 
   test "rejects non-string names" do
     assert_raise ArgumentError, ~r/expected query parameter name to be a string/, fn ->
-      QueryParam.new!(:id, 42)
+      QueryParam.new!(:id)
     end
   end
 
   test "rejects non-keyword options" do
     assert_raise ArgumentError, ~r/expected query parameter options to be a keyword list/, fn ->
-      QueryParam.new!("id", 42, %{style: :form})
+      QueryParam.new!("id", %{style: :form})
     end
   end
 
   test "rejects string option keys" do
     assert_raise ArgumentError, ~r/expected a keyword list/, fn ->
-      QueryParam.new!("id", 42, [{"style", :form}])
+      QueryParam.new!("id", [{"style", :form}])
     end
   end
 
   test "rejects unknown option keys" do
     assert_raise ArgumentError, ~r/unknown keys/, fn ->
-      QueryParam.new!("id", 42, style: :form, future_field: true)
+      QueryParam.new!("id", style: :form, future_field: true)
     end
   end
 
   test "rejects unknown styles" do
     assert_raise ArgumentError, ~r/unknown query parameter style :matrix/, fn ->
-      QueryParam.new!("id", 42, style: :matrix)
+      QueryParam.new!("id", style: :matrix)
     end
   end
 
   test "rejects string styles" do
     assert_raise ArgumentError, ~r/unknown query parameter style "form"/, fn ->
-      QueryParam.new!("id", 42, style: "form")
+      QueryParam.new!("id", style: "form")
     end
   end
 
   test "rejects non-boolean explode" do
     assert_raise ArgumentError, ~r/expected query parameter :explode to be a boolean/, fn ->
-      QueryParam.new!("id", 42, explode: "true")
+      QueryParam.new!("id", explode: "true")
     end
   end
 
@@ -76,7 +71,7 @@ defmodule Tesla.QueryParamTest do
     assert_raise ArgumentError,
                  ~r/expected query parameter :allow_reserved to be a boolean/,
                  fn ->
-                   QueryParam.new!("id", 42, allow_reserved: "true")
+                   QueryParam.new!("id", allow_reserved: "true")
                  end
   end
 
@@ -85,20 +80,20 @@ defmodule Tesla.QueryParamTest do
   end
 
   test "encodes values against the unreserved set by default" do
-    param = QueryParam.new!("q", nil)
+    param = QueryParam.new!("q")
 
     assert QueryParam.encode_value(param, "a/b c#d|") == "a%2Fb%20c%23d%7C"
   end
 
   test "preserves reserved values and percent triples when allow_reserved is true" do
-    param = QueryParam.new!("q", nil, allow_reserved: true)
+    param = QueryParam.new!("q", allow_reserved: true)
 
     assert QueryParam.encode_value(param, "a/b?c#d%2Fe %zz|") ==
              "a/b?c#d%2Fe%20%25zz%7C"
   end
 
   test "preserves lowercase percent triples and escapes incomplete percent sequences" do
-    param = QueryParam.new!("q", nil, allow_reserved: true)
+    param = QueryParam.new!("q", allow_reserved: true)
 
     assert QueryParam.encode_value(param, "%2f%") == "%2f%25"
   end

--- a/test/tesla/query_params_test.exs
+++ b/test/tesla/query_params_test.exs
@@ -1,0 +1,63 @@
+defmodule Tesla.QueryParamsTest do
+  use ExUnit.Case, async: true
+
+  alias Tesla.QueryParam
+  alias Tesla.QueryParams
+
+  test "keeps query parameter definitions in declaration order" do
+    definitions = [
+      QueryParam.new!("page"),
+      QueryParam.new!("ids", style: :pipe_delimited)
+    ]
+
+    query_params = QueryParams.new!(definitions)
+
+    assert QueryParams.definitions(query_params) == definitions
+  end
+
+  test "indexes query parameter definitions by name" do
+    query_params =
+      QueryParams.new!([
+        QueryParam.new!("page"),
+        QueryParam.new!("ids", style: :pipe_delimited)
+      ])
+
+    assert {:ok, %QueryParam{name: "page", style: :form}} =
+             QueryParams.fetch(query_params, "page")
+
+    assert {:ok, %QueryParam{name: "ids", style: :pipe_delimited}} =
+             QueryParams.fetch(query_params, "ids")
+
+    assert QueryParams.fetch(query_params, "missing") == :error
+  end
+
+  test "stores and fetches query params from request private data" do
+    query_params = QueryParams.new!([QueryParam.new!("page")])
+    private = QueryParams.put_private(%{existing: true}, query_params)
+
+    assert private.existing
+    assert QueryParams.fetch_private(private) == {:ok, query_params}
+  end
+
+  test "ignores invalid private query params data" do
+    assert QueryParams.fetch_private(%{tesla_query_params: :invalid}) == :error
+    assert QueryParams.fetch_private(%{}) == :error
+  end
+
+  test "raises on duplicate query parameter definitions" do
+    assert_raise ArgumentError, ~r/duplicate query parameter "page"/, fn ->
+      QueryParams.new!([
+        QueryParam.new!("page"),
+        QueryParam.new!("page", style: :pipe_delimited)
+      ])
+    end
+  end
+
+  test "raises when definitions are not query params" do
+    assert_raise ArgumentError,
+                 ~r/expected query parameter definitions to be Tesla.QueryParam structs/,
+                 fn ->
+                   QueryParams.new!([%{name: "page"}])
+                 end
+  end
+end


### PR DESCRIPTION
- Align query serialization with the static-definition and dynamic-value split already used by path parameters before the new API is released.
- Make generated OpenAPI clients able to precompute query metadata once while passing only per-request OpenAPI values at runtime.
- Preserve ordinary query params alongside OpenAPI-defined query serialization.
- Keep the public docs and guides consistent with the release-candidate API shape.