### PR TITLE
chore(openapi): hide query string error fields

### DIFF
--- a/guides/explanations/4.openapi.md
+++ b/guides/explanations/4.openapi.md
@@ -64,7 +64,7 @@ end
 Use `Tesla.OpenAPI.QueryString.raw!/2` when the OpenAPI media type already produced the
 exact query string. Do not send `Tesla.OpenAPI.QueryString` through
 `Tesla.Middleware.Query` as a normal query map in `:modern` mode, which expects
-request values backed by `Tesla.OpenAPI.QueryParams` private data.
+request values backed by `Tesla.OpenAPI.QueryParams` in `t:Tesla.Env.private/0`.
 
 ## Mapping OpenAPI fields
 

--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -228,7 +228,7 @@ end
 ## Build the operation module
 
 Now assemble the nested modules into the generated operation. Static path
-metadata and request private data stay on the operation module with
+metadata and `t:Tesla.Env.private/0` data stay on the operation module with
 `Tesla.OpenAPI.PathTemplate`, `Tesla.OpenAPI.PathParam`, and `Tesla.OpenAPI.PathParams`:
 
 ```elixir
@@ -313,9 +313,9 @@ end
 ## Build the client stack
 
 Use `Tesla.Middleware.PathParams` in `:modern` mode when generated operations
-pass `Tesla.OpenAPI.PathParams` through request private data. Use
+pass `Tesla.OpenAPI.PathParams` through `t:Tesla.Env.private/0`. Use
 `Tesla.Middleware.Query` in `:modern` mode when generated operations pass
-`Tesla.OpenAPI.QueryParams` through request private data:
+`Tesla.OpenAPI.QueryParams` through `t:Tesla.Env.private/0`:
 
 ```elixir
 defmodule MyApi.Client do

--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -1,26 +1,6 @@
 defmodule Tesla.Env do
   @moduledoc """
   This module defines a `t:Tesla.Env.t/0` struct that stores all data related to request/response.
-
-  ## Fields
-
-  - `:method` - method of request. Example: `:get`
-  - `:url` - request url. Example: `"https://www.google.com"`
-  - `:query` - structured query params. See `t:query/0`.
-    Note: query params passed in url (e.g. `"/get?param=value"`) are not parsed to `query` field.
-  - `:headers` - list of request/response headers.
-    Example: `[{"content-type", "application/json"}]`.
-    Note: request headers are overridden by response headers when adapter is called.
-  - `:body` - request/response body.
-    Note: request body is overridden by response body when adapter is called.
-  - `:status` - response status. Example: `200`
-  - `:opts` - list of options. Example: `[adapter: [recv_timeout: 30_000]]`
-  - `:assigns` - a place for user data as a map. It can be used to carry application-specific
-    metadata through the middleware pipeline.
-
-  - `:private` - a map reserved for libraries and middleware to use. The keys must be atoms.
-    Prefix the keys with the name of your project to avoid any future conflicts. The `tesla_`
-    prefix is reserved for Tesla.
   """
 
   @type client :: Tesla.Client.t()
@@ -78,6 +58,28 @@ defmodule Tesla.Env do
   @type assigns :: %{optional(atom) => any}
   @type private :: %{optional(atom) => any}
 
+  @typedoc """
+  Request/response state carried through the middleware pipeline.
+
+  ## Fields
+
+    * `:method` - method of request. Example: `:get`.
+    * `:url` - request URL. Example: `"https://www.google.com"`.
+    * `:query` - structured query params. See `t:query/0`.
+      Query params passed in the URL, such as `"/get?param=value"`, are not
+      parsed to the `:query` field.
+    * `:headers` - list of request/response headers.
+      Example: `[{"content-type", "application/json"}]`.
+      Request headers are overridden by response headers when the adapter is called.
+    * `:body` - request/response body.
+      Request body is overridden by response body when the adapter is called.
+    * `:status` - response status. Example: `200`.
+    * `:opts` - list of options. Example: `[adapter: [recv_timeout: 30_000]]`.
+    * `:assigns` - user data as a map for application-specific metadata.
+    * `:private` - data reserved for libraries and middleware. Keys must be
+      atoms. Prefix keys with the name of your project to avoid conflicts.
+      The `tesla_` prefix is reserved for Tesla.
+  """
   @type t :: %__MODULE__{
           method: method,
           query: query,

--- a/lib/tesla/open_api.ex
+++ b/lib/tesla/open_api.ex
@@ -33,7 +33,7 @@ defmodule Tesla.OpenAPI do
                  ])
       end
 
-  Path and query parameter collections are placed in request private data
+  Path and query parameter collections are placed in `t:Tesla.Env.private/0`
   because their middleware serializes them into the request URL. Header and
   cookie parameter collections are applied before the request enters the
   middleware stack and produce raw header tuples.
@@ -51,7 +51,7 @@ defmodule Tesla.OpenAPI do
   """
 
   @doc """
