### PR TITLE
chore(openapi): simplify parameter collections

### DIFF
--- a/lib/tesla/open_api/cookie_params.ex
+++ b/lib/tesla/open_api/cookie_params.ex
@@ -21,30 +21,18 @@ defmodule Tesla.OpenAPI.CookieParams do
   """
 
   alias Tesla.OpenAPI.CookieParam
+  alias Tesla.Param
 
-  @enforce_keys [:definitions, :by_name]
-  defstruct [:definitions, :by_name]
+  @enforce_keys [:definitions]
+  defstruct [:definitions]
 
   @opaque t :: %__MODULE__{
-            definitions: [CookieParam.t()],
-            by_name: %{String.t() => CookieParam.t()}
+            definitions: [CookieParam.t()]
           }
 
   @spec new!([CookieParam.t()]) :: t()
   def new!(definitions) when is_list(definitions) do
-    %__MODULE__{definitions: definitions, by_name: by_name!(definitions)}
-  end
-
-  @doc false
-  @spec definitions(t()) :: [CookieParam.t()]
-  def definitions(%__MODULE__{definitions: definitions}) do
-    definitions
-  end
-
-  @doc false
-  @spec fetch(t(), String.t()) :: {:ok, %CookieParam{}} | :error
-  def fetch(%__MODULE__{by_name: by_name}, name) when is_binary(name) do
-    Map.fetch(by_name, name)
+    %__MODULE__{definitions: Param.validate_definitions!(definitions, CookieParam, :cookie)}
   end
 
   @spec to_headers(t(), map() | nil) :: Tesla.Env.headers()
@@ -76,24 +64,5 @@ defmodule Tesla.OpenAPI.CookieParams do
       :error ->
         {cookies, values}
     end
-  end
-
-  defp by_name!(definitions) do
-    Enum.reduce(definitions, %{}, &put_by_name!/2)
-  end
-
-  defp put_by_name!(%CookieParam{name: name} = cookie_param, by_name) do
-    case Map.has_key?(by_name, name) do
-      true ->
-        raise ArgumentError, "duplicate cookie parameter #{inspect(name)}"
-
-      false ->
-        Map.put(by_name, name, cookie_param)
-    end
-  end
-
-  defp put_by_name!(value, _by_name) do
-    raise ArgumentError,
-          "expected cookie parameter definitions to be #{inspect(CookieParam)} structs; got #{inspect(value)}"
   end
 end

--- a/lib/tesla/open_api/header_params.ex
+++ b/lib/tesla/open_api/header_params.ex
@@ -17,30 +17,18 @@ defmodule Tesla.OpenAPI.HeaderParams do
   """
 
   alias Tesla.OpenAPI.HeaderParam
+  alias Tesla.Param
 
-  @enforce_keys [:definitions, :by_name]
-  defstruct [:definitions, :by_name]
+  @enforce_keys [:definitions]
+  defstruct [:definitions]
 
   @opaque t :: %__MODULE__{
-            definitions: [HeaderParam.t()],
-            by_name: %{String.t() => HeaderParam.t()}
+            definitions: [HeaderParam.t()]
           }
 
   @spec new!([HeaderParam.t()]) :: t()
   def new!(definitions) when is_list(definitions) do
-    %__MODULE__{definitions: definitions, by_name: by_name!(definitions)}
-  end
-
-  @doc false
-  @spec definitions(t()) :: [HeaderParam.t()]
-  def definitions(%__MODULE__{definitions: definitions}) do
-    definitions
-  end
-
-  @doc false
-  @spec fetch(t(), String.t()) :: {:ok, %HeaderParam{}} | :error
-  def fetch(%__MODULE__{by_name: by_name}, name) when is_binary(name) do
-    Map.fetch(by_name, name)
+    %__MODULE__{definitions: Param.validate_definitions!(definitions, HeaderParam, :header)}
   end
 
   @spec to_headers(t(), map() | nil) :: Tesla.Env.headers()
@@ -66,24 +54,5 @@ defmodule Tesla.OpenAPI.HeaderParams do
       :error ->
         {headers, values}
     end
-  end
-
-  defp by_name!(definitions) do
-    Enum.reduce(definitions, %{}, &put_by_name!/2)
-  end
-
-  defp put_by_name!(%HeaderParam{name: name} = header_param, by_name) do
-    case Map.has_key?(by_name, name) do
-      true ->
-        raise ArgumentError, "duplicate header parameter #{inspect(name)}"
-
-      false ->
-        Map.put(by_name, name, header_param)
-    end
-  end
-
-  defp put_by_name!(value, _by_name) do
-    raise ArgumentError,
-          "expected header parameter definitions to be #{inspect(HeaderParam)} structs; got #{inspect(value)}"
   end
 end

