### PR TITLE
feat(openapi): add response wrapper macro

### DIFF
--- a/guides/cheatsheets/openapi.cheatmd
+++ b/guides/cheatsheets/openapi.cheatmd
@@ -22,6 +22,14 @@ client =
   ])
 ```
 
+## Response Wrapper
+
+```elixir
+defmodule MyApi.Response do
+  use Tesla.OpenAPI.Response
+end
+```
+
 ## Generated Operation Metadata
 
 ```elixir

--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -196,32 +196,7 @@ body returned by each operation:
 
 ```elixir
 defmodule MyApi.Response do
-  @moduledoc """
-  HTTP response wrapper with status, headers, and typed body.
-
-  The `ok` field is `true` for 2xx status codes (200-299).
-  """
-
-  @type headers() :: [{String.t(), String.t()}]
-
-  @type t(body_type, header_type) :: %__MODULE__{
-          status: integer(),
-          ok: boolean(),
-          headers: header_type,
-          body: body_type
-        }
-
-  defstruct status: nil, ok: nil, headers: nil, body: nil
-
-  @doc false
-  def new(%Tesla.Env{} = env, body) do
-    %__MODULE__{
-      status: env.status,
-      ok: env.status >= 200 and env.status <= 299,
-      headers: env.headers,
-      body: body
-    }
-  end
+  use Tesla.OpenAPI.Response
 end
 ```
 
@@ -254,7 +229,9 @@ defmodule MyApi.Operation.GetItem do
   @type resp_body_200() :: MyApi.Schemas.GetItemResponse.t()
   @type resp_header_200() :: Response.headers()
   @type resp_200() :: Response.t(resp_body_200(), resp_header_200())
-  @type result() :: {:ok, resp_200()} | {:error, term()}
+  @type resp_401() :: Response.t(nil, Response.headers())
+  @type resp_404() :: Response.t(nil, Response.headers())
+  @type result() :: {:ok, resp_200() | resp_401() | resp_404()} | {:error, term()}
 
   @path_template PathTemplate.new!("/items/{id}{coords}")
 
@@ -299,6 +276,9 @@ defmodule MyApi.Operation.GetItem do
     case Tesla.request(client.client, request_opts) do
       {:ok, %Tesla.Env{status: 200} = env} ->
         {:ok, Response.new(env, MyApi.Schemas.GetItemResponse.new(env.body))}
+
+      {:ok, %Tesla.Env{status: status} = env} when status in [401, 404] ->
+        {:ok, Response.new(env, nil)}
 
       {:ok, env} ->
         {:ok, Response.new(env, env.body)}

--- a/lib/tesla/open_api.ex
+++ b/lib/tesla/open_api.ex
@@ -38,6 +38,15 @@ defmodule Tesla.OpenAPI do
   cookie parameter collections are applied before the request enters the
   middleware stack and produce raw header tuples.
 
+  ## Response Wrappers
+
+  Generated clients can define a local response module with
+  `Tesla.OpenAPI.Response`:
+
+      defmodule MyApi.Response do
+        use Tesla.OpenAPI.Response
+      end
+
   ## Field Mapping
 
   `in` chooses the Tesla API. It is not passed as an option to the value

--- a/lib/tesla/open_api/response.ex
+++ b/lib/tesla/open_api/response.ex
@@ -1,0 +1,54 @@
+defmodule Tesla.OpenAPI.Response do
+  @moduledoc """
+  Macro for defining generated-client response wrappers.
+
+  Generated clients own their response module and can use this macro to get a
+  small wrapper around `t:Tesla.Env.t/0`:
+
+      defmodule MyApi.Response do
+        use Tesla.OpenAPI.Response
+      end
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      @moduledoc """
+      HTTP response wrapper with status, headers, and typed body.
+
+      The `ok` field is `true` for 2xx status codes (200-299).
+      """
+
+      @type headers() :: [{String.t(), String.t()}]
+
+      @typedoc """
+      HTTP response wrapper with status, headers, and typed body.
+
+      ## Fields
+
+        * `:status` - response status.
+        * `:ok` - `true` for 2xx status codes (200-299).
+        * `:headers` - response headers.
+        * `:body` - typed response body.
+      """
+      @type t(body_type, header_type) :: %__MODULE__{
+              status: integer(),
+              ok: boolean(),
+              headers: header_type,
+              body: body_type
+            }
+
+      defstruct status: nil, ok: nil, headers: nil, body: nil
+
+      @doc false
+      @spec new(Tesla.Env.t(), body_type) :: t(body_type, headers()) when body_type: term()
+      def new(%Tesla.Env{} = env, body) do
+        %__MODULE__{
+          status: env.status,
+          ok: env.status >= 200 and env.status <= 299,
+          headers: env.headers,
+          body: body
+        }
+      end
+    end
+  end
+end

--- a/lib/tesla/open_api/response.ex
+++ b/lib/tesla/open_api/response.ex
@@ -15,7 +15,8 @@ defmodule Tesla.OpenAPI.Response do
       @moduledoc """
       HTTP response wrapper with status, headers, and typed body.
 
