### PR TITLE
chore(openapi): namespace parameter modules

### DIFF
--- a/guides/explanations/4.openapi.md
+++ b/guides/explanations/4.openapi.md
@@ -13,23 +13,23 @@ serialization options where they apply.
 
 | OpenAPI location | Tesla API |
 | --- | --- |
-| `path` | `Tesla.PathTemplate`, `Tesla.PathParam`, `Tesla.PathParams`, and `Tesla.Middleware.PathParams` in `:modern` mode |
-| `query` | `Tesla.QueryParam`, `Tesla.QueryParams`, and `Tesla.Middleware.Query` in `:modern` mode |
-| `querystring` | `Tesla.QueryString` passed directly as the request `:query` |
-| `header` | `Tesla.HeaderParam.to_header/1` |
-| `cookie` | `Tesla.CookieParam.to_header/1` |
+| `path` | `Tesla.OpenAPI.PathTemplate`, `Tesla.OpenAPI.PathParam`, `Tesla.OpenAPI.PathParams`, and `Tesla.Middleware.PathParams` in `:modern` mode |
+| `query` | `Tesla.OpenAPI.QueryParam`, `Tesla.OpenAPI.QueryParams`, and `Tesla.Middleware.Query` in `:modern` mode |
+| `querystring` | `Tesla.OpenAPI.QueryString` passed directly as the request `:query` |
+| `header` | `Tesla.OpenAPI.HeaderParam.to_header/1` |
+| `cookie` | `Tesla.OpenAPI.CookieParam.to_header/1` |
 
 `path` and `query` parameters use middleware because they are transformed into
 the final request URL. `header` and `cookie` parameters produce raw header
 tuples before the request enters the middleware stack.
 
 In `Tesla.Middleware.Query` `:modern` mode, values matching
-`Tesla.QueryParams` definitions use OpenAPI query serialization. Other query
+`Tesla.OpenAPI.QueryParams` definitions use OpenAPI query serialization. Other query
 params remain normal Tesla query params.
 
 OpenAPI does not define a global operation flag for rejecting unknown query
 parameter names. When a query parameter schema uses `additionalProperties`,
-keep that as an object-valued `Tesla.QueryParam` value. If a generated client
+keep that as an object-valued `Tesla.OpenAPI.QueryParam` value. If a generated client
 needs a closed set of top-level query names, validate that in the generated
 operation module before calling Tesla.
 
@@ -39,12 +39,12 @@ query string value. It must not be mixed with normal query parameters.
 ## Query string operations
 
 OpenAPI `in: "querystring"` treats the entire query string as one value. Use
-`Tesla.QueryString` for those operations instead of `Tesla.QueryParam`:
+`Tesla.OpenAPI.QueryString` for those operations instead of `Tesla.OpenAPI.QueryParam`:
 
 ```elixir
 defmodule MyApi.Operation.Search do
   alias MyApi.Client
-  alias Tesla.QueryString
+  alias Tesla.OpenAPI.QueryString
 
   defstruct query_string: nil
 
@@ -61,10 +61,10 @@ defmodule MyApi.Operation.Search do
 end
 ```
 
-Use `Tesla.QueryString.raw!/2` when the OpenAPI media type already produced the
-exact query string. Do not send `Tesla.QueryString` through
+Use `Tesla.OpenAPI.QueryString.raw!/2` when the OpenAPI media type already produced the
+exact query string. Do not send `Tesla.OpenAPI.QueryString` through
 `Tesla.Middleware.Query` as a normal query map in `:modern` mode, which expects
-request values backed by `Tesla.QueryParams` private data.
+request values backed by `Tesla.OpenAPI.QueryParams` private data.
 
 ## Mapping OpenAPI fields
 
@@ -86,7 +86,7 @@ snake case, so OpenAPI `pipeDelimited`, `deepObject`, and `allowReserved` become
 `:pipe_delimited`, `:deep_object`, and `:allow_reserved`.
 
 `schema.additionalProperties` affects the value a generated client accepts for
-an object parameter. It does not become a `Tesla.QueryParam` option.
+an object parameter. It does not become a `Tesla.OpenAPI.QueryParam` option.
 
 For a generated-operation walkthrough, see
 [Working with OpenAPI parameters](../howtos/openapi-parameters.md).

--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -85,8 +85,8 @@ defmodule MyApi.Operation.GetItem.Path do
 end
 ```
 
-The static OpenAPI path metadata for those names will use `Tesla.PathParam`,
-`Tesla.PathParams`, and `Tesla.PathTemplate` when the operation module is built.
+The static OpenAPI path metadata for those names will use `Tesla.OpenAPI.PathParam`,
+`Tesla.OpenAPI.PathParams`, and `Tesla.OpenAPI.PathTemplate` when the operation module is built.
 
 ## Build the query module
 
@@ -117,11 +117,11 @@ defmodule MyApi.Operation.GetItem.Query do
 end
 ```
 
-`Tesla.QueryParam` supports the OpenAPI query styles `:form`,
+`Tesla.OpenAPI.QueryParam` supports the OpenAPI query styles `:form`,
 `:space_delimited`, `:pipe_delimited`, and `:deep_object`. Omit optional query
 parameters from the returned map when they should not be sent. The static
-OpenAPI query metadata for those names will use `Tesla.QueryParam` and
-`Tesla.QueryParams` when the operation module is built.
+OpenAPI query metadata for those names will use `Tesla.OpenAPI.QueryParam` and
+`Tesla.OpenAPI.QueryParams` when the operation module is built.
 
 Other top-level query params can share the same request query map and remain
 normal Tesla query params. This example keeps those values in a generated
@@ -129,12 +129,12 @@ normal Tesla query params. This example keeps those values in a generated
 
 ## Build the header module
 