--- a/lib/tesla/open_api/path_params.ex
+++ b/lib/tesla/open_api/path_params.ex
@@ -23,6 +23,7 @@ defmodule Tesla.OpenAPI.PathParams do
   """
 
   alias Tesla.OpenAPI.PathParam
+  alias Tesla.Param
 
   @enforce_keys [:definitions]
   defstruct [:definitions]
@@ -35,7 +36,12 @@ defmodule Tesla.OpenAPI.PathParams do
 
   @spec new!([PathParam.t()]) :: t()
   def new!(definitions) when is_list(definitions) do
-    %__MODULE__{definitions: by_name!(definitions)}
+    definitions =
+      definitions
+      |> Param.validate_definitions!(PathParam, :path)
+      |> Map.new(&definition_by_name/1)
+
+    %__MODULE__{definitions: definitions}
   end
 
   @doc """
@@ -80,22 +86,7 @@ defmodule Tesla.OpenAPI.PathParams do
     Map.fetch(definitions, name)
   end
 
-  defp by_name!(definitions) do
-    Enum.reduce(definitions, %{}, &put_definition_by_name!/2)
-  end
-
-  defp put_definition_by_name!(%PathParam{name: name} = path_param, definitions) do
-    case Map.has_key?(definitions, name) do
-      true ->
-        raise ArgumentError, "duplicate path parameter #{inspect(name)}"
-
-      false ->
-        Map.put(definitions, name, path_param)
-    end
-  end
-
-  defp put_definition_by_name!(value, _definitions) do
-    raise ArgumentError,
-          "expected path parameter definitions to be #{inspect(PathParam)} structs; got #{inspect(value)}"
+  defp definition_by_name(%PathParam{name: name} = definition) do
+    {name, definition}
   end
 end

--- a/lib/tesla/open_api/query_params.ex
+++ b/lib/tesla/open_api/query_params.ex
@@ -27,20 +27,20 @@ defmodule Tesla.OpenAPI.QueryParams do
   """
 
   alias Tesla.OpenAPI.QueryParam
+  alias Tesla.Param
 
-  @enforce_keys [:definitions, :by_name]
-  defstruct [:definitions, :by_name]
+  @enforce_keys [:definitions]
+  defstruct [:definitions]
 
   @opaque t :: %__MODULE__{
-            definitions: [QueryParam.t()],
-            by_name: %{String.t() => QueryParam.t()}
+            definitions: [QueryParam.t()]
           }
 
   @private_key :tesla_query_params
 
   @spec new!([QueryParam.t()]) :: t()
   def new!(definitions) when is_list(definitions) do
-    %__MODULE__{definitions: definitions, by_name: by_name!(definitions)}
+    %__MODULE__{definitions: Param.validate_definitions!(definitions, QueryParam, :query)}
   end
 
   @doc """
@@ -83,30 +83,5 @@ defmodule Tesla.OpenAPI.QueryParams do
   @spec definitions(t()) :: [QueryParam.t()]
   def definitions(%__MODULE__{definitions: definitions}) do
     definitions
-  end
-
-  @doc false
-  @spec fetch(t(), String.t()) :: {:ok, %QueryParam{}} | :error
-  def fetch(%__MODULE__{by_name: by_name}, name) when is_binary(name) do
-    Map.fetch(by_name, name)
-  end
-
-  defp by_name!(definitions) do
-    Enum.reduce(definitions, %{}, &put_by_name!/2)
-  end
-
-  defp put_by_name!(%QueryParam{name: name} = query_param, by_name) do
-    case Map.has_key?(by_name, name) do
-      true ->
-        raise ArgumentError, "duplicate query parameter #{inspect(name)}"
-
-      false ->
-        Map.put(by_name, name, query_param)
-    end
-  end
-
-  defp put_by_name!(value, _by_name) do
-    raise ArgumentError,
-          "expected query parameter definitions to be #{inspect(QueryParam)} structs; got #{inspect(value)}"
   end
 end

--- a/lib/tesla/param.ex
+++ b/lib/tesla/param.ex
@@ -40,6 +40,42 @@ defmodule Tesla.Param do
     validate_option_boolean!(kind, :allow_reserved, value)
   end
 
+  def validate_definitions!(definitions, module, kind) when is_list(definitions) do
+    definitions
+    |> validate_definitions!(module, kind, [], MapSet.new())
+    |> Enum.reverse()
+  end
+
+  defp validate_definitions!([], _module, _kind, definitions, _names) do
+    definitions
+  end
+
+  defp validate_definitions!([definition | rest], module, kind, definitions, names) do
+    {definition, names} = validate_definition!(definition, module, kind, names)
+    validate_definitions!(rest, module, kind, [definition | definitions], names)
+  end
+
+  defp validate_definition!(
+         %{__struct__: definition_module, name: name} = definition,
+         module,
+         kind,
+         names
+       )
+       when definition_module == module do
+    case MapSet.member?(names, name) do
+      true ->
+        raise ArgumentError, "duplicate #{kind} parameter #{inspect(name)}"
+
+      false ->
+        {definition, MapSet.put(names, name)}
+    end
+  end
+
+  defp validate_definition!(value, module, kind, _names) do
+    raise ArgumentError,
+          "expected #{kind} parameter definitions to be #{inspect(module)} structs; got #{inspect(value)}"
+  end
+
   defp validate_option_boolean!(_kind, _key, value) when is_boolean(value) do
     value
   end

