### PR TITLE
fix(path-params): raise on missing required path parameter values

### DIFF
--- a/lib/tesla/middleware/path_params/modern.ex
+++ b/lib/tesla/middleware/path_params/modern.ex
@@ -58,24 +58,24 @@ defmodule Tesla.Middleware.PathParams.Modern do
     end
   end
 
-  defp render_template_expression(name, expression, {path_params, values}) do
-    replace_param(path_params, values, name, expression)
+  defp render_template_expression(name, _expression, {path_params, values}) do
+    replace_param(path_params, values, name)
   end
 
-  defp replace_placeholder(path_params, values, match, name) do
-    replace_param(path_params, values, name, match)
+  defp replace_placeholder(path_params, values, _match, name) do
+    replace_param(path_params, values, name)
   end
 
-  defp replace_param(path_params, values, name, match) do
+  defp replace_param(path_params, values, name) do
     case fetch_param(path_params, values, name) do
       {:ok, _path_param, nil} ->
-        match
+        raise_missing!(name)
 
       {:ok, path_param, value} ->
         serialize_value(path_param, value)
 
       :error ->
-        match
+        raise_missing!(name)
     end
   end
 
@@ -97,6 +97,13 @@ defmodule Tesla.Middleware.PathParams.Modern do
       :error ->
         :error
     end
+  end
+
+  defp raise_missing!(name) do
+    raise ArgumentError,
+          "missing value for path parameter #{inspect(name)}; path parameters are required " <>
+            "per the OpenAPI Specification. See " <>
+            "https://spec.openapis.org/oas/latest.html#parameter-required"
   end
 
   defp serialize_undefined(:simple, _param) do

--- a/lib/tesla/middleware/path_params/modern.ex
+++ b/lib/tesla/middleware/path_params/modern.ex
@@ -100,10 +100,7 @@ defmodule Tesla.Middleware.PathParams.Modern do
   end
 
   defp raise_missing!(name) do
-    raise ArgumentError,
-          "missing value for path parameter #{inspect(name)}; path parameters are required " <>
-            "per the OpenAPI Specification. See " <>
-            "https://spec.openapis.org/oas/latest.html#parameter-required"
+    raise ArgumentError, "missing value for path parameter #{inspect(name)}"
   end
 
   defp serialize_undefined(:simple, _param) do

--- a/lib/tesla/open_api/path_param.ex
+++ b/lib/tesla/open_api/path_param.ex
@@ -48,10 +48,11 @@ defmodule Tesla.OpenAPI.PathParam do
 
   ## Missing And Empty Values
 
