### PR TITLE
chore(openapi): clarify value object docs

### DIFF
--- a/guides/cheatsheets/openapi.cheatmd
+++ b/guides/cheatsheets/openapi.cheatmd
@@ -25,63 +25,93 @@ client =
 ## Generated Operation Metadata
 
 ```elixir
-alias Tesla.OpenAPI
-alias Tesla.OpenAPI.{PathParam, PathParams, PathTemplate, QueryParam, QueryParams}
+defmodule MyApi.Operation.GetItem do
+  alias Tesla.OpenAPI
+  alias Tesla.OpenAPI.{PathParam, PathParams, PathTemplate, QueryParam, QueryParams}
 
-@path_template PathTemplate.new!("/items/{id}{coords}")
+  @path_template PathTemplate.new!("/items/{id}{coords}")
 
-@path_params PathParams.new!([
-               PathParam.new!("id"),
-               PathParam.new!("coords", style: :matrix, explode: true)
-             ])
+  @path_params PathParams.new!([
+                 PathParam.new!("id"),
+                 PathParam.new!("coords", style: :matrix, explode: true)
+               ])
 
-@query_params QueryParams.new!([
-                QueryParam.new!("color", style: :pipe_delimited),
-                QueryParam.new!("filter", style: :deep_object)
-              ])
+  @query_params QueryParams.new!([
+                  QueryParam.new!("color", style: :pipe_delimited),
+                  QueryParam.new!("filter", style: :deep_object)
+                ])
 
-@private OpenAPI.merge_private([
-           PathTemplate.put_private(@path_template),
-           PathParams.put_private(@path_params),
-           QueryParams.put_private(@query_params)
-         ])
+  @private OpenAPI.merge_private([
+             PathTemplate.put_private(@path_template),
+             PathParams.put_private(@path_params),
+             QueryParams.put_private(@query_params)
+           ])
+end
 ```
 
 ## Request Values
 
 ```elixir
-Tesla.get(client, @path_template.path,
-  query: %{
-    "color" => ["blue", "black"],
-    "filter" => [role: "admin"],
-    "debug" => true
-  },
-  opts: [
-    path_params: %{
-      "id" => 42,
-      "coords" => ["blue", "black"]
-    }
-  ],
-  private: @private
-)
+defmodule MyApi.Operation.GetItem do
+  alias Tesla.OpenAPI
+  alias Tesla.OpenAPI.{PathParam, PathParams, PathTemplate, QueryParam, QueryParams}
+
+  @path_template PathTemplate.new!("/items/{id}{coords}")
+
+  @path_params PathParams.new!([
+                 PathParam.new!("id"),
+                 PathParam.new!("coords", style: :matrix, explode: true)
+               ])
+
+  @query_params QueryParams.new!([
+                  QueryParam.new!("color", style: :pipe_delimited),
+                  QueryParam.new!("filter", style: :deep_object)
+                ])
+
+  @private OpenAPI.merge_private([
+             PathTemplate.put_private(@path_template),
+             PathParams.put_private(@path_params),
+             QueryParams.put_private(@query_params)
+           ])
+
+  def request(client) do
+    Tesla.get(client, @path_template.path,
+      query: %{
+        "color" => ["blue", "black"],
+        "filter" => [role: "admin"],
+        "debug" => true
+      },
+      opts: [
+        path_params: %{
+          "id" => 42,
+          "coords" => ["blue", "black"]
+        }
+      ],
+      private: @private
+    )
+  end
+end
 ```
 
 ## Headers And Cookies
 
 ```elixir
-alias Tesla.OpenAPI.{CookieParam, CookieParams, HeaderParam, HeaderParams}
+defmodule MyApi.Operation.GetItem do
+  alias Tesla.OpenAPI.{CookieParam, CookieParams, HeaderParam, HeaderParams}
 
-@header_params HeaderParams.new!([
-                 HeaderParam.new!("X-Request-ID")
-               ])
+  @header_params HeaderParams.new!([
+                   HeaderParam.new!("X-Request-ID")
+                 ])
 
-@cookie_params CookieParams.new!([
-                 CookieParam.new!("session_id")
-               ])
+  @cookie_params CookieParams.new!([
+                   CookieParam.new!("session_id")
+                 ])
 
-headers =
-  HeaderParams.to_headers(@header_params, %{"X-Request-ID" => "req-123"}) ++
-    CookieParams.to_headers(@cookie_params, %{"session_id" => "abc123"})
+  def headers do
+    HeaderParams.to_headers(@header_params, %{"X-Request-ID" => "req-123"}) ++
+      CookieParams.to_headers(@cookie_params, %{"session_id" => "abc123"})
+  end
+end
 ```
 
 ## Query String Parameter