-For `in: "header"`, convert `Tesla.HeaderParam` structs to the raw header
+For `in: "header"`, convert `Tesla.OpenAPI.HeaderParam` structs to the raw header
 tuples accepted by Tesla:
 
 ```elixir
 defmodule MyApi.Operation.GetItem.Header do
-  alias Tesla.HeaderParam
+  alias Tesla.OpenAPI.HeaderParam
 
   @type t :: %__MODULE__{
           request_id: String.t()
@@ -152,16 +152,16 @@ defmodule MyApi.Operation.GetItem.Header do
 end
 ```
 
-`Tesla.HeaderParam` supports the OpenAPI header style `:simple`.
+`Tesla.OpenAPI.HeaderParam` supports the OpenAPI header style `:simple`.
 
 ## Build the cookie module
 
-For `in: "cookie"`, convert one or more `Tesla.CookieParam` structs into a
+For `in: "cookie"`, convert one or more `Tesla.OpenAPI.CookieParam` structs into a
 single `Cookie` header:
 
 ```elixir
 defmodule MyApi.Operation.GetItem.Cookie do
-  alias Tesla.CookieParam
+  alias Tesla.OpenAPI.CookieParam
 
   @type t :: %__MODULE__{
           session_id: String.t()
@@ -181,7 +181,7 @@ defmodule MyApi.Operation.GetItem.Cookie do
 end
 ```
 
-`Tesla.CookieParam` supports the OpenAPI cookie styles `:form` and `:cookie`.
+`Tesla.OpenAPI.CookieParam` supports the OpenAPI cookie styles `:form` and `:cookie`.
 
 ## Build the response wrapper
 
@@ -223,14 +223,14 @@ end
 
 Now assemble the nested modules into the generated operation. Static path
 metadata and request private data stay on the operation module with
-`Tesla.PathTemplate`, `Tesla.PathParam`, and `Tesla.PathParams`:
+`Tesla.OpenAPI.PathTemplate`, `Tesla.OpenAPI.PathParam`, and `Tesla.OpenAPI.PathParams`:
 
 ```elixir
 defmodule MyApi.Operation.GetItem do
   alias MyApi.Client
   alias MyApi.Operation.GetItem.{Cookie, Header, Path, Query}
   alias MyApi.Response
-  alias Tesla.{PathParam, PathParams, PathTemplate, QueryParam, QueryParams}
+  alias Tesla.OpenAPI.{PathParam, PathParams, PathTemplate, QueryParam, QueryParams}
 
   defstruct path: nil,
             query: nil,
@@ -306,9 +306,9 @@ end
 ## Build the client stack
 
 Use `Tesla.Middleware.PathParams` in `:modern` mode when generated operations
-pass `Tesla.PathParams` through request private data. Use
+pass `Tesla.OpenAPI.PathParams` through request private data. Use
 `Tesla.Middleware.Query` in `:modern` mode when generated operations pass
-`Tesla.QueryParams` through request private data:
+`Tesla.OpenAPI.QueryParams` through request private data:
 
 ```elixir
 defmodule MyApi.Client do

--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -433,18 +433,18 @@ defmodule Tesla do
   unspecified. Pass an ordered list of pairs if the exact query string order
   matters.
 
-  Pass `t:Tesla.QueryString.t/0` as the query when the entire query string is
+  Pass `t:Tesla.OpenAPI.QueryString.t/0` as the query when the entire query string is
   already serialized as one value:
 
-      iex> query = Tesla.QueryString.raw!("foo=a+%2B+b&bar=true")
+      iex> query = Tesla.OpenAPI.QueryString.raw!("foo=a+%2B+b&bar=true")
       iex> Tesla.build_url("https://api.example.com", query)
       "https://api.example.com?foo=a+%2B+b&bar=true"
   """
   @spec build_url(Tesla.Env.url(), Tesla.Env.query(), encoding_strategy) :: binary
   def build_url(url, query, encoding \\ :www_form)
 
-  def build_url(url, %Tesla.QueryString{} = query_string, _encoding) do
-    Tesla.QueryString.append_to_url(query_string, url)
+  def build_url(url, %Tesla.OpenAPI.QueryString{} = query_string, _encoding) do
+    Tesla.OpenAPI.QueryString.append_to_url(query_string, url)
   end
 
   def build_url(url, [], _encoding), do: url
@@ -470,8 +470,8 @@ defmodule Tesla do
   @spec encode_query(Tesla.Env.query(), encoding_strategy) :: binary
   def encode_query(query, encoding \\ :www_form)
 
-  def encode_query(%Tesla.QueryString{} = query_string, _encoding) do
-    Tesla.QueryString.to_query(query_string)
+  def encode_query(%Tesla.OpenAPI.QueryString{} = query_string, _encoding) do
+    Tesla.OpenAPI.QueryString.to_query(query_string)
   end
 
   def encode_query(query, fun) when is_function(fun, 1), do: fun.(query)

--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -44,7 +44,7 @@ defmodule Tesla.Env do
   @type query_scalar_list :: [query_scalar]
   @type query_pair :: {query_key, param}
   @type query_list :: [query_pair]
-  @type query_string :: Tesla.QueryString.t()
+  @type query_string :: Tesla.OpenAPI.QueryString.t()
   @type param :: query_scalar | query_scalar_list | query_list | %{optional(query_key) => param}
 
   @typedoc """
@@ -58,10 +58,10 @@ defmodule Tesla.Env do
 
   Map query params do not guarantee encoded parameter order when Tesla's default
   URL builder encodes them directly. In `Tesla.Middleware.Query` `:modern` mode,
-  values matching `Tesla.QueryParams` definitions are encoded in definition
+  values matching `Tesla.OpenAPI.QueryParams` definitions are encoded in definition
   order.
 