-  `nil` values and missing path parameters are handled by
-  `Tesla.Middleware.PathParams`, which leaves unmatched placeholders untouched.
-  Empty arrays and empty objects serialize according to the OpenAPI
-  "undefined" column for the selected style.
+  Path parameters are required per the OpenAPI Specification
+  ([Parameter Object — `required`](https://spec.openapis.org/oas/latest.html#parameter-required)).
+  `Tesla.Middleware.PathParams` raises `ArgumentError` when a placeholder's value
+  is missing or `nil`. Empty arrays and empty objects serialize according to the
+  OpenAPI "undefined" column for the selected style.
   """
 
   alias Tesla.Param
@@ -72,6 +73,9 @@ defmodule Tesla.OpenAPI.PathParam do
 
   @doc """
   Creates a path parameter definition.
+
+  Path parameters are always required per the OpenAPI Specification:
+  [Parameter Object — `required`](https://spec.openapis.org/oas/latest.html#parameter-required).
 
   Options use Elixir atoms for hand-written Tesla code:
 

--- a/lib/tesla/open_api/path_param.ex
+++ b/lib/tesla/open_api/path_param.ex
@@ -50,9 +50,10 @@ defmodule Tesla.OpenAPI.PathParam do
 
   Path parameters are required per the OpenAPI Specification
   ([Parameter Object — `required`](https://spec.openapis.org/oas/latest.html#parameter-required)).
-  `Tesla.Middleware.PathParams` raises `ArgumentError` when a placeholder's value
-  is missing or `nil`. Empty arrays and empty objects serialize according to the
-  OpenAPI "undefined" column for the selected style.
+  When `Tesla.Middleware.PathParams` runs in `:modern` mode and request values
+  are supplied via `opts[:path_params]`, it raises `ArgumentError` if a defined
+  placeholder's value is missing or `nil`. Empty arrays and empty objects
+  serialize according to the OpenAPI "undefined" column for the selected style.
   """
 
   alias Tesla.Param

--- a/test/tesla/middleware/path_params/modern_test.exs
+++ b/test/tesla/middleware/path_params/modern_test.exs
@@ -566,11 +566,28 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       assert env.url == "/users/5;coords=blue;coords=black"
     end
 
-    test "raises when template expression value is nil or missing" do
-      template = PathTemplate.new!("/users/{id}/{missing}")
+    test "raises when a template expression value is nil" do
+      template = PathTemplate.new!("/users/{id}")
       opts = [path_params: [path_param(nil)]]
 
       assert_raise ArgumentError, ~r/missing value for path parameter "id"/, fn ->
+        call(
+          %Env{
+            url: template.path,
+            private: path_template_private(template),
+            opts: opts
+          },
+          [],
+          mode: :modern
+        )
+      end
+    end
+
+    test "raises when a template expression has no matching path parameter definition" do
+      template = PathTemplate.new!("/users/{id}/{missing}")
+      opts = [path_params: [path_param("id", 42)]]
+
+      assert_raise ArgumentError, ~r/missing value for path parameter "missing"/, fn ->
         call(
           %Env{
             url: template.path,

--- a/test/tesla/middleware/path_params/modern_test.exs
+++ b/test/tesla/middleware/path_params/modern_test.exs
@@ -481,12 +481,24 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
 
       assert {:ok, env} =
                call(
-                 %Env{url: "/users/{id}/{Id}/{ID}", opts: opts},
+                 %Env{url: "/users/{id}/{Id}", opts: opts},
                  [],
                  mode: :modern
                )
 
-      assert env.url == "/users/lower/upper/{ID}"
+      assert env.url == "/users/lower/upper"
+    end
+
+    test "raises on case-mismatched template name" do
+      opts = [path_params: [path_param("id", "lower")]]
+
+      assert_raise ArgumentError, ~r/missing value for path parameter "ID"/, fn ->
+        call(
+          %Env{url: "/users/{ID}", opts: opts},
+          [],
+          mode: :modern
+        )
+      end
     end
 
     test "replaces repeated template expressions with the same parameter value" do
@@ -554,22 +566,21 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       assert env.url == "/users/5;coords=blue;coords=black"
     end
 
-    test "preserves missing and nil template expressions" do
+    test "raises when template expression value is nil or missing" do
       template = PathTemplate.new!("/users/{id}/{missing}")
       opts = [path_params: [path_param(nil)]]
 
-      assert {:ok, env} =
-               call(
-                 %Env{
-                   url: template.path,
-                   private: path_template_private(template),
-                   opts: opts
-                 },
-                 [],
-                 mode: :modern
-               )
-
-      assert env.url == "/users/{id}/{missing}"
+      assert_raise ArgumentError, ~r/missing value for path parameter "id"/, fn ->
+        call(
+          %Env{
+            url: template.path,
+            private: path_template_private(template),
+            opts: opts
+          },
+          [],
+          mode: :modern
+        )
+      end
     end
 
     test "falls back when private path template does not match the request path" do
@@ -819,30 +830,28 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       assert env.url == "/users/John%20Smith"
     end
 
-    test "leaves placeholder when value is missing" do
+    test "raises when value is missing" do
       opts = [path_params: [path_param("other", 1)]]
 
-      assert {:ok, env} =
-               call(
-                 %Env{url: "/users/{id}", opts: opts},
-                 [],
-                 mode: :modern
-               )
-
-      assert env.url == "/users/{id}"
+      assert_raise ArgumentError, ~r/missing value for path parameter "id"/, fn ->
+        call(
+          %Env{url: "/users/{id}", opts: opts},
+          [],
+          mode: :modern
+        )
+      end
     end
 
-    test "leaves placeholder when request value is nil" do
+    test "raises when request value is nil" do
       opts = [path_params: [path_param(nil)]]
 
-      assert {:ok, env} =
-               call(
-                 %Env{url: "/users/{id}", opts: opts},
-                 [],
-                 mode: :modern
-               )
-
-      assert env.url == "/users/{id}"
+      assert_raise ArgumentError, ~r/missing value for path parameter "id"/, fn ->
+        call(
+          %Env{url: "/users/{id}", opts: opts},
+          [],
+          mode: :modern
+        )
+      end
     end
 
     test "serializes empty array as OpenAPI undefined" do


### PR DESCRIPTION
- Scoped to `Tesla.Middleware.PathParams` in `mode: :modern` when request values are supplied via `opts[:path_params]`: unresolved placeholders silently produced invalid URLs (e.g. `/users/42/locations/{coords}`), shifting failures from the call site to opaque downstream errors.
- Path parameters are always required per the [OpenAPI Specification — Parameter Object `required`](https://spec.openapis.org/oas/latest.html#parameter-required), so for the OpenAPI flow a missing or `nil` value is a programming error and surfacing it at the boundary makes the contract enforceable.
- Legacy `Tesla.Middleware.PathParams` and the modern flow without `opts[:path_params]` are unchanged and continue to leave placeholders untouched.