### PR TITLE
chore(openapi): move private helper

### DIFF
--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -230,6 +230,7 @@ defmodule MyApi.Operation.GetItem do
   alias MyApi.Client
   alias MyApi.Operation.GetItem.{Cookie, Header, Path, Query}
   alias MyApi.Response
+  alias Tesla.OpenAPI
   alias Tesla.OpenAPI.{PathParam, PathParams, PathTemplate, QueryParam, QueryParams}
 
   defstruct path: nil,
@@ -261,7 +262,7 @@ defmodule MyApi.Operation.GetItem do
                   QueryParam.new!("filter", style: :deep_object)
                 ])
 
-  @private Tesla.Env.merge_private([
+  @private OpenAPI.merge_private([
              PathTemplate.put_private(@path_template),
              PathParams.put_private(@path_params),
              QueryParams.put_private(@query_params)

--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -103,25 +103,4 @@ defmodule Tesla.Env do
             private: %{},
             __module__: nil,
             __client__: nil
-
-  @doc """
-  Merges request private data maps from left to right.
-
-  This is useful for generated clients that precompute several Tesla private
-  values as module attributes:
-
-      @private Tesla.Env.merge_private([
-                 Tesla.OpenAPI.PathTemplate.put_private(@path_template),
-                 Tesla.OpenAPI.PathParams.put_private(@path_params),
-                 Tesla.OpenAPI.QueryParams.put_private(@query_params)
-               ])
-  """
-  @spec merge_private([private]) :: private
-  def merge_private(privates) when is_list(privates) do
-    Enum.reduce(privates, %{}, &merge_private/2)
-  end
-
-  defp merge_private(private, merged) when is_map(private) do
-    Map.merge(merged, private)
-  end
 end

--- a/lib/tesla/open_api.ex
+++ b/lib/tesla/open_api.ex
@@ -1,0 +1,26 @@
+defmodule Tesla.OpenAPI do
+  @moduledoc """
+  Helpers for OpenAPI-compatible generated clients.
+
+  Generated clients can precompute OpenAPI parameter definitions as module
+  attributes and merge their request private data once:
+
+      @private Tesla.OpenAPI.merge_private([
+                 Tesla.OpenAPI.PathTemplate.put_private(@path_template),
+                 Tesla.OpenAPI.PathParams.put_private(@path_params),
+                 Tesla.OpenAPI.QueryParams.put_private(@query_params)
+               ])
+  """
+
+  @doc """
+  Merges request private data maps from left to right.
+  """
+  @spec merge_private([Tesla.Env.private()]) :: Tesla.Env.private()
+  def merge_private(privates) when is_list(privates) do
+    Enum.reduce(privates, %{}, &merge_private/2)
+  end
+
+  defp merge_private(private, merged) when is_map(private) do
+    Map.merge(merged, private)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -120,7 +120,8 @@ defmodule Tesla.Mixfile do
           Tesla.Adapter,
           Tesla.Middleware
         ],
-        "OpenAPI Parameters": [
+        OpenAPI: [
+          Tesla.OpenAPI,
           Tesla.OpenAPI.CookieParam,
           Tesla.OpenAPI.HeaderParam,
           Tesla.OpenAPI.PathParam,

--- a/test/tesla/open_api_test.exs
+++ b/test/tesla/open_api_test.exs
@@ -1,10 +1,10 @@
-defmodule Tesla.EnvTest do
+defmodule Tesla.OpenAPITest do
   use ExUnit.Case, async: true
 
-  alias Tesla.Env
+  alias Tesla.OpenAPI
 
   test "merges private data maps from left to right" do
-    assert Env.merge_private([
+    assert OpenAPI.merge_private([
              %{tesla_path_template: :template},
              %{tesla_path_params: :path_params},
              %{tesla_query_params: :query_params, tesla_path_params: :override}


### PR DESCRIPTION
- Keep OpenAPI generated-client helpers under the same namespace as the parameter metadata they compose.
- Avoid keeping OpenAPI-specific private-data assembly on the generic request environment API before release.