--- a/lib/tesla/open_api.ex
+++ b/lib/tesla/open_api.ex
@@ -21,11 +21,17 @@ defmodule Tesla.OpenAPI do
   Generated clients should keep OpenAPI parameter definitions as module
   attributes and pass only request values at runtime:
 
-      @private Tesla.OpenAPI.merge_private([
-                 Tesla.OpenAPI.PathTemplate.put_private(@path_template),
-                 Tesla.OpenAPI.PathParams.put_private(@path_params),
-                 Tesla.OpenAPI.QueryParams.put_private(@query_params)
-               ])
+      defmodule MyApi.Operation.GetItem do
+        @path_template Tesla.OpenAPI.PathTemplate.new!("/items/{id}")
+        @path_params Tesla.OpenAPI.PathParams.new!([Tesla.OpenAPI.PathParam.new!("id")])
+        @query_params Tesla.OpenAPI.QueryParams.new!([Tesla.OpenAPI.QueryParam.new!("filter")])
+
+        @private Tesla.OpenAPI.merge_private([
+                   Tesla.OpenAPI.PathTemplate.put_private(@path_template),
+                   Tesla.OpenAPI.PathParams.put_private(@path_params),
+                   Tesla.OpenAPI.QueryParams.put_private(@query_params)
+                 ])
+      end
 
   Path and query parameter collections are placed in request private data
   because their middleware serializes them into the request URL. Header and

--- a/lib/tesla/open_api/cookie_param.ex
+++ b/lib/tesla/open_api/cookie_param.ex
@@ -2,7 +2,7 @@ defmodule Tesla.OpenAPI.CookieParam do
   @moduledoc """
   A cookie parameter with explicit serialization settings.
 
-  `Tesla.OpenAPI.CookieParam` is a Tesla-native value object for cookie parameters whose
+  `Tesla.OpenAPI.CookieParam` is a value object for cookie parameters whose
   serialization needs to be controlled explicitly. Its serialization options
   follow the OpenAPI cookie parameter style semantics, while keeping the public
   API focused on the cookie use case.

--- a/lib/tesla/open_api/cookie_param.ex
+++ b/lib/tesla/open_api/cookie_param.ex
@@ -75,7 +75,12 @@ defmodule Tesla.OpenAPI.CookieParam do
       and `false` for all other styles.
     * `:allow_reserved` - boolean. Defaults to `false`.
   """
-  @spec new!(String.t(), keyword()) :: t()
+  @spec new!(
+          String.t(),
+          style: style(),
+          explode: boolean(),
+          allow_reserved: boolean()
+        ) :: t()
   def new!(name, opts \\ []) do
     name = Param.validate_name!(:cookie, name)
     opts = Param.validate_opts!(:cookie, opts)

--- a/lib/tesla/open_api/cookie_param.ex
+++ b/lib/tesla/open_api/cookie_param.ex
@@ -23,17 +23,6 @@ defmodule Tesla.OpenAPI.CookieParam do
         "theme" => "dark"
       })
 
-  ## Options
-
-  `new!/2` accepts a keyword list using Elixir atoms for hand-written Tesla
-  code:
-
-    * `:style` - one of `:form` or `:cookie`. Defaults to `:form`, matching
-      the OpenAPI compatibility default for cookie parameters.
-    * `:explode` - boolean. Defaults to `true` when the style is `:form`,
-      and `false` for all other styles.
-    * `:allow_reserved` - boolean. Defaults to `false`.
-
   [oas-style]: https://spec.openapis.org/oas/latest.html#style-values
 
   ## Encoding
@@ -75,6 +64,17 @@ defmodule Tesla.OpenAPI.CookieParam do
   @styles [:form, :cookie]
   @expected_styles ":form or :cookie"
 
+  @doc """
+  Creates a cookie parameter definition.
+
+  Options use Elixir atoms for hand-written Tesla code:
+
+    * `:style` - one of `:form` or `:cookie`. Defaults to `:form`, matching
+      the OpenAPI compatibility default for cookie parameters.
+    * `:explode` - boolean. Defaults to `true` when the style is `:form`,
+      and `false` for all other styles.
+    * `:allow_reserved` - boolean. Defaults to `false`.
+  """
   @spec new!(String.t(), keyword()) :: t()
   def new!(name, opts \\ []) do
     name = Param.validate_name!(:cookie, name)