--- a/test/tesla/open_api/cookie_params_test.exs
+++ b/test/tesla/open_api/cookie_params_test.exs
@@ -8,33 +8,6 @@ defmodule Tesla.OpenAPI.CookieParamsTest do
     defstruct [:role, :id]
   end
 
-  test "keeps cookie parameter definitions in declaration order" do
-    definitions = [
-      CookieParam.new!("session_id"),
-      CookieParam.new!("theme", style: :cookie)
-    ]
-
-    cookie_params = CookieParams.new!(definitions)
-
-    assert CookieParams.definitions(cookie_params) == definitions
-  end
-
-  test "indexes cookie parameter definitions by name" do
-    cookie_params =
-      CookieParams.new!([
-        CookieParam.new!("session_id"),
-        CookieParam.new!("theme", style: :cookie)
-      ])
-
-    assert {:ok, %CookieParam{name: "session_id", style: :form}} =
-             CookieParams.fetch(cookie_params, "session_id")
-
-    assert {:ok, %CookieParam{name: "theme", style: :cookie}} =
-             CookieParams.fetch(cookie_params, "theme")
-
-    assert CookieParams.fetch(cookie_params, "missing") == :error
-  end
-
   describe "OpenAPI form style examples" do
     test "form style with explode false" do
       cookie_params = CookieParams.new!([CookieParam.new!("color", explode: false)])

--- a/test/tesla/open_api/header_params_test.exs
+++ b/test/tesla/open_api/header_params_test.exs
@@ -8,33 +8,6 @@ defmodule Tesla.OpenAPI.HeaderParamsTest do
     defstruct [:role, :id]
   end
 
-  test "keeps header parameter definitions in declaration order" do
-    definitions = [
-      HeaderParam.new!("X-Request-ID"),
-      HeaderParam.new!("X-Filter", explode: true)
-    ]
-
-    header_params = HeaderParams.new!(definitions)
-
-    assert HeaderParams.definitions(header_params) == definitions
-  end
-
-  test "indexes header parameter definitions by name" do
-    header_params =
-      HeaderParams.new!([
-        HeaderParam.new!("X-Request-ID"),
-        HeaderParam.new!("X-Filter", explode: true)
-      ])
-
-    assert {:ok, %HeaderParam{name: "X-Request-ID", style: :simple}} =
-             HeaderParams.fetch(header_params, "X-Request-ID")
-
-    assert {:ok, %HeaderParam{name: "X-Filter", explode: true}} =
-             HeaderParams.fetch(header_params, "X-Filter")
-
-    assert HeaderParams.fetch(header_params, "missing") == :error
-  end
-
   describe "OpenAPI style examples" do
     test "simple style with explode false" do
       header_params = HeaderParams.new!([HeaderParam.new!("color")])

--- a/test/tesla/open_api/query_params_test.exs
+++ b/test/tesla/open_api/query_params_test.exs
@@ -4,33 +4,6 @@ defmodule Tesla.OpenAPI.QueryParamsTest do
   alias Tesla.OpenAPI.QueryParam
   alias Tesla.OpenAPI.QueryParams
 
-  test "keeps query parameter definitions in declaration order" do
-    definitions = [
-      QueryParam.new!("page"),
-      QueryParam.new!("ids", style: :pipe_delimited)
-    ]
-
-    query_params = QueryParams.new!(definitions)
-
-    assert QueryParams.definitions(query_params) == definitions
-  end
-
-  test "indexes query parameter definitions by name" do
-    query_params =
-      QueryParams.new!([
-        QueryParam.new!("page"),
-        QueryParam.new!("ids", style: :pipe_delimited)
-      ])
-
-    assert {:ok, %QueryParam{name: "page", style: :form}} =
-             QueryParams.fetch(query_params, "page")
-
-    assert {:ok, %QueryParam{name: "ids", style: :pipe_delimited}} =
-             QueryParams.fetch(query_params, "ids")
-
-    assert QueryParams.fetch(query_params, "missing") == :error
-  end
-
   test "stores and fetches query params from request private data" do
     query_params = QueryParams.new!([QueryParam.new!("page")])
     private = QueryParams.put_private(%{existing: true}, query_params)


### PR DESCRIPTION
- Keep OpenAPI parameter collection structs focused on one normalized source of truth.
- Avoid carrying cached lookup state in generated-client metadata before the API is released.