### PR TITLE
feat(openapi): split header and cookie params

### DIFF
--- a/guides/explanations/4.openapi.md
+++ b/guides/explanations/4.openapi.md
@@ -16,12 +16,12 @@ serialization options where they apply.
 | `path` | `Tesla.OpenAPI.PathTemplate`, `Tesla.OpenAPI.PathParam`, `Tesla.OpenAPI.PathParams`, and `Tesla.Middleware.PathParams` in `:modern` mode |
 | `query` | `Tesla.OpenAPI.QueryParam`, `Tesla.OpenAPI.QueryParams`, and `Tesla.Middleware.Query` in `:modern` mode |
 | `querystring` | `Tesla.OpenAPI.QueryString` passed directly as the request `:query` |
-| `header` | `Tesla.OpenAPI.HeaderParam.to_header/1` |
-| `cookie` | `Tesla.OpenAPI.CookieParam.to_header/1` |
+| `header` | `Tesla.OpenAPI.HeaderParam` and `Tesla.OpenAPI.HeaderParams.to_headers/2` |
+| `cookie` | `Tesla.OpenAPI.CookieParam` and `Tesla.OpenAPI.CookieParams.to_headers/2` |
 
 `path` and `query` parameters use middleware because they are transformed into
-the final request URL. `header` and `cookie` parameters produce raw header
-tuples before the request enters the middleware stack.
+the final request URL. `header` and `cookie` parameter collections produce raw
+header tuples before the request enters the middleware stack.
 
 In `Tesla.Middleware.Query` `:modern` mode, values matching
 `Tesla.OpenAPI.QueryParams` definitions use OpenAPI query serialization. Other query

--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -129,12 +129,12 @@ normal Tesla query params. This example keeps those values in a generated
 
 ## Build the header module
 
-For `in: "header"`, convert `Tesla.OpenAPI.HeaderParam` structs to the raw header
-tuples accepted by Tesla:
+For `in: "header"`, define `Tesla.OpenAPI.HeaderParam` metadata once and use
+`Tesla.OpenAPI.HeaderParams` to convert request values to raw header tuples:
 
 ```elixir
 defmodule MyApi.Operation.GetItem.Header do
-  alias Tesla.OpenAPI.HeaderParam
+  alias Tesla.OpenAPI.{HeaderParam, HeaderParams}
 
   @type t :: %__MODULE__{
           request_id: String.t()
@@ -142,12 +142,16 @@ defmodule MyApi.Operation.GetItem.Header do
 
   defstruct [:request_id]
 
+  @header_params HeaderParams.new!([
+                   HeaderParam.new!("X-Request-ID")
+                 ])
+
   def to_headers(nil), do: []
 
   def to_headers(%__MODULE__{} = headers) do
-    [
-      HeaderParam.to_header(HeaderParam.new!("X-Request-ID", headers.request_id))
-    ]
+    HeaderParams.to_headers(@header_params, %{
+      "X-Request-ID" => headers.request_id
+    })
   end
 end
 ```
@@ -156,12 +160,12 @@ end
 
 ## Build the cookie module
 
-For `in: "cookie"`, convert one or more `Tesla.OpenAPI.CookieParam` structs into a
-single `Cookie` header:
+For `in: "cookie"`, define `Tesla.OpenAPI.CookieParam` metadata once and use
+`Tesla.OpenAPI.CookieParams` to convert request values to the `Cookie` header:
 
 ```elixir
 defmodule MyApi.Operation.GetItem.Cookie do
-  alias Tesla.OpenAPI.CookieParam
+  alias Tesla.OpenAPI.{CookieParam, CookieParams}
 
   @type t :: %__MODULE__{
           session_id: String.t()
@@ -169,14 +173,16 @@ defmodule MyApi.Operation.GetItem.Cookie do
 
   defstruct [:session_id]
 
+  @cookie_params CookieParams.new!([
+                   CookieParam.new!("session_id")
+                 ])
+
   def to_headers(nil), do: []
 
   def to_headers(%__MODULE__{} = cookies) do
-    [
-      CookieParam.to_header([
-        CookieParam.new!("session_id", cookies.session_id)
-      ])
-    ]
+    CookieParams.to_headers(@cookie_params, %{
+      "session_id" => cookies.session_id
+    })
   end
 end
 ```

--- a/lib/tesla/open_api/cookie_param.ex
+++ b/lib/tesla/open_api/cookie_param.ex
@@ -7,20 +7,25 @@ defmodule Tesla.OpenAPI.CookieParam do
   follow the OpenAPI cookie parameter style semantics, while keeping the public
   API focused on the cookie use case.
 
-  Convert cookie parameters to the raw `Cookie` header tuple accepted by Tesla:
+  Define cookie parameters once and apply them to request values with
+  `Tesla.OpenAPI.CookieParams`:
 
-      alias Tesla.OpenAPI.CookieParam
+      alias Tesla.OpenAPI.{CookieParam, CookieParams}
 
-      cookies = [
-        CookieParam.new!("session_id", "abc123"),
-        CookieParam.new!("theme", "dark")
-      ]
+      cookie_params =
+        CookieParams.new!([
+          CookieParam.new!("session_id"),
+          CookieParam.new!("theme")
+        ])
 
-      CookieParam.to_header(cookies)
+      CookieParams.to_headers(cookie_params, %{
+        "session_id" => "abc123",
+        "theme" => "dark"
+      })
 
   ## Options
 
-  `new!/3` accepts a keyword list using Elixir atoms for hand-written Tesla
+  `new!/2` accepts a keyword list using Elixir atoms for hand-written Tesla
   code:
 
     * `:style` - one of `:form` or `:cookie`. Defaults to `:form`, matching
@@ -33,7 +38,7 @@ defmodule Tesla.OpenAPI.CookieParam do
 
   ## Encoding
 
-  `Tesla.OpenAPI.CookieParam.to_header/1` serializes values using the
+  `Tesla.OpenAPI.CookieParams.to_headers/2` serializes values using the
   [OpenAPI cookie parameter rules][oas-style] for the `form` and `cookie`
   styles.
 
@@ -56,14 +61,12 @@ defmodule Tesla.OpenAPI.CookieParam do
 
   alias Tesla.Param
 