--- a/lib/tesla/open_api/cookie_param.ex
+++ b/lib/tesla/open_api/cookie_param.ex
@@ -4,8 +4,7 @@ defmodule Tesla.OpenAPI.CookieParam do
 
   `Tesla.OpenAPI.CookieParam` is a value object for cookie parameters whose
   serialization needs to be controlled explicitly. Its serialization options
-  follow the OpenAPI cookie parameter style semantics, while keeping the public
-  API focused on the cookie use case.
+  follow the OpenAPI cookie parameter style semantics.
 
   Define cookie parameters once and apply them to request values with
   `Tesla.OpenAPI.CookieParams`:

--- a/lib/tesla/open_api/cookie_params.ex
+++ b/lib/tesla/open_api/cookie_params.ex
@@ -7,17 +7,18 @@ defmodule Tesla.OpenAPI.CookieParams do
   a static operation specification, prefer defining the collection in a module
   attribute and passing only dynamic values when creating request headers.
 
-      alias Tesla.OpenAPI.{CookieParam, CookieParams}
+      defmodule MyApi.Operation.GetItem.Cookie do
+        alias Tesla.OpenAPI.{CookieParam, CookieParams}
 
-      @cookie_params CookieParams.new!([
-                       CookieParam.new!("session_id"),
-                       CookieParam.new!("theme")
-                     ])
+        @cookie_params CookieParams.new!([
+                         CookieParam.new!("session_id"),
+                         CookieParam.new!("theme")
+                       ])
 
-      CookieParams.to_headers(@cookie_params, %{
-        "session_id" => "abc123",
-        "theme" => "dark"
-      })
+        def to_headers(values) do
+          CookieParams.to_headers(@cookie_params, values)
+        end
+      end
   """
 
   alias Tesla.OpenAPI.CookieParam

--- a/lib/tesla/open_api/cookie_params.ex
+++ b/lib/tesla/open_api/cookie_params.ex
@@ -1,20 +1,20 @@
 defmodule Tesla.OpenAPI.CookieParams do
   @moduledoc """
-  Precompiled cookie parameter definitions.
+  A collection of cookie parameter definitions.
 
   `Tesla.OpenAPI.CookieParams` keeps static cookie parameter metadata separate
-  from per-request values. Generated clients can build it once and pass only
-  dynamic values when creating request headers.
+  from per-request values. Since cookie parameter definitions usually come from
+  a static operation specification, prefer defining the collection in a module
+  attribute and passing only dynamic values when creating request headers.
 
       alias Tesla.OpenAPI.{CookieParam, CookieParams}
 
-      cookie_params =
-        CookieParams.new!([
-          CookieParam.new!("session_id"),
-          CookieParam.new!("theme")
-        ])
+      @cookie_params CookieParams.new!([
+                       CookieParam.new!("session_id"),
+                       CookieParam.new!("theme")
+                     ])
 
