### PR TITLE
chore(mock): mark module deprecated

### DIFF
--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -2,6 +2,10 @@ defmodule Tesla.Mock do
   @moduledoc """
   Mock adapter for better testing.
 
+  > #### Deprecated {: .warning}
+  >
+  > Use a Mox adapter with `Tesla.Test` helpers for new tests.
+
   ## Setup
 
   ```elixir
@@ -102,6 +106,7 @@ defmodule Tesla.Mock do
   **WARNING**: Using global mocks may affect tests with local mock
   (because of fallback to global mock in case local one is not found)
   """
+  @moduledoc deprecated: "Use Mox with Tesla.Test instead"
 
   defmodule Error do
     defexception env: nil, ex: nil, stacktrace: []


### PR DESCRIPTION
- The testing docs already steer users toward Mox, so the legacy mock adapter should carry the same signal in API docs.
- New tests should use the supported helper surface without extending the legacy module contract.