-  @derive {Inspect, except: [:value]}
-  @enforce_keys [:name, :value, :style, :explode, :allow_reserved]
-  defstruct [:name, :value, :style, :explode, :allow_reserved]
+  @enforce_keys [:name, :style, :explode, :allow_reserved]
+  defstruct [:name, :style, :explode, :allow_reserved]
 
   @type style :: :form | :cookie
   @opaque t :: %__MODULE__{
             name: String.t(),
-            value: term(),
             style: style(),
             explode: boolean(),
             allow_reserved: boolean()
@@ -72,8 +75,8 @@ defmodule Tesla.OpenAPI.CookieParam do
   @styles [:form, :cookie]
   @expected_styles ":form or :cookie"
 
-  @spec new!(String.t(), term(), keyword()) :: t()
-  def new!(name, value, opts \\ []) do
+  @spec new!(String.t(), keyword()) :: t()
+  def new!(name, opts \\ []) do
     name = Param.validate_name!(:cookie, name)
     opts = Param.validate_opts!(:cookie, opts)
     opts = Keyword.validate!(opts, [:style, :explode, :allow_reserved])
@@ -88,7 +91,6 @@ defmodule Tesla.OpenAPI.CookieParam do
 
     %__MODULE__{
       name: name,
-      value: value,
       style: style,
       explode: Param.validate_explode!(:cookie, explode),
       allow_reserved: Param.validate_allow_reserved!(:cookie, allow_reserved)
@@ -107,38 +109,17 @@ defmodule Tesla.OpenAPI.CookieParam do
     false
   end
 
-  @spec to_header(t() | [t()]) :: {String.t(), String.t()}
-  def to_header(%__MODULE__{} = param) do
-    {"cookie", serialize(param)}
-  end
-
-  def to_header(params) when is_list(params) do
-    {"cookie", Enum.map_join(params, "; ", &serialize_param!/1)}
-  end
-
-  def to_header(param) do
-    raise ArgumentError,
-          "expected cookie header to be a #{inspect(__MODULE__)} struct or a list of #{inspect(__MODULE__)} structs; got #{inspect(param)}"
-  end
-
-  defp serialize_param!(%__MODULE__{} = param) do
-    serialize(param)
-  end
-
-  defp serialize_param!(param) do
-    raise ArgumentError,
-          "expected cookie header to be a #{inspect(__MODULE__)} struct; got #{inspect(param)}"
-  end
-
-  defp serialize(%__MODULE__{style: :form} = param) do
-    param
-    |> value_type()
+  @doc false
+  @spec serialize(%__MODULE__{}, term()) :: String.t()
+  def serialize(%__MODULE__{style: :form} = param, value) do
+    value
+    |> Param.value_type()
     |> serialize_form(param)
   end
 
-  defp serialize(%__MODULE__{style: :cookie} = param) do
-    param
-    |> value_type()
+  def serialize(%__MODULE__{style: :cookie} = param, value) do
+    value
+    |> Param.value_type()
     |> serialize_cookie(param)
   end
 
@@ -252,9 +233,5 @@ defmodule Tesla.OpenAPI.CookieParam do
 
   defp encode_form_value(%__MODULE__{allow_reserved: true}, value) do
     Param.encode_reserved_query(value)
-  end
-
-  defp value_type(%__MODULE__{value: value}) do
-    Param.value_type(value)
   end
 end

--- a/lib/tesla/open_api/cookie_params.ex
+++ b/lib/tesla/open_api/cookie_params.ex
@@ -1,0 +1,99 @@
+defmodule Tesla.OpenAPI.CookieParams do
+  @moduledoc """
+  Precompiled cookie parameter definitions.
+
+  `Tesla.OpenAPI.CookieParams` keeps static cookie parameter metadata separate
+  from per-request values. Generated clients can build it once and pass only
+  dynamic values when creating request headers.
+
+      alias Tesla.OpenAPI.{CookieParam, CookieParams}
+
+      cookie_params =
+        CookieParams.new!([
+          CookieParam.new!("session_id"),
+          CookieParam.new!("theme")
+        ])
+
+      CookieParams.to_headers(cookie_params, %{
+        "session_id" => "abc123",
+        "theme" => "dark"
+      })
+  """
+
+  alias Tesla.OpenAPI.CookieParam
+
+  @enforce_keys [:definitions, :by_name]
+  defstruct [:definitions, :by_name]
+
+  @opaque t :: %__MODULE__{
+            definitions: [CookieParam.t()],
+            by_name: %{String.t() => CookieParam.t()}
+          }
+
+  @spec new!([CookieParam.t()]) :: t()
+  def new!(definitions) when is_list(definitions) do
+    %__MODULE__{definitions: definitions, by_name: by_name!(definitions)}
+  end
+
+  @doc false
+  @spec definitions(t()) :: [CookieParam.t()]
+  def definitions(%__MODULE__{definitions: definitions}) do
+    definitions
+  end
+
+  @doc false
+  @spec fetch(t(), String.t()) :: {:ok, %CookieParam{}} | :error
+  def fetch(%__MODULE__{by_name: by_name}, name) when is_binary(name) do
+    Map.fetch(by_name, name)
+  end
+
+  @spec to_headers(t(), map() | nil) :: Tesla.Env.headers()
+  def to_headers(%__MODULE__{}, nil) do
+    []
+  end
+
+  def to_headers(%__MODULE__{definitions: definitions}, values) when is_map(values) do
+    case Enum.reduce(definitions, {[], values}, &put_cookie/2) do
+      {[], _values} ->
+        []
+
+      {cookies, _values} ->
+        header_value = Enum.join(Enum.reverse(cookies), "; ")
+        [{"cookie", header_value}]
+    end
+  end
+
+  def to_headers(%__MODULE__{}, values) do
+    raise ArgumentError,
+          "expected cookie parameter values to be a map; got #{inspect(values)}"
+  end
+
+  defp put_cookie(%CookieParam{name: name} = cookie_param, {cookies, values}) do
+    case Map.fetch(values, name) do
+      {:ok, value} ->
+        {[CookieParam.serialize(cookie_param, value) | cookies], values}
+
+      :error ->
+        {cookies, values}
+    end
+  end
+
+  defp by_name!(definitions) do
+    Enum.reduce(definitions, %{}, &put_by_name!/2)
+  end
+
+  defp put_by_name!(%CookieParam{name: name} = cookie_param, by_name) do
+    case Map.has_key?(by_name, name) do
+      true ->
+        raise ArgumentError, "duplicate cookie parameter #{inspect(name)}"
+
+      false ->
+        Map.put(by_name, name, cookie_param)
+    end
+  end
+
+  defp put_by_name!(value, _by_name) do
+    raise ArgumentError,
+          "expected cookie parameter definitions to be #{inspect(CookieParam)} structs; got #{inspect(value)}"
+  end
+end

--- a/lib/tesla/open_api/header_param.ex
+++ b/lib/tesla/open_api/header_param.ex
@@ -7,16 +7,21 @@ defmodule Tesla.OpenAPI.HeaderParam do
   follow the OpenAPI header parameter style semantics, while keeping the public
   API focused on the header use case.
 
-  Convert a header parameter to the raw header tuple accepted by Tesla:
+  Define header parameters once and apply them to request values with
+  `Tesla.OpenAPI.HeaderParams`:
 
-      alias Tesla.OpenAPI.HeaderParam
+      alias Tesla.OpenAPI.{HeaderParam, HeaderParams}
 
-      HeaderParam.new!("X-Token", [12345678, 90099])
-      |> HeaderParam.to_header()
+      header_params =
+        HeaderParams.new!([
+          HeaderParam.new!("X-Token")
+        ])
+
+      HeaderParams.to_headers(header_params, %{"X-Token" => [12345678, 90099]})
 
   ## Options
 
-  `new!/3` accepts a keyword list using Elixir atoms for hand-written Tesla
+  `new!/2` accepts a keyword list using Elixir atoms for hand-written Tesla
   code:
 
     * `:style` - must be `:simple`. Defaults to `:simple`.
@@ -26,7 +31,7 @@ defmodule Tesla.OpenAPI.HeaderParam do
 
   ## Encoding
 
-  `Tesla.OpenAPI.HeaderParam.to_header/1` serializes values using the
+  `Tesla.OpenAPI.HeaderParams.to_headers/2` serializes values using the
   [OpenAPI header parameter rules][oas-style] for the `simple` style. Header
   values are passed through unchanged after converting each part with
   `to_string/1`; URI percent-encoding is not applied.
@@ -41,14 +46,12 @@ defmodule Tesla.OpenAPI.HeaderParam do
 
   alias Tesla.Param
 
-  @derive {Inspect, except: [:value]}
-  @enforce_keys [:name, :value, :style, :explode]
-  defstruct [:name, :value, :style, :explode]
+  @enforce_keys [:name, :style, :explode]
+  defstruct [:name, :style, :explode]
 
   @type style :: :simple
   @opaque t :: %__MODULE__{
             name: String.t(),
-            value: term(),
             style: style(),
             explode: boolean()
           }
@@ -56,15 +59,14 @@ defmodule Tesla.OpenAPI.HeaderParam do
   @styles [:simple]
   @expected_styles ":simple"
 
-  @spec new!(String.t(), term(), keyword()) :: t()
-  def new!(name, value, opts \\ []) do
+  @spec new!(String.t(), keyword()) :: t()
+  def new!(name, opts \\ []) do
     name = Param.validate_name!(:header, name)
     opts = Param.validate_opts!(:header, opts)
     opts = Keyword.validate!(opts, style: :simple, explode: false)
 
     %__MODULE__{
       name: name,
-      value: value,
       style: validate_style!(opts[:style]),
       explode: Param.validate_explode!(:header, opts[:explode])
     }
@@ -74,14 +76,11 @@ defmodule Tesla.OpenAPI.HeaderParam do
     Param.validate_style!(style, @styles, :header, @expected_styles)
   end
 
-  @spec to_header(t()) :: {String.t(), String.t()}
-  def to_header(%__MODULE__{} = param) do
-    {param.name, serialize(param)}
-  end
-
-  defp serialize(param) do
-    param
-    |> value_type()
+  @doc false
+  @spec serialize(%__MODULE__{}, term()) :: String.t()
+  def serialize(%__MODULE__{} = param, value) do
+    value
+    |> Param.value_type()
     |> serialize_simple(param)
   end
 
@@ -109,9 +108,5 @@ defmodule Tesla.OpenAPI.HeaderParam do
 
   defp serialize_exploded_pair({key, value}) do
     "#{key}=#{value}"
-  end
-
-  defp value_type(%__MODULE__{value: value}) do
-    Param.value_type(value)
   end
 end

--- a/lib/tesla/open_api/header_params.ex
+++ b/lib/tesla/open_api/header_params.ex
@@ -1,0 +1,89 @@
+defmodule Tesla.OpenAPI.HeaderParams do
+  @moduledoc """
+  Precompiled header parameter definitions.
+
+  `Tesla.OpenAPI.HeaderParams` keeps static header parameter metadata separate
+  from per-request values. Generated clients can build it once and pass only
+  dynamic values when creating request headers.
+
+      alias Tesla.OpenAPI.{HeaderParam, HeaderParams}
+
+      header_params =
+        HeaderParams.new!([
+          HeaderParam.new!("X-Request-ID")
+        ])
+
+      HeaderParams.to_headers(header_params, %{"X-Request-ID" => "req-123"})
+  """
+
+  alias Tesla.OpenAPI.HeaderParam
+
+  @enforce_keys [:definitions, :by_name]
+  defstruct [:definitions, :by_name]
+
+  @opaque t :: %__MODULE__{
+            definitions: [HeaderParam.t()],
+            by_name: %{String.t() => HeaderParam.t()}
+          }
+
+  @spec new!([HeaderParam.t()]) :: t()
+  def new!(definitions) when is_list(definitions) do
+    %__MODULE__{definitions: definitions, by_name: by_name!(definitions)}
+  end
+
+  @doc false
+  @spec definitions(t()) :: [HeaderParam.t()]
+  def definitions(%__MODULE__{definitions: definitions}) do
+    definitions
+  end
+
+  @doc false
+  @spec fetch(t(), String.t()) :: {:ok, %HeaderParam{}} | :error
+  def fetch(%__MODULE__{by_name: by_name}, name) when is_binary(name) do
+    Map.fetch(by_name, name)
+  end
+
+  @spec to_headers(t(), map() | nil) :: Tesla.Env.headers()
+  def to_headers(%__MODULE__{}, nil) do
+    []
+  end
+
+  def to_headers(%__MODULE__{definitions: definitions}, values) when is_map(values) do
+    {headers, _values} = Enum.reduce(definitions, {[], values}, &put_header/2)
+    Enum.reverse(headers)
+  end
+
+  def to_headers(%__MODULE__{}, values) do
+    raise ArgumentError,
+          "expected header parameter values to be a map; got #{inspect(values)}"
+  end
+
+  defp put_header(%HeaderParam{name: name} = header_param, {headers, values}) do
+    case Map.fetch(values, name) do
+      {:ok, value} ->
+        {[{name, HeaderParam.serialize(header_param, value)} | headers], values}
+
+      :error ->
+        {headers, values}
+    end
+  end
+
+  defp by_name!(definitions) do
+    Enum.reduce(definitions, %{}, &put_by_name!/2)
+  end
+
+  defp put_by_name!(%HeaderParam{name: name} = header_param, by_name) do
+    case Map.has_key?(by_name, name) do
+      true ->
+        raise ArgumentError, "duplicate header parameter #{inspect(name)}"
+
+      false ->
+        Map.put(by_name, name, header_param)
+    end
+  end
+
+  defp put_by_name!(value, _by_name) do
+    raise ArgumentError,
+          "expected header parameter definitions to be #{inspect(HeaderParam)} structs; got #{inspect(value)}"
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -123,7 +123,9 @@ defmodule Tesla.Mixfile do
         OpenAPI: [
           Tesla.OpenAPI,
           Tesla.OpenAPI.CookieParam,
+          Tesla.OpenAPI.CookieParams,
           Tesla.OpenAPI.HeaderParam,
+          Tesla.OpenAPI.HeaderParams,
           Tesla.OpenAPI.PathParam,
           Tesla.OpenAPI.PathParams,
           Tesla.OpenAPI.PathTemplate,

--- a/test/tesla/open_api/cookie_param_test.exs
+++ b/test/tesla/open_api/cookie_param_test.exs
@@ -3,193 +3,48 @@ defmodule Tesla.OpenAPI.CookieParamTest do
 
   alias Tesla.OpenAPI.CookieParam
 
-  defmodule TestFilter do
-    defstruct [:role, :id]
-  end
-
   test "uses OpenAPI compatibility defaults" do
     assert %CookieParam{
              name: "color",
-             value: "blue",
              style: :form,
              explode: true,
              allow_reserved: false
-           } = CookieParam.new!("color", "blue")
+           } = CookieParam.new!("color")
   end
 
   test "defaults explode to false for cookie style" do
-    assert %CookieParam{explode: false} = CookieParam.new!("color", "blue", style: :cookie)
+    assert %CookieParam{explode: false} = CookieParam.new!("color", style: :cookie)
   end
 
   test "accepts explicit serialization options" do
     assert %CookieParam{
              name: "color",
-             value: [R: 100],
              style: :form,
              explode: false,
              allow_reserved: true
            } =
-             CookieParam.new!("color", [R: 100],
+             CookieParam.new!("color",
                style: :form,
                explode: false,
                allow_reserved: true
              )
   end
 
-  test "does not inspect runtime values" do
-    inspected = inspect(CookieParam.new!("session_id", "secret-token"))
-
-    refute inspected =~ "secret-token"
-    assert inspected =~ ~s(name: "session_id")
-    assert inspected =~ "style: :form"
-  end
-
-  describe "OpenAPI form style examples" do
-    test "form style with explode false" do
-      assert CookieParam.new!("color", nil, explode: false) |> CookieParam.to_header() ==
-               {"cookie", "color="}
-
-      assert CookieParam.new!("color", "blue", explode: false) |> CookieParam.to_header() ==
-               {"cookie", "color=blue"}
-
-      assert CookieParam.new!("color", ["blue", "black", "brown"], explode: false)
-             |> CookieParam.to_header() ==
-               {"cookie", "color=blue,black,brown"}
-
-      assert CookieParam.new!("color", [R: 100, G: 200, B: 150], explode: false)
-             |> CookieParam.to_header() ==
-               {"cookie", "color=R,100,G,200,B,150"}
-    end
-
-    test "form style with explode true" do
-      assert CookieParam.new!("color", nil) |> CookieParam.to_header() ==
-               {"cookie", "color="}
-
-      assert CookieParam.new!("color", "blue") |> CookieParam.to_header() ==
-               {"cookie", "color=blue"}
-
-      assert CookieParam.new!("color", ["blue", "black", "brown"]) |> CookieParam.to_header() ==
-               {"cookie", "color=blue&color=black&color=brown"}
-
-      assert CookieParam.new!("color", R: 100, G: 200, B: 150) |> CookieParam.to_header() ==
-               {"cookie", "R=100&G=200&B=150"}
-    end
-  end
-
-  describe "OpenAPI cookie style examples" do
-    test "cookie style with explode false" do
-      param = CookieParam.new!("color", nil, style: :cookie, explode: false)
-      assert CookieParam.to_header(param) == {"cookie", "color="}
-
-      param = CookieParam.new!("color", "blue", style: :cookie, explode: false)
-      assert CookieParam.to_header(param) == {"cookie", "color=blue"}
-
-      param =
-        CookieParam.new!("color", ["blue", "black", "brown"],
-          style: :cookie,
-          explode: false
-        )
-
-      assert CookieParam.to_header(param) == {"cookie", "color=blue,black,brown"}
-
-      param =
-        CookieParam.new!("color", [R: 100, G: 200, B: 150],
-          style: :cookie,
-          explode: false
-        )
-
-      assert CookieParam.to_header(param) == {"cookie", "color=R,100,G,200,B,150"}
-    end
-
-    test "cookie style with explode true" do
-      param = CookieParam.new!("color", nil, style: :cookie, explode: true)
-      assert CookieParam.to_header(param) == {"cookie", "color="}
-
-      param = CookieParam.new!("color", "blue", style: :cookie, explode: true)
-      assert CookieParam.to_header(param) == {"cookie", "color=blue"}
-
-      param =
-        CookieParam.new!("color", ["blue", "black", "brown"],
-          style: :cookie,
-          explode: true
-        )
-
-      expected = {"cookie", "color=blue; color=black; color=brown"}
-      assert CookieParam.to_header(param) == expected
-
-      param =
-        CookieParam.new!("color", [R: 100, G: 200, B: 150],
-          style: :cookie,
-          explode: true
-        )
-
-      assert CookieParam.to_header(param) == {"cookie", "R=100; G=200; B=150"}
-    end
-  end
-
-  test "converts multiple parameters to a raw Tesla cookie header tuple" do
-    params = [
-      CookieParam.new!("session_id", "abc123", style: :cookie, explode: true),
-      CookieParam.new!("theme", "dark", style: :cookie, explode: true)
-    ]
-
-    expected = {"cookie", "session_id=abc123; theme=dark"}
-    assert CookieParam.to_header(params) == expected
-  end
-
-  test "cookie style does not percent-encode names or values" do
-    assert CookieParam.new!("raw name", "a/b c#d%zz|é", style: :cookie)
-           |> CookieParam.to_header() ==
-             {"cookie", "raw name=a/b c#d%zz|é"}
-  end
-
-  test "form style percent-encodes names and values" do
-    assert CookieParam.new!("greeting name", "Hello, world!", style: :form)
-           |> CookieParam.to_header() ==
-             {"cookie", "greeting%20name=Hello%2C%20world%21"}
-  end
-
-  test "form style preserves reserved values and percent triples when allow_reserved is true" do
-    assert CookieParam.new!("filter", "a/b?c#d%2B%", style: :form, allow_reserved: true)
-           |> CookieParam.to_header() ==
-             {"cookie", "filter=a/b?c#d%2B%25"}
-  end
-
-  test "supports struct values as objects" do
-    header =
-      CookieParam.new!("filter", %TestFilter{role: "admin", id: 5},
-        style: :cookie,
-        explode: true
-      )
-      |> CookieParam.to_header()
-
-    assert header in [
-             {"cookie", "id=5; role=admin"},
-             {"cookie", "role=admin; id=5"}
-           ]
-  end
-
-  test "serializes empty arrays and objects as empty cookie values" do
-    assert CookieParam.new!("empty_array", []) |> CookieParam.to_header() ==
-             {"cookie", "empty_array="}
-
-    assert CookieParam.new!("empty_object", %{}) |> CookieParam.to_header() ==
-             {"cookie", "empty_object="}
-  end
-
-  test "accepts nil values" do
-    assert %CookieParam{name: "session_id", value: nil} = CookieParam.new!("session_id", nil)
-  end
-
   test "rejects document location as a hand-written option" do
     assert_raise ArgumentError, ~r/unknown keys \[:in\]/, fn ->
-      CookieParam.new!("session_id", "abc123", in: :cookie)
+      CookieParam.new!("session_id", in: :cookie)
+    end
+  end
+
+  test "rejects runtime values in the parameter definition" do
+    assert_raise ArgumentError, ~r/expected cookie parameter options to be a keyword list/, fn ->
+      CookieParam.new!("session_id", "abc123")
     end
   end
 
   test "rejects string styles in hand-written keyword options" do
     assert_raise ArgumentError, ~r/expected :form or :cookie/, fn ->
-      CookieParam.new!("session_id", "abc123", style: "cookie")
+      CookieParam.new!("session_id", style: "cookie")
     end
   end
 
@@ -203,20 +58,20 @@ defmodule Tesla.OpenAPI.CookieParamTest do
           :deep_object
         ] do
       assert_raise ArgumentError, ~r/expected :form or :cookie/, fn ->
-        CookieParam.new!("session_id", "abc123", style: style)
+        CookieParam.new!("session_id", style: style)
       end
     end
   end
 
   test "rejects non-string names" do
     assert_raise ArgumentError, ~r/expected cookie parameter name to be a string/, fn ->
-      CookieParam.new!(:session_id, "abc123")
+      CookieParam.new!(:session_id)
     end
   end
 
   test "rejects non-boolean explode option" do
     assert_raise ArgumentError, ~r/expected cookie parameter :explode to be a boolean/, fn ->
-      CookieParam.new!("session_id", "abc123", explode: "true")
+      CookieParam.new!("session_id", explode: "true")
     end
   end
 
@@ -224,44 +79,25 @@ defmodule Tesla.OpenAPI.CookieParamTest do
     assert_raise ArgumentError,
                  ~r/expected cookie parameter :allow_reserved to be a boolean/,
                  fn ->
-                   CookieParam.new!("session_id", "abc123", allow_reserved: "true")
+                   CookieParam.new!("session_id", allow_reserved: "true")
                  end
   end
 
   test "rejects atom-keyed maps as options" do
     assert_raise ArgumentError, ~r/expected cookie parameter options to be a keyword list/, fn ->
-      CookieParam.new!("session_id", "abc123", %{style: :cookie})
+      CookieParam.new!("session_id", %{style: :cookie})
     end
   end
 
   test "rejects string-keyed maps as options" do
     assert_raise ArgumentError, ~r/expected cookie parameter options to be a keyword list/, fn ->
-      CookieParam.new!("session_id", "abc123", %{"style" => :cookie})
+      CookieParam.new!("session_id", %{"style" => :cookie})
     end
   end
 
   test "rejects non-keyword lists as options" do
     assert_raise ArgumentError, ~r/expected a keyword list/, fn ->
-      CookieParam.new!("session_id", "abc123", [:cookie])
+      CookieParam.new!("session_id", [:cookie])
     end
-  end
-
-  test "rejects non-cookie parameter values in header lists" do
-    assert_raise ArgumentError,
-                 ~r/expected cookie header to be a Tesla.OpenAPI.CookieParam struct/,
-                 fn ->
-                   CookieParam.to_header([
-                     CookieParam.new!("session_id", "abc123"),
-                     {"theme", "dark"}
-                   ])
-                 end
-  end
-
-  test "rejects non-cookie parameter header input" do
-    assert_raise ArgumentError,
-                 ~r/expected cookie header to be a Tesla.OpenAPI.CookieParam struct/,
-                 fn ->
-                   CookieParam.to_header(%{session_id: "abc123"})
-                 end
   end
 end

--- a/test/tesla/open_api/cookie_params_test.exs
+++ b/test/tesla/open_api/cookie_params_test.exs
@@ -1,0 +1,233 @@
+defmodule Tesla.OpenAPI.CookieParamsTest do
+  use ExUnit.Case, async: true
+
+  alias Tesla.OpenAPI.CookieParam
+  alias Tesla.OpenAPI.CookieParams
+
+  defmodule TestFilter do
+    defstruct [:role, :id]
+  end
+
+  test "keeps cookie parameter definitions in declaration order" do
+    definitions = [
+      CookieParam.new!("session_id"),
+      CookieParam.new!("theme", style: :cookie)
+    ]
+
+    cookie_params = CookieParams.new!(definitions)
+
+    assert CookieParams.definitions(cookie_params) == definitions
+  end
+
+  test "indexes cookie parameter definitions by name" do
+    cookie_params =
+      CookieParams.new!([
+        CookieParam.new!("session_id"),
+        CookieParam.new!("theme", style: :cookie)
+      ])
+
+    assert {:ok, %CookieParam{name: "session_id", style: :form}} =
+             CookieParams.fetch(cookie_params, "session_id")
+
+    assert {:ok, %CookieParam{name: "theme", style: :cookie}} =
+             CookieParams.fetch(cookie_params, "theme")
+
+    assert CookieParams.fetch(cookie_params, "missing") == :error
+  end
+
+  describe "OpenAPI form style examples" do
+    test "form style with explode false" do
+      cookie_params = CookieParams.new!([CookieParam.new!("color", explode: false)])
+
+      assert CookieParams.to_headers(cookie_params, %{"color" => nil}) == [
+               {"cookie", "color="}
+             ]
+
+      assert CookieParams.to_headers(cookie_params, %{"color" => "blue"}) == [
+               {"cookie", "color=blue"}
+             ]
+
+      assert CookieParams.to_headers(cookie_params, %{
+               "color" => ["blue", "black", "brown"]
+             }) == [{"cookie", "color=blue,black,brown"}]
+
+      assert CookieParams.to_headers(cookie_params, %{
+               "color" => [R: 100, G: 200, B: 150]
+             }) == [{"cookie", "color=R,100,G,200,B,150"}]
+    end
+
+    test "form style with explode true" do
+      cookie_params = CookieParams.new!([CookieParam.new!("color")])
+
+      assert CookieParams.to_headers(cookie_params, %{"color" => nil}) == [
+               {"cookie", "color="}
+             ]
+
+      assert CookieParams.to_headers(cookie_params, %{"color" => "blue"}) == [
+               {"cookie", "color=blue"}
+             ]
+
+      assert CookieParams.to_headers(cookie_params, %{
+               "color" => ["blue", "black", "brown"]
+             }) == [{"cookie", "color=blue&color=black&color=brown"}]
+
+      assert CookieParams.to_headers(cookie_params, %{
+               "color" => [R: 100, G: 200, B: 150]
+             }) == [{"cookie", "R=100&G=200&B=150"}]
+    end
+  end
+
+  describe "OpenAPI cookie style examples" do
+    test "cookie style with explode false" do
+      cookie_params =
+        CookieParams.new!([
+          CookieParam.new!("color", style: :cookie, explode: false)
+        ])
+
+      assert CookieParams.to_headers(cookie_params, %{"color" => nil}) == [
+               {"cookie", "color="}
+             ]
+
+      assert CookieParams.to_headers(cookie_params, %{"color" => "blue"}) == [
+               {"cookie", "color=blue"}
+             ]
+
+      assert CookieParams.to_headers(cookie_params, %{
+               "color" => ["blue", "black", "brown"]
+             }) == [{"cookie", "color=blue,black,brown"}]
+
+      assert CookieParams.to_headers(cookie_params, %{
+               "color" => [R: 100, G: 200, B: 150]
+             }) == [{"cookie", "color=R,100,G,200,B,150"}]
+    end
+
+    test "cookie style with explode true" do
+      cookie_params =
+        CookieParams.new!([
+          CookieParam.new!("color", style: :cookie, explode: true)
+        ])
+
+      assert CookieParams.to_headers(cookie_params, %{"color" => nil}) == [
+               {"cookie", "color="}
+             ]
+
+      assert CookieParams.to_headers(cookie_params, %{"color" => "blue"}) == [
+               {"cookie", "color=blue"}
+             ]
+
+      assert CookieParams.to_headers(cookie_params, %{
+               "color" => ["blue", "black", "brown"]
+             }) == [{"cookie", "color=blue; color=black; color=brown"}]
+
+      assert CookieParams.to_headers(cookie_params, %{
+               "color" => [R: 100, G: 200, B: 150]
+             }) == [{"cookie", "R=100; G=200; B=150"}]
+    end
+  end
+
+  test "converts request values to a raw Tesla cookie header tuple" do
+    cookie_params =
+      CookieParams.new!([
+        CookieParam.new!("session_id", style: :cookie, explode: true),
+        CookieParam.new!("theme", style: :cookie, explode: true)
+      ])
+
+    assert CookieParams.to_headers(cookie_params, %{
+             "session_id" => "abc123",
+             "theme" => "dark"
+           }) == [{"cookie", "session_id=abc123; theme=dark"}]
+  end
+
+  test "skips request values without matching definitions" do
+    cookie_params = CookieParams.new!([CookieParam.new!("session_id")])
+
+    assert CookieParams.to_headers(cookie_params, %{"theme" => "dark"}) == []
+  end
+
+  test "returns no headers for nil request values" do
+    assert CookieParams.new!([CookieParam.new!("session_id")])
+           |> CookieParams.to_headers(nil) == []
+  end
+
+  test "cookie style does not percent-encode names or values" do
+    cookie_params = CookieParams.new!([CookieParam.new!("raw name", style: :cookie)])
+
+    assert CookieParams.to_headers(cookie_params, %{"raw name" => "a/b c#d%zz|é"}) == [
+             {"cookie", "raw name=a/b c#d%zz|é"}
+           ]
+  end
+
+  test "form style percent-encodes names and values" do
+    cookie_params = CookieParams.new!([CookieParam.new!("greeting name", style: :form)])
+
+    assert CookieParams.to_headers(cookie_params, %{"greeting name" => "Hello, world!"}) == [
+             {"cookie", "greeting%20name=Hello%2C%20world%21"}
+           ]
+  end
+
+  test "form style preserves reserved values and percent triples when allow_reserved is true" do
+    cookie_params =
+      CookieParams.new!([
+        CookieParam.new!("filter", style: :form, allow_reserved: true)
+      ])
+
+    assert CookieParams.to_headers(cookie_params, %{"filter" => "a/b?c#d%2B%"}) == [
+             {"cookie", "filter=a/b?c#d%2B%25"}
+           ]
+  end
+
+  test "supports struct values as objects" do
+    cookie_params =
+      CookieParams.new!([
+        CookieParam.new!("filter", style: :cookie, explode: true)
+      ])
+
+    headers =
+      CookieParams.to_headers(cookie_params, %{
+        "filter" => %TestFilter{role: "admin", id: 5}
+      })
+
+    assert headers in [
+             [{"cookie", "id=5; role=admin"}],
+             [{"cookie", "role=admin; id=5"}]
+           ]
+  end
+
+  test "serializes empty arrays and objects as empty cookie values" do
+    cookie_params =
+      CookieParams.new!([
+        CookieParam.new!("empty_array"),
+        CookieParam.new!("empty_object")
+      ])
+
+    assert CookieParams.to_headers(cookie_params, %{
+             "empty_array" => [],
+             "empty_object" => %{}
+           }) == [{"cookie", "empty_array=; empty_object="}]
+  end
+
+  test "raises on duplicate cookie parameter definitions" do
+    assert_raise ArgumentError, ~r/duplicate cookie parameter "session_id"/, fn ->
+      CookieParams.new!([
+        CookieParam.new!("session_id"),
+        CookieParam.new!("session_id", style: :cookie)
+      ])
+    end
+  end
+
+  test "raises when definitions are not cookie params" do
+    assert_raise ArgumentError,
+                 ~r/expected cookie parameter definitions to be Tesla.OpenAPI.CookieParam structs/,
+                 fn ->
+                   CookieParams.new!([%{name: "session_id"}])
+                 end
+  end
+
+  test "raises when values are not a map" do
+    cookie_params = CookieParams.new!([CookieParam.new!("session_id")])
+
+    assert_raise ArgumentError, ~r/expected cookie parameter values to be a map/, fn ->
+      CookieParams.to_headers(cookie_params, [{"session_id", "abc123"}])
+    end
+  end
+end

--- a/test/tesla/open_api/header_param_test.exs
+++ b/test/tesla/open_api/header_param_test.exs
@@ -3,114 +3,47 @@ defmodule Tesla.OpenAPI.HeaderParamTest do
 
   alias Tesla.OpenAPI.HeaderParam
 
-  defmodule TestFilter do
-    defstruct [:role, :id]
-  end
-
   test "uses default serialization options" do
     assert %HeaderParam{
              name: "X-Token",
-             value: 42,
              style: :simple,
              explode: false
-           } = HeaderParam.new!("X-Token", 42)
+           } = HeaderParam.new!("X-Token")
   end
 
   test "accepts explicit serialization options" do
     assert %HeaderParam{
              name: "X-Token",
-             value: [R: 100],
              style: :simple,
              explode: true
            } =
-             HeaderParam.new!("X-Token", [R: 100],
+             HeaderParam.new!("X-Token",
                style: :simple,
                explode: true
              )
   end
 
-  test "does not inspect runtime values" do
-    inspected = inspect(HeaderParam.new!("X-Token", "secret-token"))
-
-    refute inspected =~ "secret-token"
-    assert inspected =~ ~s(name: "X-Token")
-    assert inspected =~ "style: :simple"
-  end
-
-  describe "OpenAPI style examples" do
-    test "simple style with explode false" do
-      assert HeaderParam.new!("color", nil) |> HeaderParam.to_header() == {"color", ""}
-      assert HeaderParam.new!("color", "blue") |> HeaderParam.to_header() == {"color", "blue"}
-
-      assert HeaderParam.new!("color", ["blue", "black", "brown"]) |> HeaderParam.to_header() ==
-               {"color", "blue,black,brown"}
-
-      assert HeaderParam.new!("color", R: 100, G: 200, B: 150) |> HeaderParam.to_header() ==
-               {"color", "R,100,G,200,B,150"}
-    end
-
-    test "simple style with explode true" do
-      assert HeaderParam.new!("color", nil, explode: true) |> HeaderParam.to_header() ==
-               {"color", ""}
-
-      assert HeaderParam.new!("color", "blue", explode: true) |> HeaderParam.to_header() ==
-               {"color", "blue"}
-
-      assert HeaderParam.new!("color", ["blue", "black", "brown"], explode: true)
-             |> HeaderParam.to_header() ==
-               {"color", "blue,black,brown"}
-
-      assert HeaderParam.new!("color", [R: 100, G: 200, B: 150], explode: true)
-             |> HeaderParam.to_header() ==
-               {"color", "R=100,G=200,B=150"}
-    end
-  end
-
-  test "converts to a raw Tesla header tuple" do
-    assert HeaderParam.new!("X-Token", [12_345_678, 90099]) |> HeaderParam.to_header() ==
-             {"X-Token", "12345678,90099"}
-  end
-
-  test "does not percent-encode header values" do
-    assert HeaderParam.new!("X-Token", "a/b c#d%zz|é") |> HeaderParam.to_header() ==
-             {"X-Token", "a/b c#d%zz|é"}
-  end
-
-  test "supports struct values as objects" do
-    header =
-      HeaderParam.new!("X-Filter", %TestFilter{role: "admin", id: 5}, explode: true)
-      |> HeaderParam.to_header()
-
-    assert header in [
-             {"X-Filter", "id=5,role=admin"},
-             {"X-Filter", "role=admin,id=5"}
-           ]
-  end
-
-  test "serializes empty arrays and objects as empty values" do
-    assert HeaderParam.new!("X-Empty", []) |> HeaderParam.to_header() == {"X-Empty", ""}
-    assert HeaderParam.new!("X-Empty", %{}) |> HeaderParam.to_header() == {"X-Empty", ""}
-  end
-
-  test "accepts nil values" do
-    assert %HeaderParam{name: "X-Token", value: nil} = HeaderParam.new!("X-Token", nil)
-  end
-
   test "rejects document location as a hand-written option" do
     assert_raise ArgumentError, ~r/unknown keys \[:in\]/, fn ->
-      HeaderParam.new!("X-Token", "blue", in: :header)
+      HeaderParam.new!("X-Token", in: :header)
     end
   end
 
   test "rejects allow_reserved as a header option" do
     assert_raise ArgumentError, ~r/unknown keys \[:allow_reserved\]/, fn ->
-      HeaderParam.new!("X-Token", "blue", allow_reserved: true)
+      HeaderParam.new!("X-Token", allow_reserved: true)
+    end
+  end
+
+  test "rejects runtime values in the parameter definition" do
+    assert_raise ArgumentError, ~r/expected header parameter options to be a keyword list/, fn ->
+      HeaderParam.new!("X-Token", "blue")
     end
   end
 
   test "rejects string styles in hand-written keyword options" do
     assert_raise ArgumentError, ~r/expected :simple/, fn ->
-      HeaderParam.new!("X-Token", "blue", style: "simple")
+      HeaderParam.new!("X-Token", style: "simple")
     end
   end
 
@@ -125,38 +58,38 @@ defmodule Tesla.OpenAPI.HeaderParamTest do
           :cookie
         ] do
       assert_raise ArgumentError, ~r/expected :simple/, fn ->
-        HeaderParam.new!("X-Token", "blue", style: style)
+        HeaderParam.new!("X-Token", style: style)
       end
     end
   end
 
   test "rejects non-string names" do
     assert_raise ArgumentError, ~r/expected header parameter name to be a string/, fn ->
-      HeaderParam.new!(:token, "blue")
+      HeaderParam.new!(:token)
     end
   end
 
   test "rejects non-boolean explode option" do
     assert_raise ArgumentError, ~r/expected header parameter :explode to be a boolean/, fn ->
-      HeaderParam.new!("X-Token", "blue", explode: "true")
+      HeaderParam.new!("X-Token", explode: "true")
     end
   end
 
   test "rejects atom-keyed maps as options" do
     assert_raise ArgumentError, ~r/expected header parameter options to be a keyword list/, fn ->
-      HeaderParam.new!("X-Token", "blue", %{style: :simple})
+      HeaderParam.new!("X-Token", %{style: :simple})
     end
   end
 
   test "rejects string-keyed maps as options" do
     assert_raise ArgumentError, ~r/expected header parameter options to be a keyword list/, fn ->
-      HeaderParam.new!("X-Token", "blue", %{"style" => :simple})
+      HeaderParam.new!("X-Token", %{"style" => :simple})
     end
   end
 
   test "rejects non-keyword lists as options" do
     assert_raise ArgumentError, ~r/expected a keyword list/, fn ->
-      HeaderParam.new!("X-Token", "blue", [:simple])
+      HeaderParam.new!("X-Token", [:simple])
     end
   end
 end

--- a/test/tesla/open_api/header_params_test.exs
+++ b/test/tesla/open_api/header_params_test.exs
@@ -1,0 +1,160 @@
+defmodule Tesla.OpenAPI.HeaderParamsTest do
+  use ExUnit.Case, async: true
+
+  alias Tesla.OpenAPI.HeaderParam
+  alias Tesla.OpenAPI.HeaderParams
+
+  defmodule TestFilter do
+    defstruct [:role, :id]
+  end
+
+  test "keeps header parameter definitions in declaration order" do
+    definitions = [
+      HeaderParam.new!("X-Request-ID"),
+      HeaderParam.new!("X-Filter", explode: true)
+    ]
+
+    header_params = HeaderParams.new!(definitions)
+
+    assert HeaderParams.definitions(header_params) == definitions
+  end
+
+  test "indexes header parameter definitions by name" do
+    header_params =
+      HeaderParams.new!([
+        HeaderParam.new!("X-Request-ID"),
+        HeaderParam.new!("X-Filter", explode: true)
+      ])
+
+    assert {:ok, %HeaderParam{name: "X-Request-ID", style: :simple}} =
+             HeaderParams.fetch(header_params, "X-Request-ID")
+
+    assert {:ok, %HeaderParam{name: "X-Filter", explode: true}} =
+             HeaderParams.fetch(header_params, "X-Filter")
+
+    assert HeaderParams.fetch(header_params, "missing") == :error
+  end
+
+  describe "OpenAPI style examples" do
+    test "simple style with explode false" do
+      header_params = HeaderParams.new!([HeaderParam.new!("color")])
+
+      assert HeaderParams.to_headers(header_params, %{"color" => nil}) == [{"color", ""}]
+      assert HeaderParams.to_headers(header_params, %{"color" => "blue"}) == [{"color", "blue"}]
+
+      assert HeaderParams.to_headers(header_params, %{
+               "color" => ["blue", "black", "brown"]
+             }) == [{"color", "blue,black,brown"}]
+
+      assert HeaderParams.to_headers(header_params, %{
+               "color" => [R: 100, G: 200, B: 150]
+             }) == [{"color", "R,100,G,200,B,150"}]
+    end
+
+    test "simple style with explode true" do
+      header_params = HeaderParams.new!([HeaderParam.new!("color", explode: true)])
+
+      assert HeaderParams.to_headers(header_params, %{"color" => nil}) == [{"color", ""}]
+      assert HeaderParams.to_headers(header_params, %{"color" => "blue"}) == [{"color", "blue"}]
+
+      assert HeaderParams.to_headers(header_params, %{
+               "color" => ["blue", "black", "brown"]
+             }) == [{"color", "blue,black,brown"}]
+
+      assert HeaderParams.to_headers(header_params, %{
+               "color" => [R: 100, G: 200, B: 150]
+             }) == [{"color", "R=100,G=200,B=150"}]
+    end
+  end
+
+  test "converts request values to raw Tesla header tuples" do
+    header_params =
+      HeaderParams.new!([
+        HeaderParam.new!("X-Token"),
+        HeaderParam.new!("X-Request-ID")
+      ])
+
+    assert HeaderParams.to_headers(header_params, %{
+             "X-Token" => [12_345_678, 90099],
+             "X-Request-ID" => "req-123"
+           }) == [
+             {"X-Token", "12345678,90099"},
+             {"X-Request-ID", "req-123"}
+           ]
+  end
+
+  test "skips request values without matching definitions" do
+    header_params = HeaderParams.new!([HeaderParam.new!("X-Token")])
+
+    assert HeaderParams.to_headers(header_params, %{
+             "X-Request-ID" => "req-123"
+           }) == []
+  end
+
+  test "returns no headers for nil request values" do
+    assert HeaderParams.new!([HeaderParam.new!("X-Token")])
+           |> HeaderParams.to_headers(nil) == []
+  end
+
+  test "does not percent-encode header values" do
+    header_params = HeaderParams.new!([HeaderParam.new!("X-Token")])
+
+    assert HeaderParams.to_headers(header_params, %{"X-Token" => "a/b c#d%zz|é"}) ==
+             [{"X-Token", "a/b c#d%zz|é"}]
+  end
+
+  test "supports struct values as objects" do
+    header_params = HeaderParams.new!([HeaderParam.new!("X-Filter", explode: true)])
+
+    headers =
+      HeaderParams.to_headers(header_params, %{
+        "X-Filter" => %TestFilter{role: "admin", id: 5}
+      })
+
+    assert headers in [
+             [{"X-Filter", "id=5,role=admin"}],
+             [{"X-Filter", "role=admin,id=5"}]
+           ]
+  end
+
+  test "serializes empty arrays and objects as empty values" do
+    header_params =
+      HeaderParams.new!([
+        HeaderParam.new!("X-Empty-Array"),
+        HeaderParam.new!("X-Empty-Object")
+      ])
+
+    assert HeaderParams.to_headers(header_params, %{
+             "X-Empty-Array" => [],
+             "X-Empty-Object" => %{}
+           }) == [
+             {"X-Empty-Array", ""},
+             {"X-Empty-Object", ""}
+           ]
+  end
+
+  test "raises on duplicate header parameter definitions" do
+    assert_raise ArgumentError, ~r/duplicate header parameter "X-Token"/, fn ->
+      HeaderParams.new!([
+        HeaderParam.new!("X-Token"),
+        HeaderParam.new!("X-Token", explode: true)
+      ])
+    end
+  end
+
+  test "raises when definitions are not header params" do
+    assert_raise ArgumentError,
+                 ~r/expected header parameter definitions to be Tesla.OpenAPI.HeaderParam structs/,
+                 fn ->
+                   HeaderParams.new!([%{name: "X-Token"}])
+                 end
+  end
+
+  test "raises when values are not a map" do
+    header_params = HeaderParams.new!([HeaderParam.new!("X-Token")])
+
+    assert_raise ArgumentError, ~r/expected header parameter values to be a map/, fn ->
+      HeaderParams.to_headers(header_params, [{"X-Token", "secret"}])
+    end
+  end
+end


### PR DESCRIPTION
- Keep all OpenAPI parameter definitions reusable instead of mixing generated metadata with request values.
- Give generated clients one consistent singular-definition and plural-collection shape across path, query, header, and cookie parameters.