-      CookieParams.to_headers(cookie_params, %{
+      CookieParams.to_headers(@cookie_params, %{
         "session_id" => "abc123",
         "theme" => "dark"
       })

--- a/lib/tesla/open_api/header_param.ex
+++ b/lib/tesla/open_api/header_param.ex
@@ -2,7 +2,7 @@ defmodule Tesla.OpenAPI.HeaderParam do
   @moduledoc """
   A header parameter with explicit serialization settings.
 
-  `Tesla.OpenAPI.HeaderParam` is a Tesla-native value object for header parameters whose
+  `Tesla.OpenAPI.HeaderParam` is a value object for header parameters whose
   serialization needs to be controlled explicitly. Its serialization options
   follow the OpenAPI header parameter style semantics, while keeping the public
   API focused on the header use case.

--- a/lib/tesla/open_api/header_param.ex
+++ b/lib/tesla/open_api/header_param.ex
@@ -4,8 +4,7 @@ defmodule Tesla.OpenAPI.HeaderParam do
 
   `Tesla.OpenAPI.HeaderParam` is a value object for header parameters whose
   serialization needs to be controlled explicitly. Its serialization options
-  follow the OpenAPI header parameter style semantics, while keeping the public
-  API focused on the header use case.
+  follow the OpenAPI header parameter style semantics.
 
   Define header parameters once and apply them to request values with
   `Tesla.OpenAPI.HeaderParams`:

--- a/lib/tesla/open_api/header_param.ex
+++ b/lib/tesla/open_api/header_param.ex
@@ -19,14 +19,6 @@ defmodule Tesla.OpenAPI.HeaderParam do
 
       HeaderParams.to_headers(header_params, %{"X-Token" => [12345678, 90099]})
 
-  ## Options
-
-  `new!/2` accepts a keyword list using Elixir atoms for hand-written Tesla
-  code:
-
-    * `:style` - must be `:simple`. Defaults to `:simple`.
-    * `:explode` - boolean. Defaults to `false`.
-
   [oas-style]: https://spec.openapis.org/oas/latest.html#style-values
 
   ## Encoding
@@ -59,6 +51,14 @@ defmodule Tesla.OpenAPI.HeaderParam do
   @styles [:simple]
   @expected_styles ":simple"
 
+  @doc """
+  Creates a header parameter definition.
+
+  Options use Elixir atoms for hand-written Tesla code:
+
+    * `:style` - must be `:simple`. Defaults to `:simple`.
+    * `:explode` - boolean. Defaults to `false`.
+  """
   @spec new!(String.t(), keyword()) :: t()
   def new!(name, opts \\ []) do
     name = Param.validate_name!(:header, name)

--- a/lib/tesla/open_api/header_param.ex
+++ b/lib/tesla/open_api/header_param.ex
@@ -59,7 +59,11 @@ defmodule Tesla.OpenAPI.HeaderParam do
     * `:style` - must be `:simple`. Defaults to `:simple`.
     * `:explode` - boolean. Defaults to `false`.
   """
-  @spec new!(String.t(), keyword()) :: t()
+  @spec new!(
+          String.t(),
+          style: style(),
+          explode: boolean()
+        ) :: t()
   def new!(name, opts \\ []) do
     name = Param.validate_name!(:header, name)
     opts = Param.validate_opts!(:header, opts)

--- a/lib/tesla/open_api/header_params.ex
+++ b/lib/tesla/open_api/header_params.ex
@@ -7,13 +7,17 @@ defmodule Tesla.OpenAPI.HeaderParams do
   a static operation specification, prefer defining the collection in a module
   attribute and passing only dynamic values when creating request headers.
 
-      alias Tesla.OpenAPI.{HeaderParam, HeaderParams}
+      defmodule MyApi.Operation.GetItem.Header do
+        alias Tesla.OpenAPI.{HeaderParam, HeaderParams}
 
-      @header_params HeaderParams.new!([
-                       HeaderParam.new!("X-Request-ID")
-                     ])
+        @header_params HeaderParams.new!([
+                         HeaderParam.new!("X-Request-ID")
+                       ])
 
-      HeaderParams.to_headers(@header_params, %{"X-Request-ID" => "req-123"})
+        def to_headers(values) do
+          HeaderParams.to_headers(@header_params, values)
+        end
+      end
   """
 
   alias Tesla.OpenAPI.HeaderParam

--- a/lib/tesla/open_api/header_params.ex
+++ b/lib/tesla/open_api/header_params.ex
@@ -1,19 +1,19 @@
 defmodule Tesla.OpenAPI.HeaderParams do
   @moduledoc """
-  Precompiled header parameter definitions.
+  A collection of header parameter definitions.
 
   `Tesla.OpenAPI.HeaderParams` keeps static header parameter metadata separate
-  from per-request values. Generated clients can build it once and pass only
-  dynamic values when creating request headers.
+  from per-request values. Since header parameter definitions usually come from
+  a static operation specification, prefer defining the collection in a module
+  attribute and passing only dynamic values when creating request headers.
 
       alias Tesla.OpenAPI.{HeaderParam, HeaderParams}
 
-      header_params =
-        HeaderParams.new!([
-          HeaderParam.new!("X-Request-ID")
-        ])
+      @header_params HeaderParams.new!([
+                       HeaderParam.new!("X-Request-ID")
+                     ])
 
-      HeaderParams.to_headers(header_params, %{"X-Request-ID" => "req-123"})
+      HeaderParams.to_headers(@header_params, %{"X-Request-ID" => "req-123"})
   """
 
   alias Tesla.OpenAPI.HeaderParam

--- a/lib/tesla/open_api/path_param.ex
+++ b/lib/tesla/open_api/path_param.ex
@@ -4,8 +4,7 @@ defmodule Tesla.OpenAPI.PathParam do
 
   `Tesla.OpenAPI.PathParam` is a value object for path parameter metadata whose
   serialization needs to be controlled explicitly. Its serialization options
-  follow the OpenAPI path parameter style semantics, while keeping the public
-  API focused on the path use case.
+  follow the OpenAPI path parameter style semantics.
 
   In `Tesla.Middleware.PathParams` `:modern` mode, define path parameters once
   and pass them through request private data with `Tesla.OpenAPI.PathParams`:

--- a/lib/tesla/open_api/path_param.ex
+++ b/lib/tesla/open_api/path_param.ex
@@ -2,10 +2,10 @@ defmodule Tesla.OpenAPI.PathParam do
   @moduledoc """
   A path parameter definition with explicit serialization settings.
 
-  `Tesla.OpenAPI.PathParam` is a Tesla-native value object for path parameter metadata
-  whose serialization needs to be controlled explicitly. Its serialization
-  options follow the OpenAPI path parameter style semantics, while keeping the
-  public API focused on the path use case.
+  `Tesla.OpenAPI.PathParam` is a value object for path parameter metadata whose
+  serialization needs to be controlled explicitly. Its serialization options
+  follow the OpenAPI path parameter style semantics, while keeping the public
+  API focused on the path use case.
 
   In `Tesla.Middleware.PathParams` `:modern` mode, define path parameters once
   and pass them through request private data with `Tesla.OpenAPI.PathParams`:

--- a/lib/tesla/open_api/path_param.ex
+++ b/lib/tesla/open_api/path_param.ex
@@ -26,15 +26,6 @@ defmodule Tesla.OpenAPI.PathParam do
         PathParam.new!("coords", style: :matrix, explode: true)
       ])
 