-  A `t:Tesla.QueryString.t/0` value represents the entire URL query string and
+  A `t:Tesla.OpenAPI.QueryString.t/0` value represents the entire URL query string and
   must not be mixed with normal query params.
   """
   @type query :: query_list | query_string | %{optional(query_key) => param}
@@ -111,9 +111,9 @@ defmodule Tesla.Env do
   values as module attributes:
 
       @private Tesla.Env.merge_private([
-                 Tesla.PathTemplate.put_private(@path_template),
-                 Tesla.PathParams.put_private(@path_params),
-                 Tesla.QueryParams.put_private(@query_params)
+                 Tesla.OpenAPI.PathTemplate.put_private(@path_template),
+                 Tesla.OpenAPI.PathParams.put_private(@path_params),
+                 Tesla.OpenAPI.QueryParams.put_private(@query_params)
                ])
   """
   @spec merge_private([private]) :: private

--- a/lib/tesla/middleware/path_params.ex
+++ b/lib/tesla/middleware/path_params.ex
@@ -11,24 +11,24 @@ defmodule Tesla.Middleware.PathParams do
   protocol and produce `{key, value}` tuples when enumerated.
 
   By default, this middleware preserves legacy string substitution. Pass
-  `mode: :modern` to read `Tesla.PathParams` definitions from request private
+  `mode: :modern` to read `Tesla.OpenAPI.PathParams` definitions from request private
   data and use their explicit serialization settings.
 
   ## Precompiled OpenAPI Path Templates
 
   Generated clients can precompile OpenAPI Path Templating strings with
-  `Tesla.PathTemplate` and pass the template through request private data.
+  `Tesla.OpenAPI.PathTemplate` and pass the template through request private data.
   This keeps `env.url` as a string while letting `mode: :modern` skip parsing
   the same template on every request.
 
   ```elixir
-  template = Tesla.PathTemplate.new!("/users/{id}")
-  path_params = Tesla.PathParams.new!([Tesla.PathParam.new!("id")])
+  template = Tesla.OpenAPI.PathTemplate.new!("/users/{id}")
+  path_params = Tesla.OpenAPI.PathParams.new!([Tesla.OpenAPI.PathParam.new!("id")])
 
   private =
     %{}
-    |> Tesla.PathTemplate.put_private(template)
-    |> Tesla.PathParams.put_private(path_params)
+    |> Tesla.OpenAPI.PathTemplate.put_private(template)
+    |> Tesla.OpenAPI.PathParams.put_private(path_params)
 
   Tesla.get(client, template.path,
     opts: [path_params: %{"id" => 42}],
@@ -53,7 +53,7 @@ defmodule Tesla.Middleware.PathParams do
 
   In `mode: :modern`, OpenAPI-style placeholders are matched as `{name}` where
   `name` is any non-empty value between balanced braces. When using
-  `Tesla.PathTemplate`, template expression names follow OpenAPI Path
+  `Tesla.OpenAPI.PathTemplate`, template expression names follow OpenAPI Path
   Templating syntax instead of the legacy substitution regex.
 
   ## Examples

--- a/lib/tesla/middleware/path_params/modern.ex
+++ b/lib/tesla/middleware/path_params/modern.ex
@@ -3,9 +3,9 @@ defmodule Tesla.Middleware.PathParams.Modern do
 
   alias Tesla.Env
   alias Tesla.Param
-  alias Tesla.PathParam
-  alias Tesla.PathParams
-  alias Tesla.PathTemplate
+  alias Tesla.OpenAPI.PathParam
+  alias Tesla.OpenAPI.PathParams
+  alias Tesla.OpenAPI.PathTemplate
 
   def call(%Env{opts: opts} = env, next) do
     url = build_url(env, opts[:path_params])

--- a/lib/tesla/middleware/query.ex
+++ b/lib/tesla/middleware/query.ex
@@ -19,7 +19,7 @@ defmodule Tesla.Middleware.Query do
 
   ## Modern OpenAPI Query Params
 
-  Use `mode: :modern` with `Tesla.QueryParams` when generated clients need the
+  Use `mode: :modern` with `Tesla.OpenAPI.QueryParams` when generated clients need the
   OpenAPI query parameter styles `:form`, `:space_delimited`,
   `:pipe_delimited`, or `:deep_object`. Store the static parameter definitions
   in request private data, then pass request values as a map. Other query params
@@ -27,12 +27,12 @@ defmodule Tesla.Middleware.Query do
 
   ```elixir
   query_params =
