### PR TITLE
chore(openapi): clarify generated metadata ownership

### DIFF
--- a/guides/cheatsheets/openapi.cheatmd
+++ b/guides/cheatsheets/openapi.cheatmd
@@ -34,13 +34,16 @@ end
 
 ```elixir
 defmodule MyApi.Operation.GetItem.Path do
-  alias Tesla.OpenAPI.{PathParam, PathParams}
+  alias Tesla.OpenAPI.{PathParam, PathParams, PathTemplate}
+
+  @path_template PathTemplate.new!("/items/{id}{coords}")
 
   @path_params PathParams.new!([
                  PathParam.new!("id"),
                  PathParam.new!("coords", style: :matrix, explode: true)
                ])
 
+  def path_template, do: @path_template
   def path_params, do: @path_params
 end
 
@@ -60,10 +63,8 @@ defmodule MyApi.Operation.GetItem do
   alias Tesla.OpenAPI
   alias Tesla.OpenAPI.{PathParams, PathTemplate, QueryParams}
 
-  @path_template PathTemplate.new!("/items/{id}{coords}")
-
   @private OpenAPI.merge_private([
-             PathTemplate.put_private(@path_template),
+             PathTemplate.put_private(Path.path_template()),
              PathParams.put_private(Path.path_params()),
              QueryParams.put_private(Query.query_params())
            ])
@@ -78,16 +79,14 @@ defmodule MyApi.Operation.GetItem do
   alias Tesla.OpenAPI
   alias Tesla.OpenAPI.{PathParams, PathTemplate, QueryParams}
 
-  @path_template PathTemplate.new!("/items/{id}{coords}")
-
   @private OpenAPI.merge_private([
-             PathTemplate.put_private(@path_template),
+             PathTemplate.put_private(Path.path_template()),
              PathParams.put_private(Path.path_params()),
              QueryParams.put_private(Query.query_params())
            ])
 
   def request(client) do
-    Tesla.get(client, @path_template.path,
+    Tesla.get(client, Path.path_template().path,
       query: %{
         "color" => ["blue", "black"],
         "filter" => [role: "admin"],

--- a/guides/cheatsheets/openapi.cheatmd
+++ b/guides/cheatsheets/openapi.cheatmd
@@ -63,6 +63,8 @@ defmodule MyApi.Operation.GetItem do
   alias Tesla.OpenAPI
   alias Tesla.OpenAPI.{PathParams, PathTemplate, QueryParams}
 
+  @request_path Path.path_template().path
+
   @private OpenAPI.merge_private([
              PathTemplate.put_private(Path.path_template()),
              PathParams.put_private(Path.path_params()),
@@ -79,6 +81,8 @@ defmodule MyApi.Operation.GetItem do
   alias Tesla.OpenAPI
   alias Tesla.OpenAPI.{PathParams, PathTemplate, QueryParams}
 
+  @request_path Path.path_template().path
+
   @private OpenAPI.merge_private([
              PathTemplate.put_private(Path.path_template()),
              PathParams.put_private(Path.path_params()),
@@ -86,7 +90,7 @@ defmodule MyApi.Operation.GetItem do
            ])
 
   def request(client) do
-    Tesla.get(client, Path.path_template().path,
+    Tesla.get(client, @request_path,
       query: %{
         "color" => ["blue", "black"],
         "filter" => [role: "admin"],

--- a/guides/cheatsheets/openapi.cheatmd
+++ b/guides/cheatsheets/openapi.cheatmd
@@ -33,21 +33,36 @@ end
 ## Generated Operation Metadata
 
 ```elixir
+defmodule MyApi.Operation.GetItem.Path do
+  alias Tesla.OpenAPI.{PathParam, PathParams}
+
+  def path_params do
+    PathParams.new!([
+      PathParam.new!("id"),
+      PathParam.new!("coords", style: :matrix, explode: true)
+    ])
+  end
+end
+
+defmodule MyApi.Operation.GetItem.Query do
+  alias Tesla.OpenAPI.{QueryParam, QueryParams}
+
+  def query_params do
+    QueryParams.new!([
+      QueryParam.new!("color", style: :pipe_delimited),
+      QueryParam.new!("filter", style: :deep_object)
+    ])
+  end
+end
+
 defmodule MyApi.Operation.GetItem do
+  alias MyApi.Operation.GetItem.{Path, Query}
   alias Tesla.OpenAPI