-  ## Options
-
-  `new!/2` accepts a keyword list using Elixir atoms for hand-written Tesla
-  code:
-
-    * `:style` — one of `:simple`, `:matrix`, `:label`. Defaults to `:simple`.
-    * `:explode` — boolean. Defaults to `false`.
-    * `:allow_reserved` — boolean. Defaults to `false`.
-
   [oas-style]: https://spec.openapis.org/oas/latest.html#style-values
 
   ## Encoding
@@ -80,6 +71,15 @@ defmodule Tesla.OpenAPI.PathParam do
   @styles [:simple, :matrix, :label]
   @expected_styles ":simple, :matrix, or :label"
 
+  @doc """
+  Creates a path parameter definition.
+
+  Options use Elixir atoms for hand-written Tesla code:
+
+    * `:style` — one of `:simple`, `:matrix`, `:label`. Defaults to `:simple`.
+    * `:explode` — boolean. Defaults to `false`.
+    * `:allow_reserved` — boolean. Defaults to `false`.
+  """
   @spec new!(String.t(), keyword()) :: t()
   def new!(name, opts \\ []) do
     name = Param.validate_name!(:path, name)

--- a/lib/tesla/open_api/path_param.ex
+++ b/lib/tesla/open_api/path_param.ex
@@ -80,7 +80,12 @@ defmodule Tesla.OpenAPI.PathParam do
     * `:explode` — boolean. Defaults to `false`.
     * `:allow_reserved` — boolean. Defaults to `false`.
   """
-  @spec new!(String.t(), keyword()) :: t()
+  @spec new!(
+          String.t(),
+          style: style(),
+          explode: boolean(),
+          allow_reserved: boolean()
+        ) :: t()
   def new!(name, opts \\ []) do
     name = Param.validate_name!(:path, name)
     opts = Param.validate_opts!(:path, opts)

--- a/lib/tesla/open_api/path_params.ex
+++ b/lib/tesla/open_api/path_params.ex
@@ -1,24 +1,25 @@
 defmodule Tesla.OpenAPI.PathParams do
   @moduledoc """
-  Precompiled path parameter definitions for `Tesla.Middleware.PathParams`.
+  A collection of path parameter definitions for `Tesla.Middleware.PathParams`.
 
   `Tesla.OpenAPI.PathParams` keeps static path parameter metadata separate from
-  per-request values. Generated clients can build it once, store it in request
-  private data, and pass only the dynamic values through `opts[:path_params]`.
+  per-request values. Since path parameter definitions usually come from a
+  static operation specification, prefer defining the collection in a module
+  attribute, storing it in request private data, and passing only the dynamic
+  values through `opts[:path_params]`.
 
       alias Tesla.OpenAPI.{PathParam, PathParams}
 
-      path_params =
-        PathParams.new!([
-          PathParam.new!("id"),
-          PathParam.new!("coords", style: :matrix, explode: true)
-        ])
+      @path_params PathParams.new!([
+                     PathParam.new!("id"),
+                     PathParam.new!("coords", style: :matrix, explode: true)
+                   ])
 
