### PR TITLE
chore(openapi): add parameter collection benchmarks

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -8,6 +8,7 @@ export_locals_without_parens = [
 
 [
   inputs: [
+    "bench/**/*.{ex,exs}",
     "lib/**/*.{ex,exs}",
     "test/**/*.{ex,exs}",
     "mix.exs"

--- a/bench/openapi_parameter_collections.exs
+++ b/bench/openapi_parameter_collections.exs
@@ -1,0 +1,209 @@
+defmodule Tesla.Bench.OpenAPIParameterCollections.OperationTemplate do
+  @moduledoc false
+
+  defmacro __using__(size: size) do
+    names = Enum.map(1..size, &"param#{&1}")
+    path = "/items/" <> Enum.map_join(names, "/", &"{#{&1}}")
+
+    path_params = params(names, Tesla.OpenAPI.PathParam)
+    query_params = params(names, Tesla.OpenAPI.QueryParam)
+    header_params = params(names, Tesla.OpenAPI.HeaderParam)
+    cookie_params = params(names, Tesla.OpenAPI.CookieParam)
+
+    quote do
+      @moduledoc false
+
+      defstruct path: nil,
+                query: nil,
+                headers: nil,
+                cookies: nil
+
+      @path_template Tesla.OpenAPI.PathTemplate.new!(unquote(path))
+      @path_params Tesla.OpenAPI.PathParams.new!([unquote_splicing(path_params)])
+      @query_params Tesla.OpenAPI.QueryParams.new!([unquote_splicing(query_params)])
+      @header_params Tesla.OpenAPI.HeaderParams.new!([unquote_splicing(header_params)])
+      @cookie_params Tesla.OpenAPI.CookieParams.new!([unquote_splicing(cookie_params)])
+
+      @private Tesla.OpenAPI.merge_private([
+                 Tesla.OpenAPI.PathTemplate.put_private(@path_template),
+                 Tesla.OpenAPI.PathParams.put_private(@path_params),
+                 Tesla.OpenAPI.QueryParams.put_private(@query_params)
+               ])
+
+      def handle_operation(
+            %Tesla.Bench.OpenAPIParameterCollections.Client{client: client},
+            %__MODULE__{} = operation
+          ) do
+        request_opts = [
+          method: :get,
+          url: @path_template.path,
+          query: operation.query,
+          headers: headers(operation),
+          opts: [path_params: operation.path],
+          private: @private
+        ]
+
+        case Tesla.request(client, request_opts) do
+          {:ok, %Tesla.Env{} = env} ->
+            {env.status, byte_size(env.url), length(env.headers)}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+      end
+
+      defp headers(%__MODULE__{headers: headers, cookies: cookies}) do
+        Tesla.OpenAPI.HeaderParams.to_headers(@header_params, headers) ++
+          Tesla.OpenAPI.CookieParams.to_headers(@cookie_params, cookies)
+      end
+    end
+  end
+
+  defp params(names, module) do
+    Enum.map(names, &param(&1, module))
+  end
+
+  defp param(name, module) do
+    quote do
+      unquote(module).new!(unquote(name))
+    end
+  end
+end
+
+defmodule Tesla.Bench.OpenAPIParameterCollections do
+  @moduledoc false
+
+  alias Tesla.Env
+
+  defmodule Client do
+    @moduledoc false
+
+    defstruct [:client]
+
+    def new do
+      middleware = [
+        {Tesla.Middleware.BaseUrl, base_url: "https://api.example.com"},
+        {Tesla.Middleware.PathParams, mode: :modern},
+        {Tesla.Middleware.Query, mode: :modern}
+      ]
+
+      %__MODULE__{client: Tesla.client(middleware, adapter())}
+    end
+
+    defp adapter do
+      fn %Env{} = env ->
+        {:ok, %{env | url: Tesla.build_url(env), query: [], status: 200, body: :ok}}
+      end
+    end
+  end
+
+  defmodule Operation3 do
+    use Tesla.Bench.OpenAPIParameterCollections.OperationTemplate, size: 3
+  end
+
+  defmodule Operation10 do
+    use Tesla.Bench.OpenAPIParameterCollections.OperationTemplate, size: 10
+  end
+
+  defmodule Operation25 do
+    use Tesla.Bench.OpenAPIParameterCollections.OperationTemplate, size: 25
+  end
+
+  defmodule Operation100 do
+    use Tesla.Bench.OpenAPIParameterCollections.OperationTemplate, size: 100
+  end
+
+  def inputs(sizes) do
+    client = Client.new()
+
+    Map.new(input_specs(sizes), fn {label, size, known_count, extra_count} ->
+      operation_module = operation_module(size)
+
+      operation =
+        struct(operation_module,
+          path: values(size, 0),
+          query: values(known_count, extra_count),
+          headers: values(known_count, extra_count),
+          cookies: values(known_count, extra_count)
+        )
+
+      {label, %{client: client, operation: operation}}
+    end)
+  end
+
+  def call(%{client: client, operation: operation}) do
+    module = operation.__struct__
+
+    module.handle_operation(client, operation)
+  end
+
+  defp operation_module(3) do
+    Operation3
+  end
+
+  defp operation_module(10) do
+    Operation10
+  end
+
+  defp operation_module(25) do
+    Operation25
+  end
+
+  defp operation_module(100) do
+    Operation100
+  end
+
+  defp input_specs(sizes) do
+    for size <- sizes,
+        {profile, known_count, extra_count} <- value_profiles(size) do
+      {"#{size} #{profile}", size, known_count, extra_count}
+    end
+  end
+
+  defp value_profiles(size) do
+    sparse_count = min(size, 3)
+
+    [
+      {"dense known", size, 0},
+      {"dense plus extras", size, size},
+      {"sparse known", sparse_count, 0},
+      {"sparse plus extras", sparse_count, size},
+      {"extras only", 0, size}
+    ]
+  end
+
+  defp values(known_count, extra_count) do
+    known = Map.new(indexes(known_count), &{"param#{&1}", &1})
+    extra = Map.new(indexes(extra_count), &{"extra#{&1}", &1})
+
+    Map.merge(extra, known)
+  end
+
+  defp indexes(0) do
+    []
+  end
+
+  defp indexes(size) do
+    1..size
+  end
+end
+
+alias Tesla.Bench.OpenAPIParameterCollections
+
+sizes = [3, 10, 25, 100]
+
+Benchee.run(
+  %{
+    "current middleware" => &OpenAPIParameterCollections.call/1
+  },
+  time: 0.5,
+  warmup: 0.2,
+  memory_time: 0.1,
+  inputs: OpenAPIParameterCollections.inputs(sizes),
+  title: "OpenAPI generated operation: current middleware stack",
+  print: [
+    benchmarking: false,
+    configuration: false,
+    fast_warning: false
+  ]
+)

--- a/mix.exs
+++ b/mix.exs
@@ -84,6 +84,7 @@ defmodule Tesla.Mixfile do
       {:mix_test_watch, ">= 0.0.0", only: :dev},
       {:dialyxir, ">= 0.0.0", only: [:dev, :test], runtime: false},
       {:inch_ex, ">= 0.0.0", only: :docs},
+      {:benchee, "~> 1.4", only: :dev, runtime: false},
 
       # httparrot dependencies
       {:httparrot, "~> 1.4", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,12 @@
 %{
+  "benchee": {:hex, :benchee, "1.5.0", "4d812c31d54b0ec0167e91278e7de3f596324a78a096fd3d0bea68bb0c513b10", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}, {:statistex, "~> 1.1", [hex: :statistex, repo: "hexpm", optional: false]}, {:table, "~> 0.1.0", [hex: :table, repo: "hexpm", optional: true]}], "hexpm", "5b075393aea81b8ae74eadd1c28b1d87e8a63696c649d8293db7c4df3eb67535"},
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
   "castore": {:hex, :castore, "1.0.14", "4582dd7d630b48cf5e1ca8d3d42494db51e406b7ba704e81fbd401866366896a", [:mix], [], "hexpm", "7bc1b65249d31701393edaaac18ec8398d8974d52c647b7904d01b964137b9f4"},
   "certifi": {:hex, :certifi, "2.15.0", "0e6e882fcdaaa0a5a9f2b3db55b1394dba07e8d6d9bcad08318fb604c6839712", [:rebar3], [], "hexpm", "b147ed22ce71d72eafdad94f055165c1c182f61a2ff49df28bcc71d1d5b94a60"},
   "con_cache": {:hex, :con_cache, "1.1.0", "45c7c6cd6dc216e47636232e8c683734b7fe293221fccd9454fa1757bc685044", [:mix], [{:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "8655f2ae13a1e56c8aef304d250814c7ed929c12810f126fc423ecc8e871593b"},
   "cowboy": {:hex, :cowboy, "2.12.0", "f276d521a1ff88b2b9b4c54d0e753da6c66dd7be6c9fca3d9418b561828a3731", [:make, :rebar3], [{:cowlib, "2.13.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "1.8.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "8a7abe6d183372ceb21caa2709bec928ab2b72e18a3911aa1771639bef82651e"},
   "cowlib": {:hex, :cowlib, "2.16.0", "54592074ebbbb92ee4746c8a8846e5605052f29309d3a873468d76cdf932076f", [:make, :rebar3], [], "hexpm", "7f478d80d66b747344f0ea7708c187645cfcc08b11aa424632f78e25bf05db51"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "dialyxir": {:hex, :dialyxir, "1.4.7", "dda948fcee52962e4b6c5b4b16b2d8fa7d50d8645bbae8b8685c3f9ecb7f5f4d", [:mix], [{:erlex, ">= 0.2.8", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "b34527202e6eb8cee198efec110996c25c5898f43a4094df157f8d28f27d9efe"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.44", "f20830dd6b5c77afe2b063777ddbbff09f9759396500cdbe7523efd58d7a339c", [:mix], [], "hexpm", "4778ac752b4701a5599215f7030989c989ffdc4f6df457c5f36938cc2d2a2750"},
@@ -45,6 +47,7 @@
   "poison": {:hex, :poison, "6.0.0", "9bbe86722355e36ffb62c51a552719534257ba53f3271dacd20fbbd6621a583a", [:mix], [{:decimal, "~> 2.1", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "bb9064632b94775a3964642d6a78281c07b7be1319e0016e1643790704e739a2"},
   "ranch": {:hex, :ranch, "2.2.0", "25528f82bc8d7c6152c57666ca99ec716510fe0925cb188172f41ce93117b1b0", [:make, :rebar3], [], "hexpm", "fa0b99a1780c80218a4197a59ea8d3bdae32fbff7e88527d7d8a4787eff4f8e7"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
+  "statistex": {:hex, :statistex, "1.1.0", "7fec1eb2f580a0d2c1a05ed27396a084ab064a40cfc84246dbfb0c72a5c761e5", [:mix], [], "hexpm", "f5950ea26ad43246ba2cce54324ac394a4e7408fdcf98b8e230f503a0cba9cf5"},
   "telemetry": {:hex, :telemetry, "1.3.0", "fedebbae410d715cf8e7062c96a1ef32ec22e764197f70cda73d82778d61e7a2", [:rebar3], [], "hexpm", "7015fc8919dbe63764f4b4b87a95b7c0996bd539e0d499be6ec9d7f3875b79e6"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.1", "a48703a25c170eedadca83b11e88985af08d35f37c6f664d6dcfb106a97782fc", [:rebar3], [], "hexpm", "b3a917854ce3ae233619744ad1e0102e05673136776fb2fa76234f3e03b23642"},
 }


### PR DESCRIPTION
- Keep the OpenAPI parameter collection performance tradeoffs visible before changing the unreleased API surface again.
- Make benchmark results easier to trust when evaluating API-shape changes.