-  alias Tesla.OpenAPI.{PathParam, PathParams, PathTemplate, QueryParam, QueryParams}
+  alias Tesla.OpenAPI.{PathParams, PathTemplate, QueryParams}
 
   @path_template PathTemplate.new!("/items/{id}{coords}")
-
-  @path_params PathParams.new!([
-                 PathParam.new!("id"),
-                 PathParam.new!("coords", style: :matrix, explode: true)
-               ])
-
-  @query_params QueryParams.new!([
-                  QueryParam.new!("color", style: :pipe_delimited),
-                  QueryParam.new!("filter", style: :deep_object)
-                ])
+  @path_params Path.path_params()
+  @query_params Query.query_params()
 
   @private OpenAPI.merge_private([
              PathTemplate.put_private(@path_template),
@@ -61,20 +76,13 @@ end
 
 ```elixir
 defmodule MyApi.Operation.GetItem do
+  alias MyApi.Operation.GetItem.{Path, Query}
   alias Tesla.OpenAPI
-  alias Tesla.OpenAPI.{PathParam, PathParams, PathTemplate, QueryParam, QueryParams}
+  alias Tesla.OpenAPI.{PathParams, PathTemplate, QueryParams}
 
   @path_template PathTemplate.new!("/items/{id}{coords}")
-
-  @path_params PathParams.new!([
-                 PathParam.new!("id"),
-                 PathParam.new!("coords", style: :matrix, explode: true)
-               ])
-
-  @query_params QueryParams.new!([
-                  QueryParam.new!("color", style: :pipe_delimited),
-                  QueryParam.new!("filter", style: :deep_object)
-                ])
+  @path_params Path.path_params()
+  @query_params Query.query_params()
 
   @private OpenAPI.merge_private([
              PathTemplate.put_private(@path_template),
@@ -104,16 +112,32 @@ end
 ## Headers And Cookies
 
 ```elixir
+defmodule MyApi.Operation.GetItem.Header do
+  alias Tesla.OpenAPI.{HeaderParam, HeaderParams}
+
+  def header_params do
+    HeaderParams.new!([
+      HeaderParam.new!("X-Request-ID")
+    ])
+  end
+end
+
+defmodule MyApi.Operation.GetItem.Cookie do
+  alias Tesla.OpenAPI.{CookieParam, CookieParams}
+
+  def cookie_params do
+    CookieParams.new!([
+      CookieParam.new!("session_id")
+    ])
+  end
+end
+
 defmodule MyApi.Operation.GetItem do
-  alias Tesla.OpenAPI.{CookieParam, CookieParams, HeaderParam, HeaderParams}
+  alias MyApi.Operation.GetItem.{Cookie, Header}
+  alias Tesla.OpenAPI.{CookieParams, HeaderParams}
 
-  @header_params HeaderParams.new!([
-                   HeaderParam.new!("X-Request-ID")
-                 ])
-
-  @cookie_params CookieParams.new!([
-                   CookieParam.new!("session_id")
-                 ])
+  @header_params Header.header_params()
+  @cookie_params Cookie.cookie_params()
 
   def headers do
     HeaderParams.to_headers(@header_params, %{"X-Request-ID" => "req-123"}) ++

--- a/guides/cheatsheets/openapi.cheatmd
+++ b/guides/cheatsheets/openapi.cheatmd
@@ -61,13 +61,11 @@ defmodule MyApi.Operation.GetItem do
   alias Tesla.OpenAPI.{PathParams, PathTemplate, QueryParams}
 
   @path_template PathTemplate.new!("/items/{id}{coords}")
-  @path_params Path.path_params()
-  @query_params Query.query_params()
 
   @private OpenAPI.merge_private([
              PathTemplate.put_private(@path_template),
-             PathParams.put_private(@path_params),
-             QueryParams.put_private(@query_params)
+             PathParams.put_private(Path.path_params()),
+             QueryParams.put_private(Query.query_params())
            ])
 end
 ```
@@ -81,13 +79,11 @@ defmodule MyApi.Operation.GetItem do
   alias Tesla.OpenAPI.{PathParams, PathTemplate, QueryParams}
 
   @path_template PathTemplate.new!("/items/{id}{coords}")
-  @path_params Path.path_params()
-  @query_params Query.query_params()
 
   @private OpenAPI.merge_private([
              PathTemplate.put_private(@path_template),
-             PathParams.put_private(@path_params),
-             QueryParams.put_private(@query_params)
+             PathParams.put_private(Path.path_params()),
+             QueryParams.put_private(Query.query_params())
            ])
 
   def request(client) do

--- a/guides/cheatsheets/openapi.cheatmd
+++ b/guides/cheatsheets/openapi.cheatmd
@@ -36,23 +36,23 @@ end
 defmodule MyApi.Operation.GetItem.Path do
   alias Tesla.OpenAPI.{PathParam, PathParams}
 
-  def path_params do
-    PathParams.new!([
-      PathParam.new!("id"),
-      PathParam.new!("coords", style: :matrix, explode: true)
-    ])
-  end
+  @path_params PathParams.new!([
+                 PathParam.new!("id"),
+                 PathParam.new!("coords", style: :matrix, explode: true)
+               ])
+
+  def path_params, do: @path_params
 end
 
 defmodule MyApi.Operation.GetItem.Query do
   alias Tesla.OpenAPI.{QueryParam, QueryParams}
 
-  def query_params do
-    QueryParams.new!([
-      QueryParam.new!("color", style: :pipe_delimited),
-      QueryParam.new!("filter", style: :deep_object)
-    ])
-  end
+  @query_params QueryParams.new!([
+                  QueryParam.new!("color", style: :pipe_delimited),
+                  QueryParam.new!("filter", style: :deep_object)
+                ])
+
+  def query_params, do: @query_params
 end
 
 defmodule MyApi.Operation.GetItem do
@@ -115,21 +115,21 @@ end
 defmodule MyApi.Operation.GetItem.Header do
   alias Tesla.OpenAPI.{HeaderParam, HeaderParams}
 
-  def header_params do
-    HeaderParams.new!([
-      HeaderParam.new!("X-Request-ID")
-    ])
-  end
+  @header_params HeaderParams.new!([
+                   HeaderParam.new!("X-Request-ID")
+                 ])
+
+  def header_params, do: @header_params
 end
 
 defmodule MyApi.Operation.GetItem.Cookie do
   alias Tesla.OpenAPI.{CookieParam, CookieParams}
 
-  def cookie_params do
-    CookieParams.new!([
-      CookieParam.new!("session_id")
-    ])
-  end
+  @cookie_params CookieParams.new!([
+                   CookieParam.new!("session_id")
+                 ])
+
+  def cookie_params, do: @cookie_params
 end
 
 defmodule MyApi.Operation.GetItem do

--- a/guides/cheatsheets/openapi.cheatmd
+++ b/guides/cheatsheets/openapi.cheatmd
@@ -63,7 +63,7 @@ defmodule MyApi.Operation.GetItem do
   alias Tesla.OpenAPI
   alias Tesla.OpenAPI.{PathParams, PathTemplate, QueryParams}
 
-  @request_path Path.path_template().path
+  @operation_path Path.path_template().path
 
   @private OpenAPI.merge_private([
              PathTemplate.put_private(Path.path_template()),
@@ -81,7 +81,7 @@ defmodule MyApi.Operation.GetItem do
   alias Tesla.OpenAPI
   alias Tesla.OpenAPI.{PathParams, PathTemplate, QueryParams}
 
-  @request_path Path.path_template().path
+  @operation_path Path.path_template().path
 
   @private OpenAPI.merge_private([
              PathTemplate.put_private(Path.path_template()),
@@ -90,7 +90,7 @@ defmodule MyApi.Operation.GetItem do
            ])
 
   def request(client) do
-    Tesla.get(client, @request_path,
+    Tesla.get(client, @operation_path,
       query: %{
         "color" => ["blue", "black"],
         "filter" => [role: "admin"],

--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -141,7 +141,8 @@ end
 `Tesla.OpenAPI.QueryParam` supports the OpenAPI query styles `:form`,
 `:space_delimited`, `:pipe_delimited`, and `:deep_object`. Omit optional query
 parameters from the returned map when they should not be sent. The operation
-module stores the result of `Query.query_params()` in a module attribute.
+module assigns `@query_params Query.query_params()` so the result is stored in
+a module attribute.
 
 Other top-level query params can share the same request query map and remain
 normal Tesla query params. This example keeps those values in a generated

--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -79,12 +79,12 @@ defmodule MyApi.Operation.GetItem.Path do
 
   defstruct [:id, :coords]
 
-  def path_params do
-    PathParams.new!([
-      PathParam.new!("id"),
-      PathParam.new!("coords", style: :matrix, explode: true)
-    ])
-  end
+  @path_params PathParams.new!([
+                 PathParam.new!("id"),
+                 PathParam.new!("coords", style: :matrix, explode: true)
+               ])
+
+  def path_params, do: @path_params
 
   def to_path_params(%__MODULE__{} = path) do
     %{
@@ -118,12 +118,12 @@ defmodule MyApi.Operation.GetItem.Query do
 
   defstruct color: nil, filter: nil, "$additional": %{}
 
-  def query_params do
-    QueryParams.new!([
-      QueryParam.new!("color", style: :pipe_delimited),
-      QueryParam.new!("filter", style: :deep_object)
-    ])
-  end
+  @query_params QueryParams.new!([
+                  QueryParam.new!("color", style: :pipe_delimited),
+                  QueryParam.new!("filter", style: :deep_object)
+                ])
+
+  def query_params, do: @query_params
 
   def to_query(nil), do: %{}
 
@@ -163,11 +163,11 @@ defmodule MyApi.Operation.GetItem.Header do
 
   defstruct [:request_id]
 
-  def header_params do
-    HeaderParams.new!([
-      HeaderParam.new!("X-Request-ID")
-    ])
-  end
+  @header_params HeaderParams.new!([
+                   HeaderParam.new!("X-Request-ID")
+                 ])
+
+  def header_params, do: @header_params
 
   def to_header_params(nil), do: %{}
 
@@ -196,11 +196,11 @@ defmodule MyApi.Operation.GetItem.Cookie do
 
   defstruct [:session_id]
 
-  def cookie_params do
-    CookieParams.new!([
-      CookieParam.new!("session_id")
-    ])
-  end
+  @cookie_params CookieParams.new!([
+                   CookieParam.new!("session_id")
+                 ])
+
+  def cookie_params, do: @cookie_params
 
   def to_cookie_params(nil), do: %{}
 

--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -70,7 +70,7 @@ in `:modern` mode:
 
 ```elixir
 defmodule MyApi.Operation.GetItem.Path do
-  alias Tesla.OpenAPI.{PathParam, PathParams}
+  alias Tesla.OpenAPI.{PathParam, PathParams, PathTemplate}
 
   @type t :: %__MODULE__{
           id: integer(),
@@ -79,11 +79,14 @@ defmodule MyApi.Operation.GetItem.Path do
 
   defstruct [:id, :coords]
 
+  @path_template PathTemplate.new!("/items/{id}{coords}")
+
   @path_params PathParams.new!([
                  PathParam.new!("id"),
                  PathParam.new!("coords", style: :matrix, explode: true)
                ])
 
+  def path_template, do: @path_template
   def path_params, do: @path_params
 
   def to_path_params(%__MODULE__{} = path) do
@@ -258,12 +261,11 @@ defmodule MyApi.Operation.GetItem do
   @type resp_404() :: Response.t(nil, Response.headers())
   @type result() :: {:ok, resp_200() | resp_401() | resp_404()} | {:error, term()}
 
-  @path_template PathTemplate.new!("/items/{id}{coords}")
   @header_params Header.header_params()
   @cookie_params Cookie.cookie_params()
 
   @private OpenAPI.merge_private([
-             PathTemplate.put_private(@path_template),
+             PathTemplate.put_private(Path.path_template()),
              PathParams.put_private(Path.path_params()),
              QueryParams.put_private(Query.query_params())
            ])
@@ -285,7 +287,7 @@ defmodule MyApi.Operation.GetItem do
 
     request_opts = [
       method: :get,
-      url: @path_template.path,
+      url: Path.path_template().path,
       query: Query.to_query(operation.query),
       headers: headers,
       opts: Keyword.put(opts, :path_params, Path.to_path_params(operation.path)),

--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -261,6 +261,7 @@ defmodule MyApi.Operation.GetItem do
   @type resp_404() :: Response.t(nil, Response.headers())
   @type result() :: {:ok, resp_200() | resp_401() | resp_404()} | {:error, term()}
 
+  @request_path Path.path_template().path
   @header_params Header.header_params()
   @cookie_params Cookie.cookie_params()
 
@@ -287,7 +288,7 @@ defmodule MyApi.Operation.GetItem do
 
     request_opts = [
       method: :get,
-      url: Path.path_template().path,
+      url: @request_path,
       query: Query.to_query(operation.query),
       headers: headers,
       opts: Keyword.put(opts, :path_params, Path.to_path_params(operation.path)),

--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -141,8 +141,8 @@ end
 `Tesla.OpenAPI.QueryParam` supports the OpenAPI query styles `:form`,
 `:space_delimited`, `:pipe_delimited`, and `:deep_object`. Omit optional query
 parameters from the returned map when they should not be sent. The operation
-module assigns `@query_params Query.query_params()` so the result is stored in
-a module attribute.
+module uses the result of `Query.query_params()` when it builds its private
+metadata.
 
 Other top-level query params can share the same request query map and remain
 normal Tesla query params. This example keeps those values in a generated
@@ -228,8 +228,8 @@ end
 ## Build the operation module
 
 Now assemble the nested modules into the generated operation. The nested
-modules define each parameter collection, and the operation module stores the
-results in module attributes:
+modules expose each parameter collection, and the operation module uses those
+results when it builds static request metadata:
 
 ```elixir
 defmodule MyApi.Operation.GetItem do
@@ -259,15 +259,13 @@ defmodule MyApi.Operation.GetItem do
   @type result() :: {:ok, resp_200() | resp_401() | resp_404()} | {:error, term()}
 
   @path_template PathTemplate.new!("/items/{id}{coords}")
-  @path_params Path.path_params()
-  @query_params Query.query_params()
   @header_params Header.header_params()
   @cookie_params Cookie.cookie_params()
 
   @private OpenAPI.merge_private([
              PathTemplate.put_private(@path_template),
-             PathParams.put_private(@path_params),
-             QueryParams.put_private(@query_params)
+             PathParams.put_private(Path.path_params()),
+             QueryParams.put_private(Query.query_params())
            ])
 
   def new(attrs) when is_map(attrs) do

--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -63,18 +63,27 @@ paths:
 
 ## Build the path module
 
-Start with the operation-owned value module for `in: "path"` request values.
-The final operation module will pass this map to `Tesla.Middleware.PathParams`
-in `:modern` mode:
+Start with the operation-owned module for `in: "path"` values and metadata.
+The final operation module will store `path_params/0` in a module attribute and
+pass the request value map to `Tesla.Middleware.PathParams` in `:modern` mode:
 
 ```elixir
 defmodule MyApi.Operation.GetItem.Path do
+  alias Tesla.OpenAPI.{PathParam, PathParams}
+
   @type t :: %__MODULE__{
           id: integer(),
           coords: [String.t()]
         }
 
   defstruct [:id, :coords]
+
+  def path_params do
+    PathParams.new!([
+      PathParam.new!("id"),
+      PathParam.new!("coords", style: :matrix, explode: true)
+    ])
+  end
 
   def to_path_params(%__MODULE__{} = path) do
     %{
@@ -85,17 +94,20 @@ defmodule MyApi.Operation.GetItem.Path do
 end
 ```
 
-The static OpenAPI path metadata for those names will use `Tesla.OpenAPI.PathParam`,
-`Tesla.OpenAPI.PathParams`, and `Tesla.OpenAPI.PathTemplate` when the operation module is built.
+The runtime struct contains request values only. `path_params/0` returns the
+static OpenAPI path metadata that the operation module stores in a module
+attribute.
 
 ## Build the query module
 
-Start with the operation-owned value module for `in: "query"` request values.
-The final operation module will pass this map to `Tesla.Middleware.Query` in
-`:modern` mode:
+Start with the operation-owned module for `in: "query"` values and metadata.
+The final operation module will store `query_params/0` in a module attribute
+and pass the request value map to `Tesla.Middleware.Query` in `:modern` mode:
 
 ```elixir
 defmodule MyApi.Operation.GetItem.Query do
+  alias Tesla.OpenAPI.{QueryParam, QueryParams}
+
   @type t :: %__MODULE__{
           :"$additional" => map() | nil,
           color: [String.t()],
@@ -103,6 +115,13 @@ defmodule MyApi.Operation.GetItem.Query do
         }
 
   defstruct color: nil, filter: nil, "$additional": %{}
+
+  def query_params do
+    QueryParams.new!([
+      QueryParam.new!("color", style: :pipe_delimited),
+      QueryParam.new!("filter", style: :deep_object)
+    ])
+  end
 
   def to_query(nil), do: %{}
 
@@ -119,9 +138,8 @@ end
 
 `Tesla.OpenAPI.QueryParam` supports the OpenAPI query styles `:form`,
 `:space_delimited`, `:pipe_delimited`, and `:deep_object`. Omit optional query
-parameters from the returned map when they should not be sent. The static
-OpenAPI query metadata for those names will use `Tesla.OpenAPI.QueryParam` and
-`Tesla.OpenAPI.QueryParams` when the operation module is built.
+parameters from the returned map when they should not be sent. The operation
+module stores the static `query_params/0` result in a module attribute.
 
 Other top-level query params can share the same request query map and remain
 normal Tesla query params. This example keeps those values in a generated
@@ -129,8 +147,8 @@ normal Tesla query params. This example keeps those values in a generated
 
 ## Build the header module
 
-For `in: "header"`, define `Tesla.OpenAPI.HeaderParam` metadata once and use
-`Tesla.OpenAPI.HeaderParams` to convert request values to raw header tuples:
+For `in: "header"`, expose `Tesla.OpenAPI.HeaderParam` metadata and convert the
+request struct into the value map used by `Tesla.OpenAPI.HeaderParams`:
 
 ```elixir
 defmodule MyApi.Operation.GetItem.Header do
@@ -142,16 +160,18 @@ defmodule MyApi.Operation.GetItem.Header do
 
   defstruct [:request_id]
 
-  @header_params HeaderParams.new!([
-                   HeaderParam.new!("X-Request-ID")
-                 ])
+  def header_params do
+    HeaderParams.new!([
+      HeaderParam.new!("X-Request-ID")
+    ])
+  end
 
-  def to_headers(nil), do: []
+  def to_header_params(nil), do: %{}
 
-  def to_headers(%__MODULE__{} = headers) do
-    HeaderParams.to_headers(@header_params, %{
+  def to_header_params(%__MODULE__{} = headers) do
+    %{
       "X-Request-ID" => headers.request_id
-    })
+    }
   end
 end
 ```
@@ -160,8 +180,8 @@ end
 
 ## Build the cookie module
 
-For `in: "cookie"`, define `Tesla.OpenAPI.CookieParam` metadata once and use
-`Tesla.OpenAPI.CookieParams` to convert request values to the `Cookie` header:
+For `in: "cookie"`, expose `Tesla.OpenAPI.CookieParam` metadata and convert the
+request struct into the value map used by `Tesla.OpenAPI.CookieParams`:
 
 ```elixir
 defmodule MyApi.Operation.GetItem.Cookie do
@@ -173,16 +193,18 @@ defmodule MyApi.Operation.GetItem.Cookie do
 
   defstruct [:session_id]
 
-  @cookie_params CookieParams.new!([
-                   CookieParam.new!("session_id")
-                 ])
+  def cookie_params do
+    CookieParams.new!([
+      CookieParam.new!("session_id")
+    ])
+  end
 
-  def to_headers(nil), do: []
+  def to_cookie_params(nil), do: %{}
 
-  def to_headers(%__MODULE__{} = cookies) do
-    CookieParams.to_headers(@cookie_params, %{
+  def to_cookie_params(%__MODULE__{} = cookies) do
+    %{
       "session_id" => cookies.session_id
-    })
+    }
   end
 end
 ```
@@ -202,9 +224,9 @@ end
 
 ## Build the operation module
 
-Now assemble the nested modules into the generated operation. Static path
-metadata and `t:Tesla.Env.private/0` data stay on the operation module with
-`Tesla.OpenAPI.PathTemplate`, `Tesla.OpenAPI.PathParam`, and `Tesla.OpenAPI.PathParams`:
+Now assemble the nested modules into the generated operation. The nested
+modules define each parameter collection, and the operation module stores those
+static definitions in module attributes:
 
 ```elixir
 defmodule MyApi.Operation.GetItem do
@@ -212,7 +234,7 @@ defmodule MyApi.Operation.GetItem do
   alias MyApi.Operation.GetItem.{Cookie, Header, Path, Query}
   alias MyApi.Response
   alias Tesla.OpenAPI
-  alias Tesla.OpenAPI.{PathParam, PathParams, PathTemplate, QueryParam, QueryParams}
+  alias Tesla.OpenAPI.{CookieParams, HeaderParams, PathParams, PathTemplate, QueryParams}
 
   defstruct path: nil,
             query: nil,
@@ -234,16 +256,10 @@ defmodule MyApi.Operation.GetItem do
   @type result() :: {:ok, resp_200() | resp_401() | resp_404()} | {:error, term()}
 
   @path_template PathTemplate.new!("/items/{id}{coords}")
-
-  @path_params PathParams.new!([
-                 PathParam.new!("id"),
-                 PathParam.new!("coords", style: :matrix, explode: true)
-               ])
-
-  @query_params QueryParams.new!([
-                  QueryParam.new!("color", style: :pipe_delimited),
-                  QueryParam.new!("filter", style: :deep_object)
-                ])
+  @path_params Path.path_params()
+  @query_params Query.query_params()
+  @header_params Header.header_params()
+  @cookie_params Cookie.cookie_params()
 
   @private OpenAPI.merge_private([
              PathTemplate.put_private(@path_template),
@@ -262,7 +278,9 @@ defmodule MyApi.Operation.GetItem do
 
   @doc false
   def handle_operation(%Client{} = client, %__MODULE__{} = operation, opts) do
-    headers = Header.to_headers(operation.headers) ++ Cookie.to_headers(operation.cookies)
+    headers =
+      HeaderParams.to_headers(@header_params, Header.to_header_params(operation.headers)) ++
+        CookieParams.to_headers(@cookie_params, Cookie.to_cookie_params(operation.cookies))
 
     request_opts = [
       method: :get,

--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -261,7 +261,7 @@ defmodule MyApi.Operation.GetItem do
   @type resp_404() :: Response.t(nil, Response.headers())
   @type result() :: {:ok, resp_200() | resp_401() | resp_404()} | {:error, term()}
 
-  @request_path Path.path_template().path
+  @operation_path Path.path_template().path
   @header_params Header.header_params()
   @cookie_params Cookie.cookie_params()
 
@@ -288,7 +288,7 @@ defmodule MyApi.Operation.GetItem do
 
     request_opts = [
       method: :get,
-      url: @request_path,
+      url: @operation_path,
       query: Query.to_query(operation.query),
       headers: headers,
       opts: Keyword.put(opts, :path_params, Path.to_path_params(operation.path)),

--- a/guides/howtos/openapi-parameters.md
+++ b/guides/howtos/openapi-parameters.md
@@ -64,8 +64,9 @@ paths:
 ## Build the path module
 
 Start with the operation-owned module for `in: "path"` values and metadata.
-The final operation module will store `path_params/0` in a module attribute and
-pass the request value map to `Tesla.Middleware.PathParams` in `:modern` mode:
+The final operation module will store the result of `Path.path_params()` in a
+module attribute and pass the request value map to `Tesla.Middleware.PathParams`
+in `:modern` mode:
 
 ```elixir
 defmodule MyApi.Operation.GetItem.Path do
@@ -101,8 +102,9 @@ attribute.
 ## Build the query module
 
 Start with the operation-owned module for `in: "query"` values and metadata.
-The final operation module will store `query_params/0` in a module attribute
-and pass the request value map to `Tesla.Middleware.Query` in `:modern` mode:
+The final operation module will store the result of `Query.query_params()` in a
+module attribute and pass the request value map to `Tesla.Middleware.Query` in
+`:modern` mode:
 
 ```elixir
 defmodule MyApi.Operation.GetItem.Query do
@@ -139,7 +141,7 @@ end
 `Tesla.OpenAPI.QueryParam` supports the OpenAPI query styles `:form`,
 `:space_delimited`, `:pipe_delimited`, and `:deep_object`. Omit optional query
 parameters from the returned map when they should not be sent. The operation
-module stores the static `query_params/0` result in a module attribute.
+module stores the result of `Query.query_params()` in a module attribute.
 
 Other top-level query params can share the same request query map and remain
 normal Tesla query params. This example keeps those values in a generated
@@ -225,8 +227,8 @@ end
 ## Build the operation module
 
 Now assemble the nested modules into the generated operation. The nested
-modules define each parameter collection, and the operation module stores those
-static definitions in module attributes:
+modules define each parameter collection, and the operation module stores the
+results in module attributes:
 
 ```elixir
 defmodule MyApi.Operation.GetItem do

--- a/lib/tesla/open_api.ex
+++ b/lib/tesla/open_api.ex
@@ -41,13 +41,11 @@ defmodule Tesla.OpenAPI do
         alias MyApi.Operation.GetItem.{Path, Query}
 
         @path_template Tesla.OpenAPI.PathTemplate.new!("/items/{id}")
-        @path_params Path.path_params()
-        @query_params Query.query_params()
 
         @private Tesla.OpenAPI.merge_private([
                    Tesla.OpenAPI.PathTemplate.put_private(@path_template),
-                   Tesla.OpenAPI.PathParams.put_private(@path_params),
-                   Tesla.OpenAPI.QueryParams.put_private(@query_params)
+                   Tesla.OpenAPI.PathParams.put_private(Path.path_params()),
+                   Tesla.OpenAPI.QueryParams.put_private(Query.query_params())
                  ])
       end
 

--- a/lib/tesla/open_api.ex
+++ b/lib/tesla/open_api.ex
@@ -21,10 +21,28 @@ defmodule Tesla.OpenAPI do
   Generated clients should keep OpenAPI parameter definitions as module
   attributes and pass only request values at runtime:
 
+      defmodule MyApi.Operation.GetItem.Path do
+        def path_params do
+          Tesla.OpenAPI.PathParams.new!([
+            Tesla.OpenAPI.PathParam.new!("id")
+          ])
+        end
+      end
+
+      defmodule MyApi.Operation.GetItem.Query do
+        def query_params do
+          Tesla.OpenAPI.QueryParams.new!([
+            Tesla.OpenAPI.QueryParam.new!("filter")
+          ])
+        end
+      end
+
       defmodule MyApi.Operation.GetItem do
+        alias MyApi.Operation.GetItem.{Path, Query}
+
         @path_template Tesla.OpenAPI.PathTemplate.new!("/items/{id}")
-        @path_params Tesla.OpenAPI.PathParams.new!([Tesla.OpenAPI.PathParam.new!("id")])
-        @query_params Tesla.OpenAPI.QueryParams.new!([Tesla.OpenAPI.QueryParam.new!("filter")])
+        @path_params Path.path_params()
+        @query_params Query.query_params()
 
         @private Tesla.OpenAPI.merge_private([
                    Tesla.OpenAPI.PathTemplate.put_private(@path_template),

--- a/lib/tesla/open_api.ex
+++ b/lib/tesla/open_api.ex
@@ -22,10 +22,13 @@ defmodule Tesla.OpenAPI do
   attributes and pass only request values at runtime:
 
       defmodule MyApi.Operation.GetItem.Path do
+        @path_template Tesla.OpenAPI.PathTemplate.new!("/items/{id}")
+
         @path_params Tesla.OpenAPI.PathParams.new!([
                        Tesla.OpenAPI.PathParam.new!("id")
                      ])
 
+        def path_template, do: @path_template
         def path_params, do: @path_params
       end
 
@@ -40,10 +43,8 @@ defmodule Tesla.OpenAPI do
       defmodule MyApi.Operation.GetItem do
         alias MyApi.Operation.GetItem.{Path, Query}
 
-        @path_template Tesla.OpenAPI.PathTemplate.new!("/items/{id}")
-
         @private Tesla.OpenAPI.merge_private([
-                   Tesla.OpenAPI.PathTemplate.put_private(@path_template),
+                   Tesla.OpenAPI.PathTemplate.put_private(Path.path_template()),
                    Tesla.OpenAPI.PathParams.put_private(Path.path_params()),
                    Tesla.OpenAPI.QueryParams.put_private(Query.query_params())
                  ])

--- a/lib/tesla/open_api.ex
+++ b/lib/tesla/open_api.ex
@@ -22,19 +22,19 @@ defmodule Tesla.OpenAPI do
   attributes and pass only request values at runtime:
 
       defmodule MyApi.Operation.GetItem.Path do
-        def path_params do
-          Tesla.OpenAPI.PathParams.new!([
-            Tesla.OpenAPI.PathParam.new!("id")
-          ])
-        end
+        @path_params Tesla.OpenAPI.PathParams.new!([
+                       Tesla.OpenAPI.PathParam.new!("id")
+                     ])
+
+        def path_params, do: @path_params
       end
 
       defmodule MyApi.Operation.GetItem.Query do
-        def query_params do
-          Tesla.OpenAPI.QueryParams.new!([
-            Tesla.OpenAPI.QueryParam.new!("filter")
-          ])
-        end
+        @query_params Tesla.OpenAPI.QueryParams.new!([
+                        Tesla.OpenAPI.QueryParam.new!("filter")
+                      ])
+
+        def query_params, do: @query_params
       end
 
       defmodule MyApi.Operation.GetItem do


### PR DESCRIPTION
- Generated-client examples should teach one ownership model for OpenAPI metadata.\n- Nested parameter modules should stay cohesive without making runtime structs carry static serialization rules.