-      private = PathParams.put_private(path_params)
+      @private PathParams.put_private(@path_params)
 
       Tesla.get(client, "/items/{id}{coords}",
         opts: [path_params: %{"id" => 5, "coords" => ["blue", "black"]}],
-        private: private
+        private: @private
       )
   """
 
@@ -47,12 +48,12 @@ defmodule Tesla.OpenAPI.PathParams do
   @doc """
   Adds path parameter definitions to Tesla request private data.
 
-      path_params = Tesla.OpenAPI.PathParams.new!([Tesla.OpenAPI.PathParam.new!("id")])
-      private = Tesla.OpenAPI.PathParams.put_private(path_params)
+      @path_params Tesla.OpenAPI.PathParams.new!([Tesla.OpenAPI.PathParam.new!("id")])
+      @private Tesla.OpenAPI.PathParams.put_private(@path_params)
 
       Tesla.get(client, "/items/{id}",
         opts: [path_params: %{"id" => 42}],
-        private: private
+        private: @private
       )
   """
   @spec put_private(t()) :: Tesla.Env.private()

--- a/lib/tesla/open_api/path_params.ex
+++ b/lib/tesla/open_api/path_params.ex
@@ -8,19 +8,23 @@ defmodule Tesla.OpenAPI.PathParams do
   attribute, storing it in request private data, and passing only the dynamic
   values through `opts[:path_params]`.
 
-      alias Tesla.OpenAPI.{PathParam, PathParams}
+      defmodule MyApi.Operation.GetItem do
+        alias Tesla.OpenAPI.{PathParam, PathParams}
 
-      @path_params PathParams.new!([
-                     PathParam.new!("id"),
-                     PathParam.new!("coords", style: :matrix, explode: true)
-                   ])
+        @path_params PathParams.new!([
+                       PathParam.new!("id"),
+                       PathParam.new!("coords", style: :matrix, explode: true)
+                     ])
 
-      @private PathParams.put_private(@path_params)
+        @private PathParams.put_private(@path_params)
 
-      Tesla.get(client, "/items/{id}{coords}",
-        opts: [path_params: %{"id" => 5, "coords" => ["blue", "black"]}],
-        private: @private
-      )
+        def request(client) do
+          Tesla.get(client, "/items/{id}{coords}",
+            opts: [path_params: %{"id" => 5, "coords" => ["blue", "black"]}],
+            private: @private
+          )
+        end
+      end
   """
 
   alias Tesla.OpenAPI.PathParam
@@ -48,13 +52,17 @@ defmodule Tesla.OpenAPI.PathParams do
   @doc """
   Adds path parameter definitions to Tesla request private data.
 
-      @path_params Tesla.OpenAPI.PathParams.new!([Tesla.OpenAPI.PathParam.new!("id")])
-      @private Tesla.OpenAPI.PathParams.put_private(@path_params)
+      defmodule MyApi.Operation.GetItem do
+        @path_params Tesla.OpenAPI.PathParams.new!([Tesla.OpenAPI.PathParam.new!("id")])
+        @private Tesla.OpenAPI.PathParams.put_private(@path_params)
 
-      Tesla.get(client, "/items/{id}",
-        opts: [path_params: %{"id" => 42}],
-        private: @private
-      )
+        def request(client) do
+          Tesla.get(client, "/items/{id}",
+            opts: [path_params: %{"id" => 42}],
+            private: @private
+          )
+        end
+      end
   """
   @spec put_private(t()) :: Tesla.Env.private()
   def put_private(%__MODULE__{} = path_params) do

--- a/lib/tesla/open_api/query_param.ex
+++ b/lib/tesla/open_api/query_param.ex
@@ -4,8 +4,7 @@ defmodule Tesla.OpenAPI.QueryParam do
 
   `Tesla.OpenAPI.QueryParam` is a value object for query parameter metadata
   whose serialization needs to be controlled explicitly. Its serialization
-  options follow the OpenAPI query parameter style semantics, while keeping the
-  public API focused on the query use case.
+  options follow the OpenAPI query parameter style semantics.
 
   In `Tesla.Middleware.Query` `:modern` mode, define query parameters once and
   pass them through request private data with `Tesla.OpenAPI.QueryParams`:

--- a/lib/tesla/open_api/query_param.ex
+++ b/lib/tesla/open_api/query_param.ex
@@ -95,7 +95,12 @@ defmodule Tesla.OpenAPI.QueryParam do
       and `false` for all other styles.
     * `:allow_reserved` - boolean. Defaults to `false`.
   """
-  @spec new!(String.t(), keyword()) :: t()
+  @spec new!(
+          String.t(),
+          style: style(),
+          explode: boolean(),
+          allow_reserved: boolean()
+        ) :: t()
   def new!(name, opts \\ []) do
     name = Param.validate_name!(:query, name)
     opts = Param.validate_opts!(:query, opts)

--- a/lib/tesla/open_api/query_param.ex
+++ b/lib/tesla/open_api/query_param.ex
@@ -28,17 +28,6 @@ defmodule Tesla.OpenAPI.QueryParam do
         QueryParam.new!("ids", style: :pipe_delimited)
       ])
 
-  ## Options
-
-  `new!/2` accepts a keyword list using Elixir atoms for hand-written Tesla
-  code:
-
-    * `:style` - one of `:form`, `:space_delimited`, `:pipe_delimited`, or
-      `:deep_object`. Defaults to `:form`.
-    * `:explode` - boolean. Defaults to `true` when the style is `:form`,
-      and `false` for all other styles.
-    * `:allow_reserved` - boolean. Defaults to `false`.
-
   [oas-style]: https://spec.openapis.org/oas/latest.html#style-values
 
   ## Encoding
@@ -95,6 +84,17 @@ defmodule Tesla.OpenAPI.QueryParam do
   @styles [:form, :space_delimited, :pipe_delimited, :deep_object]
   @expected_styles ":form, :space_delimited, :pipe_delimited, or :deep_object"
 
+  @doc """
+  Creates a query parameter definition.
+
+  Options use Elixir atoms for hand-written Tesla code:
+
+    * `:style` - one of `:form`, `:space_delimited`, `:pipe_delimited`, or
+      `:deep_object`. Defaults to `:form`.
+    * `:explode` - boolean. Defaults to `true` when the style is `:form`,
+      and `false` for all other styles.
+    * `:allow_reserved` - boolean. Defaults to `false`.
+  """
   @spec new!(String.t(), keyword()) :: t()
   def new!(name, opts \\ []) do
     name = Param.validate_name!(:query, name)

--- a/lib/tesla/open_api/query_param.ex
+++ b/lib/tesla/open_api/query_param.ex
@@ -2,10 +2,10 @@ defmodule Tesla.OpenAPI.QueryParam do
   @moduledoc """
   A query parameter definition with explicit serialization settings.
 
-  `Tesla.OpenAPI.QueryParam` is a Tesla-native value object for query parameter
-  metadata whose serialization needs to be controlled explicitly. Its
-  serialization options follow the OpenAPI query parameter style semantics,
-  while keeping the public API focused on the query use case.
+  `Tesla.OpenAPI.QueryParam` is a value object for query parameter metadata
+  whose serialization needs to be controlled explicitly. Its serialization
+  options follow the OpenAPI query parameter style semantics, while keeping the
+  public API focused on the query use case.
 
   In `Tesla.Middleware.Query` `:modern` mode, define query parameters once and
   pass them through request private data with `Tesla.OpenAPI.QueryParams`:

--- a/lib/tesla/open_api/query_params.ex
+++ b/lib/tesla/open_api/query_params.ex
@@ -8,23 +8,27 @@ defmodule Tesla.OpenAPI.QueryParams do
   attribute, storing it in request private data, and passing only dynamic values
   through `env.query`.
 
-      alias Tesla.OpenAPI.{QueryParam, QueryParams}
+      defmodule MyApi.Operation.ListItems do
+        alias Tesla.OpenAPI.{QueryParam, QueryParams}
 
-      @query_params QueryParams.new!([
-                      QueryParam.new!("filter"),
-                      QueryParam.new!("ids", style: :pipe_delimited)
-                    ])
+        @query_params QueryParams.new!([
+                        QueryParam.new!("filter"),
+                        QueryParam.new!("ids", style: :pipe_delimited)
+                      ])
 
-      @private QueryParams.put_private(@query_params)
+        @private QueryParams.put_private(@query_params)
 