-      The `ok` field is `true` for 2xx status codes (200-299).
+      The `ok` field is `true` for 2xx status codes (200-299), `false` for
+      other status codes, and `nil` when the status is not set.
       """
 
       @type headers() :: Tesla.Env.headers()
@@ -26,13 +27,14 @@ defmodule Tesla.OpenAPI.Response do
       ## Fields
 
         * `:status` - response status.
-        * `:ok` - `true` for 2xx status codes (200-299).
+        * `:ok` - `true` for 2xx status codes (200-299), `false` for other
+          status codes, or `nil` when the status is not set.
         * `:headers` - response headers.
         * `:body` - typed response body.
       """
       @type t(body_type, header_type) :: %__MODULE__{
-              status: integer(),
-              ok: boolean(),
+              status: Tesla.Env.status(),
+              ok: boolean() | nil,
               headers: header_type,
               body: body_type
             }
@@ -41,6 +43,15 @@ defmodule Tesla.OpenAPI.Response do
 
       @doc false
       @spec new(Tesla.Env.t(), body_type) :: t(body_type, headers()) when body_type: term()
+      def new(%Tesla.Env{status: nil} = env, body) do
+        %__MODULE__{
+          status: env.status,
+          ok: nil,
+          headers: env.headers,
+          body: body
+        }
+      end
+
       def new(%Tesla.Env{} = env, body) do
         %__MODULE__{
           status: env.status,

--- a/lib/tesla/open_api/response.ex
+++ b/lib/tesla/open_api/response.ex
@@ -18,7 +18,7 @@ defmodule Tesla.OpenAPI.Response do
       The `ok` field is `true` for 2xx status codes (200-299).
       """
 
-      @type headers() :: [{String.t(), String.t()}]
+      @type headers() :: Tesla.Env.headers()
 
       @typedoc """
       HTTP response wrapper with status, headers, and typed body.

--- a/mix.exs
+++ b/mix.exs
@@ -133,7 +133,8 @@ defmodule Tesla.Mixfile do
           Tesla.OpenAPI.QueryParam,
           Tesla.OpenAPI.QueryParams,
           Tesla.OpenAPI.QueryString,
-          Tesla.OpenAPI.QueryStringError
+          Tesla.OpenAPI.QueryStringError,
+          Tesla.OpenAPI.Response
         ],
         Adapters: [~r/Tesla.Adapter./],
         Middlewares: [~r/Tesla.Middleware./],

--- a/test/tesla/open_api/response_test.exs
+++ b/test/tesla/open_api/response_test.exs
@@ -42,4 +42,8 @@ defmodule Tesla.OpenAPI.ResponseTest do
     assert %Response{ok: true} = Response.new(%Tesla.Env{status: 299}, nil)
     assert %Response{ok: false} = Response.new(%Tesla.Env{status: 300}, nil)
   end
+
+  test "new/2 keeps ok unset when status is unset" do
+    assert %Response{status: nil, ok: nil} = Response.new(%Tesla.Env{}, nil)
+  end
 end

--- a/test/tesla/open_api/response_test.exs
+++ b/test/tesla/open_api/response_test.exs
@@ -1,0 +1,45 @@
+defmodule Tesla.OpenAPI.ResponseTest do
+  use ExUnit.Case, async: true
+
+  defmodule Response do
+    use Tesla.OpenAPI.Response
+  end
+
+  test "new/2 wraps typed response body" do
+    env = %Tesla.Env{
+      status: 200,
+      headers: [{"content-type", "application/json"}]
+    }
+
+    assert Response.new(env, %{id: 42}) == %Response{
+             status: 200,
+             ok: true,
+             headers: [{"content-type", "application/json"}],
+             body: %{id: 42}
+           }
+  end
+
+  test "new/2 marks non-2xx responses as not ok" do
+    env = %Tesla.Env{
+      status: 404,
+      headers: [{"content-type", "application/json"}]
+    }
+
+    assert Response.new(env, %{error: "not_found"}) == %Response{
+             status: 404,
+             ok: false,
+             headers: [{"content-type", "application/json"}],
+             body: %{error: "not_found"}
+           }
+  end
+
+  test "new/2 keeps the operation-selected response body" do
+    assert %Response{status: 404, ok: false, body: nil} =
+             Response.new(%Tesla.Env{status: 404}, nil)
+  end
+
+  test "new/2 treats 299 as ok and 300 as not ok" do
+    assert %Response{ok: true} = Response.new(%Tesla.Env{status: 299}, nil)
+    assert %Response{ok: false} = Response.new(%Tesla.Env{status: 300}, nil)
+  end
+end


### PR DESCRIPTION
- Generated OpenAPI clients need a local typed response wrapper without copying the same boilerplate into every client.
- Response ownership should stay with the generated client while Tesla provides the common Env wrapping behavior.