-    Tesla.QueryParams.new!([
-      Tesla.QueryParam.new!("filter"),
-      Tesla.QueryParam.new!("ids", style: :pipe_delimited)
+    Tesla.OpenAPI.QueryParams.new!([
+      Tesla.OpenAPI.QueryParam.new!("filter"),
+      Tesla.OpenAPI.QueryParam.new!("ids", style: :pipe_delimited)
     ])
 
-  private = Tesla.QueryParams.put_private(query_params)
+  private = Tesla.OpenAPI.QueryParams.put_private(query_params)
 
   client = Tesla.client([{Tesla.Middleware.Query, mode: :modern}])
 
@@ -54,8 +54,8 @@ defmodule Tesla.Middleware.Query do
   @behaviour Tesla.Middleware
 
   alias Tesla.Middleware.Query.Modern
-  alias Tesla.QueryString
-  alias Tesla.QueryStringError
+  alias Tesla.OpenAPI.QueryString
+  alias Tesla.OpenAPI.QueryStringError
 
   @impl Tesla.Middleware
   def call(env, next, mode: :modern), do: Modern.call(env, next)

--- a/lib/tesla/middleware/query/modern.ex
+++ b/lib/tesla/middleware/query/modern.ex
@@ -3,9 +3,9 @@ defmodule Tesla.Middleware.Query.Modern do
 
   alias Tesla.Env
   alias Tesla.Param
-  alias Tesla.QueryParam
-  alias Tesla.QueryParams
-  alias Tesla.QueryString
+  alias Tesla.OpenAPI.QueryParam
+  alias Tesla.OpenAPI.QueryParams
+  alias Tesla.OpenAPI.QueryString
 
   def call(%Env{} = env, next) do
     env

--- a/lib/tesla/open_api/cookie_param.ex
+++ b/lib/tesla/open_api/cookie_param.ex
@@ -1,15 +1,15 @@
-defmodule Tesla.CookieParam do
+defmodule Tesla.OpenAPI.CookieParam do
   @moduledoc """
   A cookie parameter with explicit serialization settings.
 
-  `Tesla.CookieParam` is a Tesla-native value object for cookie parameters whose
+  `Tesla.OpenAPI.CookieParam` is a Tesla-native value object for cookie parameters whose
   serialization needs to be controlled explicitly. Its serialization options
   follow the OpenAPI cookie parameter style semantics, while keeping the public
   API focused on the cookie use case.
 
   Convert cookie parameters to the raw `Cookie` header tuple accepted by Tesla:
 
-      alias Tesla.CookieParam
+      alias Tesla.OpenAPI.CookieParam
 
       cookies = [
         CookieParam.new!("session_id", "abc123"),
@@ -33,7 +33,7 @@ defmodule Tesla.CookieParam do
 
   ## Encoding
 
-  `Tesla.CookieParam.to_header/1` serializes values using the
+  `Tesla.OpenAPI.CookieParam.to_header/1` serializes values using the
   [OpenAPI cookie parameter rules][oas-style] for the `form` and `cookie`
   styles.
 

--- a/lib/tesla/open_api/header_param.ex
+++ b/lib/tesla/open_api/header_param.ex
@@ -1,15 +1,15 @@
-defmodule Tesla.HeaderParam do
+defmodule Tesla.OpenAPI.HeaderParam do
   @moduledoc """
   A header parameter with explicit serialization settings.
 
-  `Tesla.HeaderParam` is a Tesla-native value object for header parameters whose
+  `Tesla.OpenAPI.HeaderParam` is a Tesla-native value object for header parameters whose
   serialization needs to be controlled explicitly. Its serialization options
   follow the OpenAPI header parameter style semantics, while keeping the public
   API focused on the header use case.
 
   Convert a header parameter to the raw header tuple accepted by Tesla:
 
-      alias Tesla.HeaderParam
+      alias Tesla.OpenAPI.HeaderParam
 
       HeaderParam.new!("X-Token", [12345678, 90099])
       |> HeaderParam.to_header()
@@ -26,7 +26,7 @@ defmodule Tesla.HeaderParam do
 
   ## Encoding
 
-  `Tesla.HeaderParam.to_header/1` serializes values using the
+  `Tesla.OpenAPI.HeaderParam.to_header/1` serializes values using the
   [OpenAPI header parameter rules][oas-style] for the `simple` style. Header
   values are passed through unchanged after converting each part with
   `to_string/1`; URI percent-encoding is not applied.

--- a/lib/tesla/open_api/path_param.ex
+++ b/lib/tesla/open_api/path_param.ex
@@ -1,17 +1,17 @@
-defmodule Tesla.PathParam do
+defmodule Tesla.OpenAPI.PathParam do
   @moduledoc """
   A path parameter definition with explicit serialization settings.
 
-  `Tesla.PathParam` is a Tesla-native value object for path parameter metadata
+  `Tesla.OpenAPI.PathParam` is a Tesla-native value object for path parameter metadata
   whose serialization needs to be controlled explicitly. Its serialization
   options follow the OpenAPI path parameter style semantics, while keeping the
   public API focused on the path use case.
 
   In `Tesla.Middleware.PathParams` `:modern` mode, define path parameters once
-  and pass them through request private data with `Tesla.PathParams`:
+  and pass them through request private data with `Tesla.OpenAPI.PathParams`:
 
-      path_params = Tesla.PathParams.new!([PathParam.new!("id")])
-      private = Tesla.PathParams.put_private(path_params)
+      path_params = Tesla.OpenAPI.PathParams.new!([PathParam.new!("id")])
+      private = Tesla.OpenAPI.PathParams.put_private(path_params)
 
       Tesla.get(client, "/items/{id}",
         opts: [path_params: %{"id" => 42}],
@@ -20,9 +20,9 @@ defmodule Tesla.PathParam do
 
   Pass options when a value needs non-default path serialization:
 
-      alias Tesla.PathParam
+      alias Tesla.OpenAPI.PathParam
 
-      Tesla.PathParams.new!([
+      Tesla.OpenAPI.PathParams.new!([
         PathParam.new!("coords", style: :matrix, explode: true)
       ])
 

--- a/lib/tesla/open_api/path_params.ex
+++ b/lib/tesla/open_api/path_params.ex
@@ -1,12 +1,12 @@
-defmodule Tesla.PathParams do
+defmodule Tesla.OpenAPI.PathParams do
   @moduledoc """
   Precompiled path parameter definitions for `Tesla.Middleware.PathParams`.
 
-  `Tesla.PathParams` keeps static path parameter metadata separate from
+  `Tesla.OpenAPI.PathParams` keeps static path parameter metadata separate from
   per-request values. Generated clients can build it once, store it in request
   private data, and pass only the dynamic values through `opts[:path_params]`.
 
-      alias Tesla.{PathParam, PathParams}
+      alias Tesla.OpenAPI.{PathParam, PathParams}
 
       path_params =
         PathParams.new!([
@@ -22,7 +22,7 @@ defmodule Tesla.PathParams do
       )
   """
 
-  alias Tesla.PathParam
+  alias Tesla.OpenAPI.PathParam
 
   @enforce_keys [:definitions]
   defstruct [:definitions]
@@ -41,8 +41,8 @@ defmodule Tesla.PathParams do
   @doc """
   Adds path parameter definitions to Tesla request private data.
 
-      path_params = Tesla.PathParams.new!([Tesla.PathParam.new!("id")])
-      private = Tesla.PathParams.put_private(path_params)
+      path_params = Tesla.OpenAPI.PathParams.new!([Tesla.OpenAPI.PathParam.new!("id")])
+      private = Tesla.OpenAPI.PathParams.put_private(path_params)
 
       Tesla.get(client, "/items/{id}",
         opts: [path_params: %{"id" => 42}],

--- a/lib/tesla/open_api/path_template.ex
+++ b/lib/tesla/open_api/path_template.ex
@@ -1,20 +1,20 @@
-defmodule Tesla.PathTemplate do
+defmodule Tesla.OpenAPI.PathTemplate do
   @moduledoc """
   A precompiled OpenAPI Path Templating path.
 
-  `Tesla.PathTemplate` keeps the request path as a string while carrying a
+  `Tesla.OpenAPI.PathTemplate` keeps the request path as a string while carrying a
   compiled representation that `Tesla.Middleware.PathParams` can use to avoid
   parsing the same path template on every request.
 
-      alias Tesla.PathTemplate
+      alias Tesla.OpenAPI.PathTemplate
 
       template = PathTemplate.new!("/items/{id}")
-      path_params = Tesla.PathParams.new!([Tesla.PathParam.new!("id")])
+      path_params = Tesla.OpenAPI.PathParams.new!([Tesla.OpenAPI.PathParam.new!("id")])
 
       private =
         %{}
         |> PathTemplate.put_private(template)
-        |> Tesla.PathParams.put_private(path_params)
+        |> Tesla.OpenAPI.PathParams.put_private(path_params)
 
       Tesla.get(client, template.path,
         opts: [path_params: %{"id" => id}],
@@ -55,13 +55,13 @@ defmodule Tesla.PathTemplate do
   @doc """
   Adds the compiled path template to Tesla request private data.
 
-      template = Tesla.PathTemplate.new!("/items/{id}")
-      path_params = Tesla.PathParams.new!([Tesla.PathParam.new!("id")])
+      template = Tesla.OpenAPI.PathTemplate.new!("/items/{id}")
+      path_params = Tesla.OpenAPI.PathParams.new!([Tesla.OpenAPI.PathParam.new!("id")])
 
       private =
         %{}
-        |> Tesla.PathTemplate.put_private(template)
-        |> Tesla.PathParams.put_private(path_params)
+        |> Tesla.OpenAPI.PathTemplate.put_private(template)
+        |> Tesla.OpenAPI.PathParams.put_private(path_params)
 
       Tesla.get(client, template.path,
         opts: [path_params: %{"id" => id}],

--- a/lib/tesla/open_api/query_param.ex
+++ b/lib/tesla/open_api/query_param.ex
@@ -1,16 +1,16 @@
-defmodule Tesla.QueryParam do
+defmodule Tesla.OpenAPI.QueryParam do
   @moduledoc """
   A query parameter definition with explicit serialization settings.
 
-  `Tesla.QueryParam` is a Tesla-native value object for query parameter
+  `Tesla.OpenAPI.QueryParam` is a Tesla-native value object for query parameter
   metadata whose serialization needs to be controlled explicitly. Its
   serialization options follow the OpenAPI query parameter style semantics,
   while keeping the public API focused on the query use case.
 
   In `Tesla.Middleware.Query` `:modern` mode, define query parameters once and
-  pass them through request private data with `Tesla.QueryParams`:
+  pass them through request private data with `Tesla.OpenAPI.QueryParams`:
 
-      alias Tesla.{QueryParam, QueryParams}
+      alias Tesla.OpenAPI.{QueryParam, QueryParams}
 
       query_params = QueryParams.new!([QueryParam.new!("id")])
       private = QueryParams.put_private(query_params)
@@ -22,9 +22,9 @@ defmodule Tesla.QueryParam do
 
   Pass options when a query value needs non-default serialization:
 
-      alias Tesla.QueryParam
+      alias Tesla.OpenAPI.QueryParam
 
-      Tesla.QueryParams.new!([
+      Tesla.OpenAPI.QueryParams.new!([
         QueryParam.new!("ids", style: :pipe_delimited)
       ])
 
@@ -63,10 +63,10 @@ defmodule Tesla.QueryParam do
   ## OpenAPI additionalProperties
 
   OpenAPI `additionalProperties` belongs to the schema of an object-valued
-  parameter. Model that parameter with `Tesla.QueryParam` and pass the dynamic
+  parameter. Model that parameter with `Tesla.OpenAPI.QueryParam` and pass the dynamic
   properties as the request value:
 
-      query_params = Tesla.QueryParams.new!([Tesla.QueryParam.new!("filter")])
+      query_params = Tesla.OpenAPI.QueryParams.new!([Tesla.OpenAPI.QueryParam.new!("filter")])
       query = %{"filter" => [status: "open", owner: "yordis"]}
 
   In `:form` style with `explode: true`, this serializes to

--- a/lib/tesla/open_api/query_params.ex
+++ b/lib/tesla/open_api/query_params.ex
@@ -1,12 +1,12 @@
-defmodule Tesla.QueryParams do
+defmodule Tesla.OpenAPI.QueryParams do
   @moduledoc """
   Precompiled query parameter definitions for `Tesla.Middleware.Query`.
 
-  `Tesla.QueryParams` keeps static query parameter metadata separate from
+  `Tesla.OpenAPI.QueryParams` keeps static query parameter metadata separate from
   per-request values. Generated clients can build it once, store it in request
   private data, and pass only dynamic values through `env.query`.
 
-      alias Tesla.{QueryParam, QueryParams}
+      alias Tesla.OpenAPI.{QueryParam, QueryParams}
 
       query_params =
         QueryParams.new!([
@@ -26,7 +26,7 @@ defmodule Tesla.QueryParams do
       )
   """
 
-  alias Tesla.QueryParam
+  alias Tesla.OpenAPI.QueryParam
 
   @enforce_keys [:definitions, :by_name]
   defstruct [:definitions, :by_name]
@@ -46,8 +46,8 @@ defmodule Tesla.QueryParams do
   @doc """
   Adds query parameter definitions to Tesla request private data.
 
-      query_params = Tesla.QueryParams.new!([Tesla.QueryParam.new!("page")])
-      private = Tesla.QueryParams.put_private(query_params)
+      query_params = Tesla.OpenAPI.QueryParams.new!([Tesla.OpenAPI.QueryParam.new!("page")])
+      private = Tesla.OpenAPI.QueryParams.put_private(query_params)
 
       Tesla.get(client, "/items",
         query: %{"page" => 2},

--- a/lib/tesla/open_api/query_string.ex
+++ b/lib/tesla/open_api/query_string.ex
@@ -1,8 +1,8 @@
-defmodule Tesla.QueryString do
+defmodule Tesla.OpenAPI.QueryString do
   @moduledoc """
   A whole URL query string with explicit serialization.
 
-  `Tesla.QueryString` is a Tesla-native value object for requests where the
+  `Tesla.OpenAPI.QueryString` is a Tesla-native value object for requests where the
   entire query string is serialized as one value. It is useful for OpenAPI 3.2
   [`in: "querystring"` parameters][oas-parameter-locations], where the query
   string is content-based and does not behave like a normal named query
@@ -10,7 +10,7 @@ defmodule Tesla.QueryString do
 
   Pass a query string value directly as the request `:query`:
 
-      alias Tesla.QueryString
+      alias Tesla.OpenAPI.QueryString
 
       Tesla.get(client, "/search",
         query: QueryString.form!(foo: "a + b", bar: true)
@@ -28,7 +28,7 @@ defmodule Tesla.QueryString do
   [oas-parameter-locations]: https://spec.openapis.org/oas/latest.html#parameter-locations
   """
 
-  alias Tesla.QueryStringError
+  alias Tesla.OpenAPI.QueryStringError
 
   @derive {Inspect, except: [:encoded]}
   @enforce_keys [:encoded, :content_type]

--- a/lib/tesla/open_api/query_string_error.ex
+++ b/lib/tesla/open_api/query_string_error.ex
@@ -1,6 +1,6 @@
-defmodule Tesla.QueryStringError do
+defmodule Tesla.OpenAPI.QueryStringError do
   @moduledoc """
-  Raised when a whole `Tesla.QueryString` cannot own the request query string.
+  Raised when a whole `Tesla.OpenAPI.QueryString` cannot own the request query string.
   """
 
   defexception [:reason, :query, :url, :value, :details]
@@ -22,11 +22,11 @@ defmodule Tesla.QueryStringError do
         }
 
   def message(%__MODULE__{reason: :existing_query_string} = _value) do
-    "cannot append #{inspect(Tesla.QueryString)} to a URL that already contains a query string"
+    "cannot append #{inspect(Tesla.OpenAPI.QueryString)} to a URL that already contains a query string"
   end
 
   def message(%__MODULE__{reason: :mixed_query_params} = value) do
-    "cannot merge #{inspect(Tesla.QueryString)} with normal query params; got #{inspect(value.query)}"
+    "cannot merge #{inspect(Tesla.OpenAPI.QueryString)} with normal query params; got #{inspect(value.query)}"
   end
 
   def message(%__MODULE__{reason: :leading_query_delimiter} = value) do

--- a/mix.exs
+++ b/mix.exs
@@ -121,15 +121,15 @@ defmodule Tesla.Mixfile do
           Tesla.Middleware
         ],
         "OpenAPI Parameters": [
-          Tesla.CookieParam,
-          Tesla.HeaderParam,
-          Tesla.PathParam,
-          Tesla.PathParams,
-          Tesla.PathTemplate,
-          Tesla.QueryParam,
-          Tesla.QueryParams,
-          Tesla.QueryString,
-          Tesla.QueryStringError
+          Tesla.OpenAPI.CookieParam,
+          Tesla.OpenAPI.HeaderParam,
+          Tesla.OpenAPI.PathParam,
+          Tesla.OpenAPI.PathParams,
+          Tesla.OpenAPI.PathTemplate,
+          Tesla.OpenAPI.QueryParam,
+          Tesla.OpenAPI.QueryParams,
+          Tesla.OpenAPI.QueryString,
+          Tesla.OpenAPI.QueryStringError
         ],
         Adapters: [~r/Tesla.Adapter./],
         Middlewares: [~r/Tesla.Middleware./],

--- a/test/tesla/middleware/path_params/modern_test.exs
+++ b/test/tesla/middleware/path_params/modern_test.exs
@@ -2,9 +2,9 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
   use ExUnit.Case, async: true
 
   alias Tesla.Env
-  alias Tesla.PathParam
-  alias Tesla.PathParams
-  alias Tesla.PathTemplate
+  alias Tesla.OpenAPI.PathParam
+  alias Tesla.OpenAPI.PathParams
+  alias Tesla.OpenAPI.PathTemplate
 
   @middleware Tesla.Middleware.PathParams
 
@@ -1009,7 +1009,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
     test "raises when request values are provided without private path params" do
       opts = [path_params: %{"id" => path_param(42)}]
 
-      assert_raise ArgumentError, ~r/expected Tesla.PathParams private data/, fn ->
+      assert_raise ArgumentError, ~r/expected Tesla.OpenAPI.PathParams private data/, fn ->
         call(
           %Env{url: "/users/{id}", opts: opts},
           [],
@@ -1021,7 +1021,7 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
     test "requires private path params for struct-shaped request values" do
       opts = [path_params: %TestUser{id: path_param(7)}]
 
-      assert_raise ArgumentError, ~r/expected Tesla.PathParams private data/, fn ->
+      assert_raise ArgumentError, ~r/expected Tesla.OpenAPI.PathParams private data/, fn ->
         call(
           %Env{url: "/users/{id}", opts: opts},
           [],

--- a/test/tesla/middleware/query/modern_test.exs
+++ b/test/tesla/middleware/query/modern_test.exs
@@ -3,9 +3,9 @@ defmodule Tesla.Middleware.Query.ModernTest do
 
   alias Tesla.Env
   alias Tesla.Middleware.Query
-  alias Tesla.QueryParam
-  alias Tesla.QueryParams
-  alias Tesla.QueryString
+  alias Tesla.OpenAPI.QueryParam
+  alias Tesla.OpenAPI.QueryParams
+  alias Tesla.OpenAPI.QueryString
 
   defmodule TestFilter do
     defstruct [:role, :id]

--- a/test/tesla/middleware/query_test.exs
+++ b/test/tesla/middleware/query_test.exs
@@ -1,8 +1,8 @@
 defmodule Tesla.Middleware.QueryTest do
   use ExUnit.Case
   alias Tesla.Env
-  alias Tesla.QueryString
-  alias Tesla.QueryStringError
+  alias Tesla.OpenAPI.QueryString
+  alias Tesla.OpenAPI.QueryStringError
 
   @middleware Tesla.Middleware.Query
 
@@ -74,7 +74,7 @@ defmodule Tesla.Middleware.QueryTest do
     query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
 
     assert_raise QueryStringError,
-                 ~r/cannot merge Tesla.QueryString with normal query params/,
+                 ~r/cannot merge Tesla.OpenAPI.QueryString with normal query params/,
                  fn ->
                    @middleware.call(%Env{query: query_string}, [], page: 1)
                  end
@@ -84,7 +84,7 @@ defmodule Tesla.Middleware.QueryTest do
     query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
 
     assert_raise QueryStringError,
-                 ~r/cannot merge Tesla.QueryString with normal query params/,
+                 ~r/cannot merge Tesla.OpenAPI.QueryString with normal query params/,
                  fn ->
                    @middleware.call(%Env{query: [page: 1]}, [], query_string)
                  end

--- a/test/tesla/open_api/cookie_param_test.exs
+++ b/test/tesla/open_api/cookie_param_test.exs
@@ -1,7 +1,7 @@
-defmodule Tesla.CookieParamTest do
+defmodule Tesla.OpenAPI.CookieParamTest do
   use ExUnit.Case, async: true
 
-  alias Tesla.CookieParam
+  alias Tesla.OpenAPI.CookieParam
 
   defmodule TestFilter do
     defstruct [:role, :id]
@@ -247,14 +247,21 @@ defmodule Tesla.CookieParamTest do
   end
 
   test "rejects non-cookie parameter values in header lists" do
-    assert_raise ArgumentError, ~r/expected cookie header to be a Tesla.CookieParam struct/, fn ->
-      CookieParam.to_header([CookieParam.new!("session_id", "abc123"), {"theme", "dark"}])
-    end
+    assert_raise ArgumentError,
+                 ~r/expected cookie header to be a Tesla.OpenAPI.CookieParam struct/,
+                 fn ->
+                   CookieParam.to_header([
+                     CookieParam.new!("session_id", "abc123"),
+                     {"theme", "dark"}
+                   ])
+                 end
   end
 
   test "rejects non-cookie parameter header input" do
-    assert_raise ArgumentError, ~r/expected cookie header to be a Tesla.CookieParam struct/, fn ->
-      CookieParam.to_header(%{session_id: "abc123"})
-    end
+    assert_raise ArgumentError,
+                 ~r/expected cookie header to be a Tesla.OpenAPI.CookieParam struct/,
+                 fn ->
+                   CookieParam.to_header(%{session_id: "abc123"})
+                 end
   end
 end

--- a/test/tesla/open_api/header_param_test.exs
+++ b/test/tesla/open_api/header_param_test.exs
@@ -1,7 +1,7 @@
-defmodule Tesla.HeaderParamTest do
+defmodule Tesla.OpenAPI.HeaderParamTest do
   use ExUnit.Case, async: true
 
-  alias Tesla.HeaderParam
+  alias Tesla.OpenAPI.HeaderParam
 
   defmodule TestFilter do
     defstruct [:role, :id]

--- a/test/tesla/open_api/path_param_test.exs
+++ b/test/tesla/open_api/path_param_test.exs
@@ -1,9 +1,9 @@
-defmodule Tesla.PathParamTest do
+defmodule Tesla.OpenAPI.PathParamTest do
   use ExUnit.Case, async: true
 
   alias Tesla.Env
-  alias Tesla.PathParam
-  alias Tesla.PathParams
+  alias Tesla.OpenAPI.PathParam
+  alias Tesla.OpenAPI.PathParams
 
   @middleware Tesla.Middleware.PathParams
 

--- a/test/tesla/open_api/path_params_test.exs
+++ b/test/tesla/open_api/path_params_test.exs
@@ -1,8 +1,8 @@
-defmodule Tesla.PathParamsTest do
+defmodule Tesla.OpenAPI.PathParamsTest do
   use ExUnit.Case, async: true
 
-  alias Tesla.PathParam
-  alias Tesla.PathParams
+  alias Tesla.OpenAPI.PathParam
+  alias Tesla.OpenAPI.PathParams
 
   test "indexes path parameter definitions by name" do
     path_params =
@@ -43,7 +43,7 @@ defmodule Tesla.PathParamsTest do
 
   test "raises when definitions are not path params" do
     assert_raise ArgumentError,
-                 ~r/expected path parameter definitions to be Tesla.PathParam structs/,
+                 ~r/expected path parameter definitions to be Tesla.OpenAPI.PathParam structs/,
                  fn ->
                    PathParams.new!([%{name: "id"}])
                  end

--- a/test/tesla/open_api/path_template_test.exs
+++ b/test/tesla/open_api/path_template_test.exs
@@ -1,7 +1,7 @@
-defmodule Tesla.PathTemplateTest do
+defmodule Tesla.OpenAPI.PathTemplateTest do
   use ExUnit.Case, async: true
 
-  alias Tesla.PathTemplate
+  alias Tesla.OpenAPI.PathTemplate
 
   defp render_expression(name, _expression, params) do
     Map.fetch!(params, name)

--- a/test/tesla/open_api/query_param_test.exs
+++ b/test/tesla/open_api/query_param_test.exs
@@ -1,7 +1,7 @@
-defmodule Tesla.QueryParamTest do
+defmodule Tesla.OpenAPI.QueryParamTest do
   use ExUnit.Case
 
-  alias Tesla.QueryParam
+  alias Tesla.OpenAPI.QueryParam
 
   test "builds a form query parameter by default" do
     assert %QueryParam{

--- a/test/tesla/open_api/query_params_test.exs
+++ b/test/tesla/open_api/query_params_test.exs
@@ -1,8 +1,8 @@
-defmodule Tesla.QueryParamsTest do
+defmodule Tesla.OpenAPI.QueryParamsTest do
   use ExUnit.Case, async: true
 
-  alias Tesla.QueryParam
-  alias Tesla.QueryParams
+  alias Tesla.OpenAPI.QueryParam
+  alias Tesla.OpenAPI.QueryParams
 
   test "keeps query parameter definitions in declaration order" do
     definitions = [
@@ -55,7 +55,7 @@ defmodule Tesla.QueryParamsTest do
 
   test "raises when definitions are not query params" do
     assert_raise ArgumentError,
-                 ~r/expected query parameter definitions to be Tesla.QueryParam structs/,
+                 ~r/expected query parameter definitions to be Tesla.OpenAPI.QueryParam structs/,
                  fn ->
                    QueryParams.new!([%{name: "page"}])
                  end

--- a/test/tesla/open_api/query_string_test.exs
+++ b/test/tesla/open_api/query_string_test.exs
@@ -1,8 +1,8 @@
-defmodule Tesla.QueryStringTest do
+defmodule Tesla.OpenAPI.QueryStringTest do
   use ExUnit.Case, async: true
 
-  alias Tesla.QueryString
-  alias Tesla.QueryStringError
+  alias Tesla.OpenAPI.QueryString
+  alias Tesla.OpenAPI.QueryStringError
 
   test "raw! builds a query string from already serialized content" do
     assert %QueryString{

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -399,19 +399,19 @@ defmodule TeslaTest do
     end
 
     test "whole query string" do
-      query_string = Tesla.QueryString.raw!("foo=a+%2B+b&bar=true")
+      query_string = Tesla.OpenAPI.QueryString.raw!("foo=a+%2B+b&bar=true")
 
       assert build_url(@api_url, query_string) == @api_url <> "?foo=a+%2B+b&bar=true"
     end
 
     test "whole form-urlencoded query string" do
-      query_string = Tesla.QueryString.form!(foo: "a + b", bar: true)
+      query_string = Tesla.OpenAPI.QueryString.form!(foo: "a + b", bar: true)
 
       assert build_url(@api_url, query_string) == @api_url <> "?foo=a+%2B+b&bar=true"
     end
 
     test "whole query string ignores custom query encoders" do
-      query_string = Tesla.QueryString.raw!("foo=a+%2B+b&bar=true")
+      query_string = Tesla.OpenAPI.QueryString.raw!("foo=a+%2B+b&bar=true")
 
       assert build_url(@api_url, query_string, fn _query ->
                raise "should not be called"
@@ -419,9 +419,9 @@ defmodule TeslaTest do
     end
 
     test "whole query string rejects URLs with existing query params" do
-      query_string = Tesla.QueryString.raw!("page=2")
+      query_string = Tesla.OpenAPI.QueryString.raw!("page=2")
 
-      assert_raise Tesla.QueryStringError, ~r/already contains a query string/, fn ->
+      assert_raise Tesla.OpenAPI.QueryStringError, ~r/already contains a query string/, fn ->
         build_url(@api_url <> "?user=3", query_string)
       end
     end
@@ -452,7 +452,10 @@ defmodule TeslaTest do
     end
 
     test "returns URL with whole query string from Tesla.Env struct" do
-      env = %Tesla.Env{url: @api_url, query: Tesla.QueryString.raw!("foo=a+%2B+b&bar=true")}
+      env = %Tesla.Env{
+        url: @api_url,
+        query: Tesla.OpenAPI.QueryString.raw!("foo=a+%2B+b&bar=true")
+      }
 
       assert Tesla.build_url(env) == @api_url <> "?foo=a+%2B+b&bar=true"
     end
@@ -460,7 +463,7 @@ defmodule TeslaTest do
 
   describe "encode_query/2" do
     test "whole query string returns its serialized value" do
-      query_string = Tesla.QueryString.raw!("foo=a+%2B+b&bar=true")
+      query_string = Tesla.OpenAPI.QueryString.raw!("foo=a+%2B+b&bar=true")
 
       assert Tesla.encode_query(query_string, fn _query ->
                raise "should not be called"


### PR DESCRIPTION
- Keep OpenAPI-specific helpers in one namespace so generated-client APIs are easier to scan.
- Avoid making spec-driven parameter metadata look like generic Tesla primitives before release.