-      Tesla.get(client, "/items",
-        query: %{
-          "filter" => [status: "open", owner: "yordis"],
-          "ids" => [10, 20],
-          "debug" => true
-        },
-        private: @private
-      )
+        def request(client) do
+          Tesla.get(client, "/items",
+            query: %{
+              "filter" => [status: "open", owner: "yordis"],
+              "ids" => [10, 20],
+              "debug" => true
+            },
+            private: @private
+          )
+        end
+      end
   """
 
   alias Tesla.OpenAPI.QueryParam
@@ -47,13 +51,17 @@ defmodule Tesla.OpenAPI.QueryParams do
   @doc """
   Adds query parameter definitions to Tesla request private data.
 
-      @query_params Tesla.OpenAPI.QueryParams.new!([Tesla.OpenAPI.QueryParam.new!("page")])
-      @private Tesla.OpenAPI.QueryParams.put_private(@query_params)
+      defmodule MyApi.Operation.ListItems do
+        @query_params Tesla.OpenAPI.QueryParams.new!([Tesla.OpenAPI.QueryParam.new!("page")])
+        @private Tesla.OpenAPI.QueryParams.put_private(@query_params)
 
-      Tesla.get(client, "/items",
-        query: %{"page" => 2},
-        private: @private
-      )
+        def request(client) do
+          Tesla.get(client, "/items",
+            query: %{"page" => 2},
+            private: @private
+          )
+        end
+      end
   """
   @spec put_private(t()) :: Tesla.Env.private()
   def put_private(%__MODULE__{} = query_params) do

--- a/lib/tesla/open_api/query_params.ex
+++ b/lib/tesla/open_api/query_params.ex
@@ -1,20 +1,21 @@
 defmodule Tesla.OpenAPI.QueryParams do
   @moduledoc """
-  Precompiled query parameter definitions for `Tesla.Middleware.Query`.
+  A collection of query parameter definitions for `Tesla.Middleware.Query`.
 
   `Tesla.OpenAPI.QueryParams` keeps static query parameter metadata separate from
-  per-request values. Generated clients can build it once, store it in request
-  private data, and pass only dynamic values through `env.query`.
+  per-request values. Since query parameter definitions usually come from a
+  static operation specification, prefer defining the collection in a module
+  attribute, storing it in request private data, and passing only dynamic values
+  through `env.query`.
 
       alias Tesla.OpenAPI.{QueryParam, QueryParams}
 
-      query_params =
-        QueryParams.new!([
-          QueryParam.new!("filter"),
-          QueryParam.new!("ids", style: :pipe_delimited)
-        ])
+      @query_params QueryParams.new!([
+                      QueryParam.new!("filter"),
+                      QueryParam.new!("ids", style: :pipe_delimited)
+                    ])
 
-      private = QueryParams.put_private(query_params)
+      @private QueryParams.put_private(@query_params)
 
       Tesla.get(client, "/items",
         query: %{
@@ -22,7 +23,7 @@ defmodule Tesla.OpenAPI.QueryParams do
           "ids" => [10, 20],
           "debug" => true
         },
-        private: private
+        private: @private
       )
   """
 
@@ -46,12 +47,12 @@ defmodule Tesla.OpenAPI.QueryParams do
   @doc """
   Adds query parameter definitions to Tesla request private data.
 
-      query_params = Tesla.OpenAPI.QueryParams.new!([Tesla.OpenAPI.QueryParam.new!("page")])
-      private = Tesla.OpenAPI.QueryParams.put_private(query_params)
+      @query_params Tesla.OpenAPI.QueryParams.new!([Tesla.OpenAPI.QueryParam.new!("page")])
+      @private Tesla.OpenAPI.QueryParams.put_private(@query_params)
 
       Tesla.get(client, "/items",
         query: %{"page" => 2},
-        private: private
+        private: @private
       )
   """
   @spec put_private(t()) :: Tesla.Env.private()

--- a/lib/tesla/open_api/query_string.ex
+++ b/lib/tesla/open_api/query_string.ex
@@ -2,8 +2,8 @@ defmodule Tesla.OpenAPI.QueryString do
   @moduledoc """
   A whole URL query string with explicit serialization.
 
-  `Tesla.OpenAPI.QueryString` is a Tesla-native value object for requests where the
-  entire query string is serialized as one value. It is useful for OpenAPI 3.2
+  `Tesla.OpenAPI.QueryString` is a value object for requests where the entire
+  query string is serialized as one value. It is useful for OpenAPI 3.2
   [`in: "querystring"` parameters][oas-parameter-locations], where the query
   string is content-based and does not behave like a normal named query
   parameter.


### PR DESCRIPTION
- OpenAPI module docs should use plain wording that does not imply a separate Tesla-specific abstraction model.