-  Merges request private data maps from left to right.
+  Merges `t:Tesla.Env.private/0` maps from left to right.
   """
   @spec merge_private([Tesla.Env.private()]) :: Tesla.Env.private()
   def merge_private(privates) when is_list(privates) do

--- a/lib/tesla/open_api/path_param.ex
+++ b/lib/tesla/open_api/path_param.ex
@@ -7,7 +7,7 @@ defmodule Tesla.OpenAPI.PathParam do
   follow the OpenAPI path parameter style semantics.
 
   In `Tesla.Middleware.PathParams` `:modern` mode, define path parameters once
-  and pass them through request private data with `Tesla.OpenAPI.PathParams`:
+  and pass them through `t:Tesla.Env.private/0` with `Tesla.OpenAPI.PathParams`:
 
       path_params = Tesla.OpenAPI.PathParams.new!([PathParam.new!("id")])
       private = Tesla.OpenAPI.PathParams.put_private(path_params)

--- a/lib/tesla/open_api/path_params.ex
+++ b/lib/tesla/open_api/path_params.ex
@@ -5,7 +5,7 @@ defmodule Tesla.OpenAPI.PathParams do
   `Tesla.OpenAPI.PathParams` keeps static path parameter metadata separate from
   per-request values. Since path parameter definitions usually come from a
   static operation specification, prefer defining the collection in a module
-  attribute, storing it in request private data, and passing only the dynamic
+  attribute, storing it in `t:Tesla.Env.private/0`, and passing only the dynamic
   values through `opts[:path_params]`.
 
       defmodule MyApi.Operation.GetItem do
@@ -50,7 +50,7 @@ defmodule Tesla.OpenAPI.PathParams do
   end
 
   @doc """
-  Adds path parameter definitions to Tesla request private data.
+  Adds path parameter definitions to `t:Tesla.Env.private/0`.
 
       defmodule MyApi.Operation.GetItem do
         @path_params Tesla.OpenAPI.PathParams.new!([Tesla.OpenAPI.PathParam.new!("id")])

--- a/lib/tesla/open_api/path_template.ex
+++ b/lib/tesla/open_api/path_template.ex
@@ -53,7 +53,7 @@ defmodule Tesla.OpenAPI.PathTemplate do
   end
 
   @doc """
-  Adds the compiled path template to Tesla request private data.
+  Adds the compiled path template to `t:Tesla.Env.private/0`.
 
       template = Tesla.OpenAPI.PathTemplate.new!("/items/{id}")
       path_params = Tesla.OpenAPI.PathParams.new!([Tesla.OpenAPI.PathParam.new!("id")])

--- a/lib/tesla/open_api/query_param.ex
+++ b/lib/tesla/open_api/query_param.ex
@@ -7,7 +7,7 @@ defmodule Tesla.OpenAPI.QueryParam do
   options follow the OpenAPI query parameter style semantics.
 
   In `Tesla.Middleware.Query` `:modern` mode, define query parameters once and
-  pass them through request private data with `Tesla.OpenAPI.QueryParams`:
+  pass them through `t:Tesla.Env.private/0` with `Tesla.OpenAPI.QueryParams`:
 
       alias Tesla.OpenAPI.{QueryParam, QueryParams}
 

--- a/lib/tesla/open_api/query_params.ex
+++ b/lib/tesla/open_api/query_params.ex
@@ -5,7 +5,7 @@ defmodule Tesla.OpenAPI.QueryParams do
   `Tesla.OpenAPI.QueryParams` keeps static query parameter metadata separate from
   per-request values. Since query parameter definitions usually come from a
   static operation specification, prefer defining the collection in a module
-  attribute, storing it in request private data, and passing only dynamic values
+  attribute, storing it in `t:Tesla.Env.private/0`, and passing only dynamic values
   through `env.query`.
 
       defmodule MyApi.Operation.ListItems do
@@ -49,7 +49,7 @@ defmodule Tesla.OpenAPI.QueryParams do
   end
 
   @doc """
-  Adds query parameter definitions to Tesla request private data.
+  Adds query parameter definitions to `t:Tesla.Env.private/0`.
 
       defmodule MyApi.Operation.ListItems do
         @query_params Tesla.OpenAPI.QueryParams.new!([Tesla.OpenAPI.QueryParam.new!("page")])

--- a/lib/tesla/open_api/query_string_error.ex
+++ b/lib/tesla/open_api/query_string_error.ex
@@ -13,13 +13,9 @@ defmodule Tesla.OpenAPI.QueryStringError do
           | :invalid_query_string
           | :leading_query_delimiter
           | :mixed_query_params
-  @type t :: %__MODULE__{
-          reason: reason(),
-          query: term(),
-          value: term(),
-          details: String.t() | nil,
-          url: String.t() | nil
-        }
+  @opaque t :: %__MODULE__{
+            reason: reason()
+          }
 
   def message(%__MODULE__{reason: :existing_query_string} = _value) do
     "cannot append #{inspect(Tesla.OpenAPI.QueryString)} to a URL that already contains a query string"


### PR DESCRIPTION
- Query string errors should expose stable categorization without making diagnostic payload fields part of the public contract.