### PR TITLE
feat(form-urlencoded): support nested bodies via :brackets option

### DIFF
--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -225,9 +225,11 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   defp encode_deep_object(data) do
     data
-    |> Enum.flat_map(fn {key, value} -> encode_value(value, [key]) end)
+    |> Enum.flat_map(&encode_root_entry/1)
     |> Enum.join("&")
   end
+
+  defp encode_root_entry({key, value}), do: encode_value(value, [key])
 
   defp encode_value(nil, _path), do: []
 
@@ -240,23 +242,17 @@ defmodule Tesla.Middleware.FormUrlencoded do
   end
 
   defp encode_value(value, path) when is_map(value) do
-    Enum.flat_map(value, fn {key, nested_value} ->
-      encode_value(nested_value, [key | path])
-    end)
+    Enum.flat_map(value, &encode_keyed_entry(&1, path))
   end
 
   defp encode_value(value, path) when is_list(value) do
     if Keyword.keyword?(value) do
-      Enum.flat_map(value, fn {key, nested_value} ->
-        encode_value(nested_value, [key | path])
-      end)
+      Enum.flat_map(value, &encode_keyed_entry(&1, path))
     else
       value
       |> Enum.reject(&is_nil/1)
       |> Enum.with_index()
-      |> Enum.flat_map(fn {nested_value, index} ->
-        encode_value(nested_value, [index | path])
-      end)
+      |> Enum.flat_map(&encode_indexed_entry(&1, path))
     end
   end
 
@@ -264,13 +260,17 @@ defmodule Tesla.Middleware.FormUrlencoded do
     ["#{encode_path(path)}=#{encode_part(value)}"]
   end
 
+  defp encode_keyed_entry({key, value}, path), do: encode_value(value, [key | path])
+
+  defp encode_indexed_entry({value, index}, path), do: encode_value(value, [index | path])
+
   defp encode_path(path) do
     [root | rest] = Enum.reverse(path)
 
-    Enum.reduce(rest, encode_part(root), fn part, encoded ->
-      "#{encoded}[#{encode_part(part)}]"
-    end)
+    Enum.reduce(rest, encode_part(root), &append_bracket/2)
   end
+
+  defp append_bracket(part, encoded), do: "#{encoded}[#{encode_part(part)}]"
 
   defp encode_part(value) when is_atom(value),
     do: value |> Atom.to_string() |> URI.encode_www_form()

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -59,75 +59,31 @@ defmodule Tesla.Middleware.FormUrlencoded do
   Myclient.post(client, "/url", %{key: %{nested: "value"}})
   ```
 
-  ## Serialization Styles
+  ## `encode: :deep_object`
 
-  The `:encode` option supports built-in serialization styles that mirror
-  OpenAPI's Encoding Object `style` field. OpenAPI defines four values:
-  `form` (default), `spaceDelimited`, `pipeDelimited`, and `deepObject`.
-  The middleware currently implements `:deep_object`; the other styles
-  may be added later.
-
-  ### `encode: :deep_object`
-
-  Recursive bracket-notation encoder for bodies that contain maps,
-  structs, or lists. The flat default behavior is unchanged when `:encode`
-  is not set.
-
-  Output shape:
-
-  - Nested maps and structs: `parent[child]=value`.
-  - Lists: `parent[0]=a&parent[1]=b` (numeric indices).
-  - Lists of objects: `items[0][name]=a&items[1][name]=b`.
-
-  OpenAPI defines `deepObject` for object values only and leaves array
-  serialization unspecified; this middleware extends the style to arrays
-  using numeric bracket indices, the convention used by Stripe, PHP's
-  `http_build_query`, and many code-generated SDKs. Bracket characters in
-  keys are emitted literally; only the segments between them are
-  percent-encoded.
+  Recursive bracket-notation encoder for nested maps and lists, modeled
+  on OpenAPI's `deepObject` style and extended to arrays with numeric
+  indices (the convention used by Stripe, `http_build_query`, and most
+  code-generated SDKs).
 
   ```elixir
-  defmodule MyClient do
-    def client do
-      Tesla.client([
-        {Tesla.Middleware.FormUrlencoded, encode: :deep_object}
-      ])
-    end
-  end
-
-  body = %{
+  Tesla.client([{Tesla.Middleware.FormUrlencoded, encode: :deep_object}])
+  |> Tesla.post("/url", %{
     expand: ["objects"],
-    objects: %{customers: ["cus_123", "cus_456"], charges: nil},
-    validation_behavior: :fix
-  }
-
-  MyClient.post(client, "/url", body)
-  # =>
-  # expand[0]=objects
-  # &objects[customers][0]=cus_123
-  # &objects[customers][1]=cus_456
-  # &validation_behavior=fix
+    objects: %{customers: ["cus_123", "cus_456"]}
+  })
+  # body: "expand[0]=objects&objects[customers][0]=cus_123&objects[customers][1]=cus_456"
   ```
 
-  Encoding behavior:
+  Behavior worth knowing:
 
-  - Nested maps recurse.
-  - Structs are not supported and raise `ArgumentError`. Convert them
-    explicitly with `Map.from_struct/1`, `to_string/1`, or a
-    domain-specific serializer before passing the body in.
-  - Keyword lists are encoded as nested objects (`parent[key]=value`),
-    not as numerically indexed arrays.
-  - `nil` is dropped at every level, including inside lists (indices are
-    assigned after filtering).
-  - Booleans encode as `"true"` / `"false"`.
-  - Atoms encode via `Atom.to_string/1`; everything else via `to_string/1`.
-  - Keys and values are escaped with `URI.encode_www_form/1`.
-  - Output ordering follows Elixir map traversal order and is not
-    guaranteed across runs; treat the encoded string as a multiset of
-    pairs, not an ordered sequence.
-
-  Decoding remains flat regardless of `:encode`. If you need to decode
-  nested form responses, configure `:decode` with `&Plug.Conn.Query.decode/1`.
+  - `nil` is dropped at every level; list indices are assigned after filtering.
+  - Keyword lists encode as objects (`parent[key]=value`), not arrays.
+  - Structs raise `ArgumentError` — convert them with `Map.from_struct/1`
+    or `to_string/1` first.
+  - Output order is not guaranteed (maps don't preserve insertion order).
+  - Decoding stays flat; pair with `decode: &Plug.Conn.Query.decode/1` for
+    symmetric round-trips.
   """
 
   @behaviour Tesla.Middleware

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -61,10 +61,18 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   ## `encode: :deep_object`
 
-  Recursive bracket-notation encoder for nested maps and lists, modeled
-  on OpenAPI's [`deepObject` style](https://spec.openapis.org/oas/v3.1.0#style-values)
-  and extended to arrays with numeric indices (the convention used by
-  Stripe, `http_build_query`, and most code-generated SDKs).
+  Recursive bracket-notation encoder for nested maps and lists.
+
+  Uses OpenAPI's [`deepObject` style](https://spec.openapis.org/oas/v3.1.0#style-values)
+  for the object case (e.g. `color[R]=100&color[G]=200`). OpenAPI 3.0.4
+  and 3.1.1 explicitly state that *"the representation of array or
+  object properties is not defined"* under `deepObject`, so this encoder
+  follows the convention used by Stripe's official SDKs
+  ([stripe-node](https://github.com/stripe/stripe-node/blob/master/src/utils.ts),
+  [stripe-python](https://github.com/stripe/stripe-python/blob/master/stripe/_encode.py),
+  [stripe-ruby](https://github.com/stripe/stripe-ruby/blob/master/lib/stripe/util.rb))
+  and PHP's `http_build_query`: numeric bracket indices for arrays and
+  recursion for deeper nesting.
 
   ```elixir
   client = Tesla.client([{Tesla.Middleware.FormUrlencoded, encode: :deep_object}])
@@ -78,7 +86,9 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   Behavior worth knowing:
 
-  - `nil` is dropped at every level; list indices are assigned after filtering.
+  - `nil` map values are dropped.
+  - `nil` list elements are dropped but the original index is preserved
+    (`[a, nil, b]` → `[0]=a&[2]=b`), matching `stripe-node`.
   - Keyword lists encode as objects (`parent[key]=value`), not arrays.
   - Structs raise `ArgumentError` — convert them with `Map.from_struct/1`
     or `to_string/1` first.
@@ -212,9 +222,11 @@ defmodule Tesla.Middleware.FormUrlencoded do
     if Keyword.keyword?(value) do
       Enum.flat_map(value, &encode_keyed_entry(&1, path))
     else
+      # Index first, then drop nils, so original positions are preserved
+      # (matches stripe-node: `[a, nil, b]` -> `[0]=a&[2]=b`).
       value
-      |> Enum.reject(&is_nil/1)
       |> Enum.with_index()
+      |> Enum.reject(&indexed_nil?/1)
       |> Enum.flat_map(&encode_indexed_entry(&1, path))
     end
   end
@@ -230,6 +242,9 @@ defmodule Tesla.Middleware.FormUrlencoded do
   defp encode_indexed_entry({value, index}, path) do
     encode_value(value, [index | path])
   end
+
+  defp indexed_nil?({nil, _index}), do: true
+  defp indexed_nil?({_value, _index}), do: false
 
   defp encode_path(path) do
     [root | rest] = Enum.reverse(path)

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -112,11 +112,9 @@ defmodule Tesla.Middleware.FormUrlencoded do
   Encoding behavior:
 
   - Nested maps recurse.
-  - Nested structs that implement `String.Chars` (e.g. `DateTime`, `Date`,
-    `URI`, `Decimal`) are encoded via `to_string/1`. Structs without a
-    `String.Chars` implementation fall back to `Map.from_struct/1` and
-    recurse like maps. A top-level struct is always unwrapped with
-    `Map.from_struct/1`.
+  - Structs are not supported and raise `ArgumentError`. Convert them
+    explicitly with `Map.from_struct/1`, `to_string/1`, or a
+    domain-specific serializer before passing the body in.
   - Keyword lists are encoded as nested objects (`parent[key]=value`),
     not as numerically indexed arrays.
   - `nil` is dropped at every level, including inside lists (indices are
@@ -221,7 +219,7 @@ defmodule Tesla.Middleware.FormUrlencoded do
   end
 
   defp encode_deep_object(data) when is_struct(data) do
-    encode_deep_object(Map.from_struct(data))
+    raise ArgumentError, struct_error_message(data)
   end
 
   defp encode_deep_object(data) do
@@ -238,12 +236,8 @@ defmodule Tesla.Middleware.FormUrlencoded do
     []
   end
 
-  defp encode_value(value, path) when is_struct(value) do
-    if String.Chars.impl_for(value) do
-      encode_value(to_string(value), path)
-    else
-      encode_value(Map.from_struct(value), path)
-    end
+  defp encode_value(value, _path) when is_struct(value) do
+    raise ArgumentError, struct_error_message(value)
   end
 
   defp encode_value(value, path) when is_map(value) do
@@ -289,6 +283,11 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   defp encode_part(value) do
     value |> to_string() |> URI.encode_www_form()
+  end
+
+  defp struct_error_message(%module{}) do
+    "cannot encode #{inspect(module)} struct with :deep_object; " <>
+      "convert it to a map, string, or other primitive before passing it as the body"
   end
 end
 

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -30,7 +30,8 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   - `:decode` - decoding function, defaults to `URI.decode_query/1`
   - `:encode` - controls how the body is encoded. Accepts:
-    - a function (arity 1) for fully custom encoding
+    - an arity-1 function that receives the body and returns a binary
+      (e.g. `&Plug.Conn.Query.encode/1` or any custom encoder)
     - `:brackets` — recursive bracket-notation encoder for nested maps
       and lists (see `encode: :brackets` below)
     - `{:brackets, opts}` — same encoder with sub-options. Currently
@@ -149,20 +150,39 @@ defmodule Tesla.Middleware.FormUrlencoded do
   (`[a, nil, b]` → `[0]=a&[2]=b`, matching PHP `http_build_query`), and
   `""` elements are emitted as `key[i]=`.
 
+  ### Root containers
+
+  The root accepts any ordered name/value pair-sequence, which matches
+  the `application/x-www-form-urlencoded` wire-level data model:
+
+  - `Map` — most common; iteration order is undefined.
+  - Keyword list (`[a: 1, b: 2]`) — preserves the order you give it.
+  - List of 2-tuples (`[{"tag", "a"}, {"tag", "b"}]`) — preserves order
+    *and* allows duplicate keys and non-atom keys
+    (`[{"tag", "a"}, {"tag", "b"}]` → `tag=a&tag=b`).
+
+  Anything else at the root (`42`, `[1, 2, 3]`, `[{:a, 1}, 2]`, a
+  struct) raises `ArgumentError`.
+
+  ### Nested containers
+
+  Inside the payload the shape is strict, no inference:
+
+  - `Map` is always an object → `parent[key]=value`.
+  - `List` is always an array → `parent[0]=…&parent[1]=…`.
+  - A tuple appearing inside a map or list raises — use a map for
+    object-shaped nesting.
+  - Structs raise `ArgumentError` — convert them with
+    `Map.from_struct/1` or `to_string/1` first.
+
   ### Other behavior worth knowing
 
-  - Keyword lists (atom-keyed) encode as objects (`parent[key]=value`),
-    not arrays. String-keyed proplists like `[{"a", 1}]` are not detected
-    as keyword lists and will raise the tuple error — convert them to a
-    map first.
-  - Structs raise `ArgumentError` — convert them with `Map.from_struct/1`
-    or `to_string/1` first.
   - Empty lists and empty maps emit nothing, which means the parent key
     disappears entirely: `%{ids: []}` → `""`, and `%{user: %{tags: []}}`
     → `""`. This matches PHP `http_build_query`. Send `""` to clear a
     field on Stripe-style update endpoints.
-  - Map keys are not ordered; keyword lists preserve the order you give
-    them.
+  - Map keys are not ordered; keyword lists and lists of 2-tuples
+    preserve the order you give them.
   - Decoding stays flat. `Plug.Conn.Query.decode/1` will parse the
     bracket keys into nested maps, but indexed lists come back as maps
     keyed by string indices (`"0"`, `"1"`, …), not as Elixir lists, so
@@ -241,15 +261,10 @@ defmodule Tesla.Middleware.FormUrlencoded do
         URI.encode_query(data)
 
       :brackets ->
-        encode_brackets(data)
+        encode_brackets(data, :string)
 
       {:brackets, sub_opts} when is_list(sub_opts) ->
-        validate_brackets_opts!(sub_opts)
-        boolean_as = brackets_boolean_as!(sub_opts)
-
-        data
-        |> normalize_booleans(boolean_as)
-        |> encode_brackets()
+        encode_brackets(data, validate_brackets_opts!(sub_opts))
 
       fun when is_function(fun, 1) ->
         fun.(data)
@@ -258,21 +273,6 @@ defmodule Tesla.Middleware.FormUrlencoded do
         raise ArgumentError,
               "unknown :encode option #{inspect(value)}; expected :brackets, " <>
                 "{:brackets, opts} where opts is a keyword list, or an arity-1 function"
-    end
-  end
-
-  defp brackets_boolean_as!(sub_opts) do
-    case Keyword.get(sub_opts, :boolean_as, :string) do
-      :string ->
-        :string
-
-      :integer ->
-        :integer
-
-      other ->
-        raise ArgumentError,
-              "invalid :boolean_as #{inspect(other)} for :brackets encoder; " <>
-                "expected :string or :integer"
     end
   end
 
@@ -286,86 +286,84 @@ defmodule Tesla.Middleware.FormUrlencoded do
               "unknown option(s) #{inspect(unknown)} for :brackets encoder; " <>
                 "expected :boolean_as"
     end
+
+    case Keyword.get(sub_opts, :boolean_as, :string) do
+      mode when mode in [:string, :integer] ->
+        mode
+
+      other ->
+        raise ArgumentError,
+              "invalid :boolean_as #{inspect(other)} for :brackets encoder; " <>
+                "expected :string or :integer"
+    end
   end
-
-  defp normalize_booleans(data, :string), do: data
-  defp normalize_booleans(data, :integer), do: deep_map_booleans(data)
-
-  defp deep_map_booleans(true), do: "1"
-  defp deep_map_booleans(false), do: "0"
-  defp deep_map_booleans(%_{} = struct), do: struct
-
-  defp deep_map_booleans(map) when is_map(map) do
-    Map.new(map, fn {k, v} -> {k, deep_map_booleans(v)} end)
-  end
-
-  defp deep_map_booleans({k, v}) when is_atom(k), do: {k, deep_map_booleans(v)}
-  defp deep_map_booleans(list) when is_list(list), do: Enum.map(list, &deep_map_booleans/1)
-  defp deep_map_booleans(other), do: other
 
   defp do_decode(data, opts) do
     decoder = Keyword.get(opts, :decode, &URI.decode_query/1)
     decoder.(data)
   end
 
-  defp encode_brackets(%module{}), do: raise_struct!(module)
+  defp encode_brackets(%module{}, _boolean_as), do: raise_struct!(module)
 
-  defp encode_brackets(data) when is_map(data) or is_list(data) do
+  defp encode_brackets(data, boolean_as) when is_map(data) do
     data
-    |> Enum.flat_map(&encode_root_entry/1)
+    |> Enum.flat_map(&encode_root_entry(&1, boolean_as))
     |> Enum.join("&")
   end
 
-  defp encode_brackets(data) do
-    raise ArgumentError,
-          "cannot encode #{inspect(data)} with :brackets; " <>
-            "expected a map or keyword list at the root"
-  end
-
-  defp encode_root_entry({key, value}) do
-    encode_value(value, [key])
-  end
-
-  defp encode_value(nil, _path) do
-    []
-  end
-
-  defp encode_value(%module{}, _path), do: raise_struct!(module)
-
-  defp encode_value(value, path) when is_map(value) do
-    Enum.flat_map(value, &encode_keyed_entry(&1, path))
-  end
-
-  defp encode_value(value, path) when is_list(value) do
-    # Keyword.keyword?/1 walks the whole list; accepted because form
-    # payloads are small and the alternative (peeking at the head) would
-    # misclassify mixed lists like [{:a, 1}, 2].
-    if Keyword.keyword?(value) do
-      Enum.flat_map(value, &encode_keyed_entry(&1, path))
+  defp encode_brackets(data, boolean_as) when is_list(data) do
+    if pair_list?(data) do
+      data
+      |> Enum.flat_map(&encode_root_entry(&1, boolean_as))
+      |> Enum.join("&")
     else
-      # Index first, then drop nils, so original positions are preserved
-      # (matches stripe-node: `[a, nil, b]` -> `[0]=a&[2]=b`).
-      value
-      |> Enum.with_index()
-      |> Enum.reject(&indexed_nil?/1)
-      |> Enum.flat_map(&encode_indexed_entry(&1, path))
+      raise_invalid_root!(data)
     end
   end
 
-  defp encode_value(value, path) do
-    ["#{encode_path(path)}=#{encode_part(value)}"]
+  defp encode_brackets(data, _boolean_as), do: raise_invalid_root!(data)
+
+  defp pair_list?(list), do: Enum.all?(list, &match?({_, _}, &1))
+
+  defp encode_root_entry({key, value}, boolean_as) do
+    encode_value(value, [key], boolean_as)
   end
 
-  defp encode_keyed_entry({key, value}, path) do
-    encode_value(value, [key | path])
+  defp encode_value(nil, _path, _boolean_as), do: []
+
+  defp encode_value(%module{}, _path, _boolean_as), do: raise_struct!(module)
+
+  defp encode_value(value, path, boolean_as) when is_map(value) do
+    Enum.flat_map(value, &encode_keyed_entry(&1, path, boolean_as))
   end
 
-  defp encode_indexed_entry({value, index}, path) do
-    encode_value(value, [index | path])
+  defp encode_value(value, path, boolean_as) when is_list(value) do
+    # Index first, then drop nils, so original positions are preserved
+    # (matches stripe-node: `[a, nil, b]` -> `[0]=a&[2]=b`).
+    value
+    |> Enum.with_index()
+    |> Enum.reject(&indexed_nil?/1)
+    |> Enum.flat_map(&encode_indexed_entry(&1, path, boolean_as))
+  end
+
+  defp encode_value(value, path, boolean_as) do
+    ["#{encode_path(path)}=#{encode_leaf(value, boolean_as)}"]
+  end
+
+  defp encode_keyed_entry({key, value}, path, boolean_as) do
+    encode_value(value, [key | path], boolean_as)
+  end
+
+  defp encode_indexed_entry({value, index}, path, boolean_as) do
+    encode_value(value, [index | path], boolean_as)
   end
 
   defp indexed_nil?({nil, _index}), do: true
   defp indexed_nil?({_value, _index}), do: false
+
+  defp encode_leaf(true, :integer), do: "1"
+  defp encode_leaf(false, :integer), do: "0"
+  defp encode_leaf(value, _boolean_as), do: encode_part(value)
 
   defp encode_path(path) do
     [root | rest] = Enum.reverse(path)
@@ -395,6 +393,12 @@ defmodule Tesla.Middleware.FormUrlencoded do
     raise ArgumentError,
           "cannot encode #{inspect(module)} struct with :brackets; " <>
             "convert it to a map, string, or other primitive before passing it as the body"
+  end
+
+  defp raise_invalid_root!(data) do
+    raise ArgumentError,
+          "cannot encode #{inspect(data)} with :brackets; " <>
+            "expected a map or keyword list at the root"
   end
 end
 

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -262,6 +262,12 @@ defmodule Tesla.Middleware.FormUrlencoded do
     value |> Atom.to_string() |> URI.encode_www_form()
   end
 
+  defp encode_part(value) when is_tuple(value) do
+    raise ArgumentError,
+          "cannot encode tuple #{inspect(value)} with :brackets; " <>
+            "convert it to a map, string, or other primitive before passing it as the body"
+  end
+
   defp encode_part(value) do
     value |> to_string() |> URI.encode_www_form()
   end

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -206,6 +206,9 @@ defmodule Tesla.Middleware.FormUrlencoded do
   end
 
   defp encode_value(value, path) when is_list(value) do
+    # Keyword.keyword?/1 walks the whole list; accepted because form
+    # payloads are small and the alternative (peeking at the head) would
+    # misclassify mixed lists like [{:a, 1}, 2].
     if Keyword.keyword?(value) do
       Enum.flat_map(value, &encode_keyed_entry(&1, path))
     else

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -23,7 +23,7 @@ defmodule Tesla.Middleware.FormUrlencoded do
   end
 
   client = Myclient.client()
-  Myclient.post(client, "/url", %{key: :value})
+  Tesla.post(client, "/url", %{key: :value})
   ```
 
   ## Options
@@ -32,7 +32,7 @@ defmodule Tesla.Middleware.FormUrlencoded do
   - `:encode` - controls how the body is encoded. Accepts:
     - a function (arity 1) for fully custom encoding
     - `:deep_object` — recursive bracket-notation encoder based on
-      OpenAPI's `deepObject` style (see *Serialization Styles* below)
+      OpenAPI's `deepObject` style (see `encode: :deep_object` below)
     - Defaults to `URI.encode_query/1` when omitted.
 
   ## Nested Maps
@@ -40,7 +40,7 @@ defmodule Tesla.Middleware.FormUrlencoded do
   Natively, nested maps are not supported in the body, so
   `%{"foo" => %{"bar" => "baz"}}` won't be encoded and raise an error.
   Support for this specific case is obtained either by setting
-  `encode: :deep_object` (see *Serialization Styles* below) or by
+  `encode: :deep_object` (see `encode: :deep_object` below) or by
   configuring the middleware to encode (and decode) with
   `Plug.Conn.Query`:
 
@@ -56,7 +56,7 @@ defmodule Tesla.Middleware.FormUrlencoded do
   end
 
   client = Myclient.client()
-  Myclient.post(client, "/url", %{key: %{nested: "value"}})
+  Tesla.post(client, "/url", %{key: %{nested: "value"}})
   ```
 
   ## `encode: :deep_object`
@@ -67,8 +67,9 @@ defmodule Tesla.Middleware.FormUrlencoded do
   Stripe, `http_build_query`, and most code-generated SDKs).
 
   ```elixir
-  Tesla.client([{Tesla.Middleware.FormUrlencoded, encode: :deep_object}])
-  |> Tesla.post("/url", %{
+  client = Tesla.client([{Tesla.Middleware.FormUrlencoded, encode: :deep_object}])
+
+  Tesla.post(client, "/url", %{
     expand: ["objects"],
     objects: %{customers: ["cus_123", "cus_456"]}
   })

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -111,12 +111,22 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   Encoding behavior:
 
-  - Maps and structs recurse via `Map.from_struct/1`.
+  - Nested maps recurse.
+  - Nested structs that implement `String.Chars` (e.g. `DateTime`, `Date`,
+    `URI`, `Decimal`) are encoded via `to_string/1`. Structs without a
+    `String.Chars` implementation fall back to `Map.from_struct/1` and
+    recurse like maps. A top-level struct is always unwrapped with
+    `Map.from_struct/1`.
+  - Keyword lists are encoded as nested objects (`parent[key]=value`),
+    not as numerically indexed arrays.
   - `nil` is dropped at every level, including inside lists (indices are
     assigned after filtering).
   - Booleans encode as `"true"` / `"false"`.
   - Atoms encode via `Atom.to_string/1`; everything else via `to_string/1`.
   - Keys and values are escaped with `URI.encode_www_form/1`.
+  - Output ordering follows Elixir map traversal order and is not
+    guaranteed across runs; treat the encoded string as a multiset of
+    pairs, not an ordered sequence.
 
   Decoding remains flat regardless of `:encode`. If you need to decode
   nested form responses, configure `:decode` with `&Plug.Conn.Query.decode/1`.
@@ -190,9 +200,18 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   defp do_encode(data, opts) do
     case Keyword.get(opts, :encode) do
-      nil -> URI.encode_query(data)
-      :deep_object -> encode_deep_object(data)
-      fun when is_function(fun, 1) -> fun.(data)
+      nil ->
+        URI.encode_query(data)
+
+      :deep_object ->
+        encode_deep_object(data)
+
+      fun when is_function(fun, 1) ->
+        fun.(data)
+
+      value ->
+        raise ArgumentError,
+              "unknown :encode option #{inspect(value)}; expected :deep_object or an arity-1 function"
     end
   end
 
@@ -212,8 +231,13 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   defp encode_value(nil, _path), do: []
 
-  defp encode_value(value, path) when is_struct(value),
-    do: encode_value(Map.from_struct(value), path)
+  defp encode_value(value, path) when is_struct(value) do
+    if String.Chars.impl_for(value) do
+      encode_value(to_string(value), path)
+    else
+      encode_value(Map.from_struct(value), path)
+    end
+  end
 
   defp encode_value(value, path) when is_map(value) do
     Enum.flat_map(value, fn {key, nested_value} ->
@@ -222,12 +246,18 @@ defmodule Tesla.Middleware.FormUrlencoded do
   end
 
   defp encode_value(value, path) when is_list(value) do
-    value
-    |> Enum.reject(&is_nil/1)
-    |> Enum.with_index()
-    |> Enum.flat_map(fn {nested_value, index} ->
-      encode_value(nested_value, [index | path])
-    end)
+    if Keyword.keyword?(value) do
+      Enum.flat_map(value, fn {key, nested_value} ->
+        encode_value(nested_value, [key | path])
+      end)
+    else
+      value
+      |> Enum.reject(&is_nil/1)
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {nested_value, index} ->
+        encode_value(nested_value, [index | path])
+      end)
+    end
   end
 
   defp encode_value(value, path) do

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -62,9 +62,9 @@ defmodule Tesla.Middleware.FormUrlencoded do
   ## `encode: :deep_object`
 
   Recursive bracket-notation encoder for nested maps and lists, modeled
-  on OpenAPI's `deepObject` style and extended to arrays with numeric
-  indices (the convention used by Stripe, `http_build_query`, and most
-  code-generated SDKs).
+  on OpenAPI's [`deepObject` style](https://spec.openapis.org/oas/v3.1.0#style-values)
+  and extended to arrays with numeric indices (the convention used by
+  Stripe, `http_build_query`, and most code-generated SDKs).
 
   ```elixir
   Tesla.client([{Tesla.Middleware.FormUrlencoded, encode: :deep_object}])

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -220,8 +220,9 @@ defmodule Tesla.Middleware.FormUrlencoded do
     decoder.(data)
   end
 
-  defp encode_deep_object(data) when is_struct(data),
-    do: encode_deep_object(Map.from_struct(data))
+  defp encode_deep_object(data) when is_struct(data) do
+    encode_deep_object(Map.from_struct(data))
+  end
 
   defp encode_deep_object(data) do
     data
@@ -229,9 +230,13 @@ defmodule Tesla.Middleware.FormUrlencoded do
     |> Enum.join("&")
   end
 
-  defp encode_root_entry({key, value}), do: encode_value(value, [key])
+  defp encode_root_entry({key, value}) do
+    encode_value(value, [key])
+  end
 
-  defp encode_value(nil, _path), do: []
+  defp encode_value(nil, _path) do
+    []
+  end
 
   defp encode_value(value, path) when is_struct(value) do
     if String.Chars.impl_for(value) do
@@ -260,9 +265,13 @@ defmodule Tesla.Middleware.FormUrlencoded do
     ["#{encode_path(path)}=#{encode_part(value)}"]
   end
 
-  defp encode_keyed_entry({key, value}, path), do: encode_value(value, [key | path])
+  defp encode_keyed_entry({key, value}, path) do
+    encode_value(value, [key | path])
+  end
 
-  defp encode_indexed_entry({value, index}, path), do: encode_value(value, [index | path])
+  defp encode_indexed_entry({value, index}, path) do
+    encode_value(value, [index | path])
+  end
 
   defp encode_path(path) do
     [root | rest] = Enum.reverse(path)
@@ -270,12 +279,17 @@ defmodule Tesla.Middleware.FormUrlencoded do
     Enum.reduce(rest, encode_part(root), &append_bracket/2)
   end
 
-  defp append_bracket(part, encoded), do: "#{encoded}[#{encode_part(part)}]"
+  defp append_bracket(part, encoded) do
+    "#{encoded}[#{encode_part(part)}]"
+  end
 
-  defp encode_part(value) when is_atom(value),
-    do: value |> Atom.to_string() |> URI.encode_www_form()
+  defp encode_part(value) when is_atom(value) do
+    value |> Atom.to_string() |> URI.encode_www_form()
+  end
 
-  defp encode_part(value), do: value |> to_string() |> URI.encode_www_form()
+  defp encode_part(value) do
+    value |> to_string() |> URI.encode_www_form()
+  end
 end
 
 defmodule Tesla.Middleware.DecodeFormUrlencoded do

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -102,12 +102,15 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   ```elixir
   # default: Stripe-compatible
-  encode_body(%{active: true}, encode: :brackets)
-  # => "active=true"
+  client = Tesla.client([{Tesla.Middleware.FormUrlencoded, encode: :brackets}])
+  Tesla.post(client, "/url", %{active: true})
+  # body: "active=true"
 
   # opt in to PHP http_build_query parity
-  encode_body(%{active: true}, encode: {:brackets, boolean_as: :integer})
-  # => "active=1"
+  client =
+    Tesla.client([{Tesla.Middleware.FormUrlencoded, encode: {:brackets, boolean_as: :integer}}])
+  Tesla.post(client, "/url", %{active: true})
+  # body: "active=1"
   ```
 
   With `boolean_as: :integer`, the encoder's output matches PHP
@@ -231,8 +234,8 @@ defmodule Tesla.Middleware.FormUrlencoded do
         encode_brackets(data)
 
       {:brackets, sub_opts} when is_list(sub_opts) ->
-        boolean_as = brackets_boolean_as!(sub_opts)
         validate_brackets_opts!(sub_opts)
+        boolean_as = brackets_boolean_as!(sub_opts)
 
         data
         |> normalize_booleans(boolean_as)
@@ -244,7 +247,7 @@ defmodule Tesla.Middleware.FormUrlencoded do
       value ->
         raise ArgumentError,
               "unknown :encode option #{inspect(value)}; expected :brackets, " <>
-                "{:brackets, opts}, or an arity-1 function"
+                "{:brackets, opts} where opts is a keyword list, or an arity-1 function"
     end
   end
 

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -29,14 +29,20 @@ defmodule Tesla.Middleware.FormUrlencoded do
   ## Options
 
   - `:decode` - decoding function, defaults to `URI.decode_query/1`
-  - `:encode` - encoding function, defaults to `URI.encode_query/1`
+  - `:encode` - controls how the body is encoded. Accepts:
+    - a function (arity 1) for fully custom encoding
+    - `:deep_object` — recursive bracket-notation encoder based on
+      OpenAPI's `deepObject` style (see *Serialization Styles* below)
+    - Defaults to `URI.encode_query/1` when omitted.
 
   ## Nested Maps
 
   Natively, nested maps are not supported in the body, so
   `%{"foo" => %{"bar" => "baz"}}` won't be encoded and raise an error.
-  Support for this specific case is obtained by configuring the middleware to
-  encode (and decode) with `Plug.Conn.Query`
+  Support for this specific case is obtained either by setting
+  `encode: :deep_object` (see *Serialization Styles* below) or by
+  configuring the middleware to encode (and decode) with
+  `Plug.Conn.Query`:
 
   ```elixir
   defmodule Myclient do
@@ -52,6 +58,68 @@ defmodule Tesla.Middleware.FormUrlencoded do
   client = Myclient.client()
   Myclient.post(client, "/url", %{key: %{nested: "value"}})
   ```
+
+  ## Serialization Styles
+
+  The `:encode` option supports built-in serialization styles that mirror
+  OpenAPI's Encoding Object `style` field. OpenAPI defines four values:
+  `form` (default), `spaceDelimited`, `pipeDelimited`, and `deepObject`.
+  The middleware currently implements `:deep_object`; the other styles
+  may be added later.
+
+  ### `encode: :deep_object`
+
+  Recursive bracket-notation encoder for bodies that contain maps,
+  structs, or lists. The flat default behavior is unchanged when `:encode`
+  is not set.
+
+  Output shape:
+
+  - Nested maps and structs: `parent[child]=value`.
+  - Lists: `parent[0]=a&parent[1]=b` (numeric indices).
+  - Lists of objects: `items[0][name]=a&items[1][name]=b`.
+
+  OpenAPI defines `deepObject` for object values only and leaves array
+  serialization unspecified; this middleware extends the style to arrays
+  using numeric bracket indices, the convention used by Stripe, PHP's
+  `http_build_query`, and many code-generated SDKs. Bracket characters in
+  keys are emitted literally; only the segments between them are
+  percent-encoded.
+
+  ```elixir
+  defmodule MyClient do
+    def client do
+      Tesla.client([
+        {Tesla.Middleware.FormUrlencoded, encode: :deep_object}
+      ])
+    end
+  end
+
+  body = %{
+    expand: ["objects"],
+    objects: %{customers: ["cus_123", "cus_456"], charges: nil},
+    validation_behavior: :fix
+  }
+
+  MyClient.post(client, "/url", body)
+  # =>
+  # expand[0]=objects
+  # &objects[customers][0]=cus_123
+  # &objects[customers][1]=cus_456
+  # &validation_behavior=fix
+  ```
+
+  Encoding behavior:
+
+  - Maps and structs recurse via `Map.from_struct/1`.
+  - `nil` is dropped at every level, including inside lists (indices are
+    assigned after filtering).
+  - Booleans encode as `"true"` / `"false"`.
+  - Atoms encode via `Atom.to_string/1`; everything else via `to_string/1`.
+  - Keys and values are escaped with `URI.encode_www_form/1`.
+
+  Decoding remains flat regardless of `:encode`. If you need to decode
+  nested form responses, configure `:decode` with `&Plug.Conn.Query.decode/1`.
   """
 
   @behaviour Tesla.Middleware
@@ -121,14 +189,63 @@ defmodule Tesla.Middleware.FormUrlencoded do
   defp decode_body(body, opts), do: do_decode(body, opts)
 
   defp do_encode(data, opts) do
-    encoder = Keyword.get(opts, :encode, &URI.encode_query/1)
-    encoder.(data)
+    case Keyword.get(opts, :encode) do
+      nil -> URI.encode_query(data)
+      :deep_object -> encode_deep_object(data)
+      fun when is_function(fun, 1) -> fun.(data)
+    end
   end
 
   defp do_decode(data, opts) do
     decoder = Keyword.get(opts, :decode, &URI.decode_query/1)
     decoder.(data)
   end
+
+  defp encode_deep_object(data) when is_struct(data),
+    do: encode_deep_object(Map.from_struct(data))
+
+  defp encode_deep_object(data) do
+    data
+    |> Enum.flat_map(fn {key, value} -> encode_value(value, [key]) end)
+    |> Enum.join("&")
+  end
+
+  defp encode_value(nil, _path), do: []
+
+  defp encode_value(value, path) when is_struct(value),
+    do: encode_value(Map.from_struct(value), path)
+
+  defp encode_value(value, path) when is_map(value) do
+    Enum.flat_map(value, fn {key, nested_value} ->
+      encode_value(nested_value, [key | path])
+    end)
+  end
+
+  defp encode_value(value, path) when is_list(value) do
+    value
+    |> Enum.reject(&is_nil/1)
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {nested_value, index} ->
+      encode_value(nested_value, [index | path])
+    end)
+  end
+
+  defp encode_value(value, path) do
+    ["#{encode_path(path)}=#{encode_part(value)}"]
+  end
+
+  defp encode_path(path) do
+    [root | rest] = Enum.reverse(path)
+
+    Enum.reduce(rest, encode_part(root), fn part, encoded ->
+      "#{encoded}[#{encode_part(part)}]"
+    end)
+  end
+
+  defp encode_part(value) when is_atom(value),
+    do: value |> Atom.to_string() |> URI.encode_www_form()
+
+  defp encode_part(value), do: value |> to_string() |> URI.encode_www_form()
 end
 
 defmodule Tesla.Middleware.DecodeFormUrlencoded do

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -33,6 +33,9 @@ defmodule Tesla.Middleware.FormUrlencoded do
     - a function (arity 1) for fully custom encoding
     - `:brackets` — recursive bracket-notation encoder for nested maps
       and lists (see `encode: :brackets` below)
+    - `{:brackets, opts}` — same encoder with sub-options. Currently
+      supports `boolean_as: :string | :integer` (see `encode: :brackets`
+      below).
     - Defaults to `URI.encode_query/1` when omitted.
 
   ## Nested Maps
@@ -61,20 +64,22 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   ## `encode: :brackets`
 
-  Recursive bracket-notation encoder for nested maps and lists.
+  Recursive indexed-bracket form encoder for nested maps and lists.
 
-  Output matches Stripe's official SDKs
-  ([stripe-node](https://github.com/stripe/stripe-node/blob/master/src/utils.ts),
-  [stripe-python](https://github.com/stripe/stripe-python/blob/master/stripe/_encode.py),
-  [stripe-ruby](https://github.com/stripe/stripe-ruby/blob/master/lib/stripe/util.rb))
-  and PHP's `http_build_query`: numeric bracket indices for arrays
-  (`key[0]=a&key[1]=b`) and recursion for deeper nesting
-  (`a[b][c]=1`). This is consistent with OpenAPI's
-  [`deepObject` style](https://spec.openapis.org/oas/v3.1.0#style-values)
-  for the object case (`color[R]=100&color[G]=200`); the OpenAPI 3.0.4
-  and 3.1.1 specs explicitly state that *"the representation of array
-  or object properties is not defined"* under `deepObject`, which this
-  encoder fills in with the conventions above.
+  The output shape — `key[0]=a&key[1]=b` for arrays, `a[b][c]=1` for
+  nested objects — is the de-facto convention used by Stripe, Rack,
+  PHP's `http_build_query`, qs (with `arrayFormat: 'indices'`), and
+  ASP.NET model binding. It is not defined by any RFC. The OpenAPI 3.0.4
+  and 3.1.1 specs cover the object case under [`deepObject`
+  style](https://spec.openapis.org/oas/v3.1.0#style-values) but
+  explicitly state that *"the representation of array or object
+  properties is not defined"*, which this encoder fills in with the
+  conventions above.
+
+  Percent-encoding of keys and values follows
+  `application/x-www-form-urlencoded` (WHATWG URL Standard / PHP's
+  default `PHP_QUERY_RFC1738`): spaces become `+`, reserved characters
+  become `%XX`.
 
   ```elixir
   client = Tesla.client([{Tesla.Middleware.FormUrlencoded, encode: :brackets}])
@@ -86,11 +91,63 @@ defmodule Tesla.Middleware.FormUrlencoded do
   # body: "expand[0]=objects&objects[customers][0]=cus_123&objects[customers][1]=cus_456"
   ```
 
-  Behavior worth knowing:
+  ### Booleans (`boolean_as`)
 
-  - `nil` map values are dropped.
-  - `nil` list elements are dropped but the original index is preserved
-    (`[a, nil, b]` → `[0]=a&[2]=b`), matching `stripe-node`.
+  Booleans default to the lowercase strings `true` / `false`, which is
+  the wire format required by Stripe's V2 API (see [stripe-python PR
+  #1499](https://github.com/stripe/stripe-python/pull/1499)) and used by
+  every official Stripe SDK. PHP's `http_build_query` would instead emit
+  `1` for `true` and `0` for `false`; opt in to that behavior with
+  `boolean_as: :integer`:
+
+  ```elixir
+  # default: Stripe-compatible
+  encode_body(%{active: true}, encode: :brackets)
+  # => "active=true"
+
+  # opt in to PHP http_build_query parity
+  encode_body(%{active: true}, encode: {:brackets, boolean_as: :integer})
+  # => "active=1"
+  ```
+
+  With `boolean_as: :integer`, the encoder's output matches PHP
+  `http_build_query` byte-for-byte (after URL-decoding `%5B`/`%5D` to
+  literal `[`/`]`) across the verified test corpus. Use `:string`
+  (default) for Stripe and most modern APIs; use `:integer` only when
+  targeting a server that specifically requires the PHP-native form.
+
+  ### `nil` vs empty string
+
+  The encoder distinguishes "don't include this field" from "include the
+  field with an empty value". This matches the three-state semantics
+  exposed by Stripe's update endpoints (and PHP's `http_build_query`):
+
+  | Input value | Wire output | Typical API meaning on update |
+  | --- | --- | --- |
+  | `nil` | (nothing emitted) | Field is absent from the request — the server leaves the existing value untouched. |
+  | `""` (empty string) | `key=` | Field is present with an empty value — the server clears or unsets it. |
+  | any other value | `key=value` | Field is set to the given value. |
+
+  Use `nil` to mean "leave this field alone" and `""` to mean "clear this
+  field". For example, on `POST /v1/customers/cus_X`:
+
+  ```elixir
+  # Leaves customer.metadata.foo untouched (field not in request):
+  %{metadata: %{plan: "pro"}}
+  # → metadata[plan]=pro
+
+  # Deletes the foo key from customer.metadata (sent with empty value):
+  %{metadata: %{foo: ""}}
+  # → metadata[foo]=
+  ```
+
+  Inside lists the same rule applies element-by-element: `nil` elements
+  are dropped while the index of remaining elements is preserved
+  (`[a, nil, b]` → `[0]=a&[2]=b`, matching PHP `http_build_query`), and
+  `""` elements are emitted as `key[i]=`.
+
+  ### Other behavior worth knowing
+
   - Keyword lists encode as objects (`parent[key]=value`), not arrays.
   - Structs raise `ArgumentError` — convert them with `Map.from_struct/1`
     or `to_string/1` first.
@@ -173,14 +230,65 @@ defmodule Tesla.Middleware.FormUrlencoded do
       :brackets ->
         encode_brackets(data)
 
+      {:brackets, sub_opts} when is_list(sub_opts) ->
+        boolean_as = brackets_boolean_as!(sub_opts)
+        validate_brackets_opts!(sub_opts)
+
+        data
+        |> normalize_booleans(boolean_as)
+        |> encode_brackets()
+
       fun when is_function(fun, 1) ->
         fun.(data)
 
       value ->
         raise ArgumentError,
-              "unknown :encode option #{inspect(value)}; expected :brackets or an arity-1 function"
+              "unknown :encode option #{inspect(value)}; expected :brackets, " <>
+                "{:brackets, opts}, or an arity-1 function"
     end
   end
+
+  defp brackets_boolean_as!(sub_opts) do
+    case Keyword.get(sub_opts, :boolean_as, :string) do
+      :string ->
+        :string
+
+      :integer ->
+        :integer
+
+      other ->
+        raise ArgumentError,
+              "invalid :boolean_as #{inspect(other)} for :brackets encoder; " <>
+                "expected :string or :integer"
+    end
+  end
+
+  defp validate_brackets_opts!(sub_opts) do
+    case Keyword.keys(sub_opts) -- [:boolean_as] do
+      [] ->
+        :ok
+
+      unknown ->
+        raise ArgumentError,
+              "unknown option(s) #{inspect(unknown)} for :brackets encoder; " <>
+                "expected :boolean_as"
+    end
+  end
+
+  defp normalize_booleans(data, :string), do: data
+  defp normalize_booleans(data, :integer), do: deep_map_booleans(data)
+
+  defp deep_map_booleans(true), do: "1"
+  defp deep_map_booleans(false), do: "0"
+  defp deep_map_booleans(%_{} = struct), do: struct
+
+  defp deep_map_booleans(map) when is_map(map) do
+    Map.new(map, fn {k, v} -> {k, deep_map_booleans(v)} end)
+  end
+
+  defp deep_map_booleans({k, v}), do: {k, deep_map_booleans(v)}
+  defp deep_map_booleans(list) when is_list(list), do: Enum.map(list, &deep_map_booleans/1)
+  defp deep_map_booleans(other), do: other
 
   defp do_decode(data, opts) do
     decoder = Keyword.get(opts, :decode, &URI.decode_query/1)

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -154,7 +154,12 @@ defmodule Tesla.Middleware.FormUrlencoded do
   - Keyword lists encode as objects (`parent[key]=value`), not arrays.
   - Structs raise `ArgumentError` — convert them with `Map.from_struct/1`
     or `to_string/1` first.
-  - Output order is not guaranteed (maps don't preserve insertion order).
+  - Empty lists and empty maps emit nothing, which means the parent key
+    disappears entirely: `%{ids: []}` → `""`, and `%{user: %{tags: []}}`
+    → `""`. This matches PHP `http_build_query`. Send `""` to clear a
+    field on Stripe-style update endpoints.
+  - Map keys are not ordered; keyword lists preserve the order you give
+    them.
   - Decoding stays flat; pair with `decode: &Plug.Conn.Query.decode/1` for
     symmetric round-trips.
   """
@@ -298,16 +303,18 @@ defmodule Tesla.Middleware.FormUrlencoded do
     decoder.(data)
   end
 
-  defp encode_brackets(%module{}) do
-    raise ArgumentError,
-          "cannot encode #{inspect(module)} struct with :brackets; " <>
-            "convert it to a map, string, or other primitive before passing it as the body"
-  end
+  defp encode_brackets(%module{}), do: raise_struct!(module)
 
-  defp encode_brackets(data) do
+  defp encode_brackets(data) when is_map(data) or is_list(data) do
     data
     |> Enum.flat_map(&encode_root_entry/1)
     |> Enum.join("&")
+  end
+
+  defp encode_brackets(data) do
+    raise ArgumentError,
+          "cannot encode #{inspect(data)} with :brackets; " <>
+            "expected a map or keyword list at the root"
   end
 
   defp encode_root_entry({key, value}) do
@@ -318,11 +325,7 @@ defmodule Tesla.Middleware.FormUrlencoded do
     []
   end
 
-  defp encode_value(%module{}, _path) do
-    raise ArgumentError,
-          "cannot encode #{inspect(module)} struct with :brackets; " <>
-            "convert it to a map, string, or other primitive before passing it as the body"
-  end
+  defp encode_value(%module{}, _path), do: raise_struct!(module)
 
   defp encode_value(value, path) when is_map(value) do
     Enum.flat_map(value, &encode_keyed_entry(&1, path))
@@ -381,6 +384,12 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   defp encode_part(value) do
     value |> to_string() |> URI.encode_www_form()
+  end
+
+  defp raise_struct!(module) do
+    raise ArgumentError,
+          "cannot encode #{inspect(module)} struct with :brackets; " <>
+            "convert it to a map, string, or other primitive before passing it as the body"
   end
 end
 

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -218,8 +218,10 @@ defmodule Tesla.Middleware.FormUrlencoded do
     decoder.(data)
   end
 
-  defp encode_deep_object(data) when is_struct(data) do
-    raise ArgumentError, struct_error_message(data)
+  defp encode_deep_object(%module{}) do
+    raise ArgumentError,
+          "cannot encode #{inspect(module)} struct with :deep_object; " <>
+            "convert it to a map, string, or other primitive before passing it as the body"
   end
 
   defp encode_deep_object(data) do
@@ -236,8 +238,10 @@ defmodule Tesla.Middleware.FormUrlencoded do
     []
   end
 
-  defp encode_value(value, _path) when is_struct(value) do
-    raise ArgumentError, struct_error_message(value)
+  defp encode_value(%module{}, _path) do
+    raise ArgumentError,
+          "cannot encode #{inspect(module)} struct with :deep_object; " <>
+            "convert it to a map, string, or other primitive before passing it as the body"
   end
 
   defp encode_value(value, path) when is_map(value) do
@@ -283,11 +287,6 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   defp encode_part(value) do
     value |> to_string() |> URI.encode_www_form()
-  end
-
-  defp struct_error_message(%module{}) do
-    "cannot encode #{inspect(module)} struct with :deep_object; " <>
-      "convert it to a map, string, or other primitive before passing it as the body"
   end
 end
 

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -31,8 +31,8 @@ defmodule Tesla.Middleware.FormUrlencoded do
   - `:decode` - decoding function, defaults to `URI.decode_query/1`
   - `:encode` - controls how the body is encoded. Accepts:
     - a function (arity 1) for fully custom encoding
-    - `:deep_object` — recursive bracket-notation encoder based on
-      OpenAPI's `deepObject` style (see `encode: :deep_object` below)
+    - `:brackets` — recursive bracket-notation encoder for nested maps
+      and lists (see `encode: :brackets` below)
     - Defaults to `URI.encode_query/1` when omitted.
 
   ## Nested Maps
@@ -40,7 +40,7 @@ defmodule Tesla.Middleware.FormUrlencoded do
   Natively, nested maps are not supported in the body, so
   `%{"foo" => %{"bar" => "baz"}}` won't be encoded and raise an error.
   Support for this specific case is obtained either by setting
-  `encode: :deep_object` (see `encode: :deep_object` below) or by
+  `encode: :brackets` (see `encode: :brackets` below) or by
   configuring the middleware to encode (and decode) with
   `Plug.Conn.Query`:
 
@@ -59,23 +59,25 @@ defmodule Tesla.Middleware.FormUrlencoded do
   Tesla.post(client, "/url", %{key: %{nested: "value"}})
   ```
 
-  ## `encode: :deep_object`
+  ## `encode: :brackets`
 
   Recursive bracket-notation encoder for nested maps and lists.
 
-  Uses OpenAPI's [`deepObject` style](https://spec.openapis.org/oas/v3.1.0#style-values)
-  for the object case (e.g. `color[R]=100&color[G]=200`). OpenAPI 3.0.4
-  and 3.1.1 explicitly state that *"the representation of array or
-  object properties is not defined"* under `deepObject`, so this encoder
-  follows the convention used by Stripe's official SDKs
+  Output matches Stripe's official SDKs
   ([stripe-node](https://github.com/stripe/stripe-node/blob/master/src/utils.ts),
   [stripe-python](https://github.com/stripe/stripe-python/blob/master/stripe/_encode.py),
   [stripe-ruby](https://github.com/stripe/stripe-ruby/blob/master/lib/stripe/util.rb))
-  and PHP's `http_build_query`: numeric bracket indices for arrays and
-  recursion for deeper nesting.
+  and PHP's `http_build_query`: numeric bracket indices for arrays
+  (`key[0]=a&key[1]=b`) and recursion for deeper nesting
+  (`a[b][c]=1`). This is consistent with OpenAPI's
+  [`deepObject` style](https://spec.openapis.org/oas/v3.1.0#style-values)
+  for the object case (`color[R]=100&color[G]=200`); the OpenAPI 3.0.4
+  and 3.1.1 specs explicitly state that *"the representation of array
+  or object properties is not defined"* under `deepObject`, which this
+  encoder fills in with the conventions above.
 
   ```elixir
-  client = Tesla.client([{Tesla.Middleware.FormUrlencoded, encode: :deep_object}])
+  client = Tesla.client([{Tesla.Middleware.FormUrlencoded, encode: :brackets}])
 
   Tesla.post(client, "/url", %{
     expand: ["objects"],
@@ -168,15 +170,15 @@ defmodule Tesla.Middleware.FormUrlencoded do
       nil ->
         URI.encode_query(data)
 
-      :deep_object ->
-        encode_deep_object(data)
+      :brackets ->
+        encode_brackets(data)
 
       fun when is_function(fun, 1) ->
         fun.(data)
 
       value ->
         raise ArgumentError,
-              "unknown :encode option #{inspect(value)}; expected :deep_object or an arity-1 function"
+              "unknown :encode option #{inspect(value)}; expected :brackets or an arity-1 function"
     end
   end
 
@@ -185,13 +187,13 @@ defmodule Tesla.Middleware.FormUrlencoded do
     decoder.(data)
   end
 
-  defp encode_deep_object(%module{}) do
+  defp encode_brackets(%module{}) do
     raise ArgumentError,
-          "cannot encode #{inspect(module)} struct with :deep_object; " <>
+          "cannot encode #{inspect(module)} struct with :brackets; " <>
             "convert it to a map, string, or other primitive before passing it as the body"
   end
 
-  defp encode_deep_object(data) do
+  defp encode_brackets(data) do
     data
     |> Enum.flat_map(&encode_root_entry/1)
     |> Enum.join("&")
@@ -207,7 +209,7 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   defp encode_value(%module{}, _path) do
     raise ArgumentError,
-          "cannot encode #{inspect(module)} struct with :deep_object; " <>
+          "cannot encode #{inspect(module)} struct with :brackets; " <>
             "convert it to a map, string, or other primitive before passing it as the body"
   end
 

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -151,7 +151,10 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   ### Other behavior worth knowing
 
-  - Keyword lists encode as objects (`parent[key]=value`), not arrays.
+  - Keyword lists (atom-keyed) encode as objects (`parent[key]=value`),
+    not arrays. String-keyed proplists like `[{"a", 1}]` are not detected
+    as keyword lists and will raise the tuple error — convert them to a
+    map first.
   - Structs raise `ArgumentError` — convert them with `Map.from_struct/1`
     or `to_string/1` first.
   - Empty lists and empty maps emit nothing, which means the parent key
@@ -160,8 +163,10 @@ defmodule Tesla.Middleware.FormUrlencoded do
     field on Stripe-style update endpoints.
   - Map keys are not ordered; keyword lists preserve the order you give
     them.
-  - Decoding stays flat; pair with `decode: &Plug.Conn.Query.decode/1` for
-    symmetric round-trips.
+  - Decoding stays flat. `Plug.Conn.Query.decode/1` will parse the
+    bracket keys into nested maps, but indexed lists come back as maps
+    keyed by string indices (`"0"`, `"1"`, …), not as Elixir lists, so
+    the round-trip is not symmetric.
   """
 
   @behaviour Tesla.Middleware
@@ -294,7 +299,7 @@ defmodule Tesla.Middleware.FormUrlencoded do
     Map.new(map, fn {k, v} -> {k, deep_map_booleans(v)} end)
   end
 
-  defp deep_map_booleans({k, v}), do: {k, deep_map_booleans(v)}
+  defp deep_map_booleans({k, v}) when is_atom(k), do: {k, deep_map_booleans(v)}
   defp deep_map_booleans(list) when is_list(list), do: Enum.map(list, &deep_map_booleans/1)
   defp deep_map_booleans(other), do: other
 

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -134,6 +134,10 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
     end
   end
 
+  defmodule Profile do
+    defstruct [:name, :age]
+  end
+
   describe "encode: :brackets end-to-end through middleware" do
     test "encodes nested bodies with bracket-indexed lists" do
       body = %{
@@ -155,10 +159,6 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
   end
 
   describe "encode: :brackets encoder behavior" do
-    defmodule Profile do
-      defstruct [:name, :age]
-    end
-
     test "indexes flat list items" do
       assert encode_body(%{ids: ["a", "b"]}, encode: :brackets) == "ids[0]=a&ids[1]=b"
     end
@@ -252,9 +252,27 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
       end
     end
 
-    test "string-keyed proplist is not treated as a keyword list and raises tuple error" do
+    test "raises clear error for non-keyword list at the root" do
+      assert_raise ArgumentError, ~r/cannot encode \[1, 2, 3\] with :brackets/, fn ->
+        encode_body([1, 2, 3], encode: :brackets)
+      end
+    end
+
+    test "raises clear error for mixed list at the root" do
+      assert_raise ArgumentError, ~r/cannot encode \[\{:a, 1\}, 2\] with :brackets/, fn ->
+        encode_body([{:a, 1}, 2], encode: :brackets)
+      end
+    end
+
+    test "list of tuples inside a map raises the tuple error (use a map for nesting)" do
       assert_raise ArgumentError, ~r/cannot encode tuple \{"a", 1\}/, fn ->
         encode_body(%{user: [{"a", 1}, {"b", 2}]}, encode: :brackets)
+      end
+    end
+
+    test "keyword list inside a map raises the tuple error (use a map for nesting)" do
+      assert_raise ArgumentError, ~r/cannot encode tuple \{:role, "admin"\}/, fn ->
+        encode_body(%{filter: [role: "admin"]}, encode: :brackets)
       end
     end
 
@@ -264,28 +282,22 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
       end
     end
 
-    test "boolean_as: :integer still rewrites booleans inside atom-keyed keyword lists" do
-      assert encode_body(%{filter: [active: true, admin: false]},
-               encode: {:brackets, boolean_as: :integer}
-             )
-             |> as_pairs() ==
-               MapSet.new(["filter[active]=1", "filter[admin]=0"])
-    end
-
     test "keyword list at top level encodes in given order" do
       assert encode_body([a: 1, b: 2, c: 3], encode: :brackets) == "a=1&b=2&c=3"
     end
 
-    test "keyword list inside map encodes as nested object" do
-      assert encode_body(%{filter: [role: "admin", active: true]}, encode: :brackets)
-             |> as_pairs() ==
-               MapSet.new(["filter[role]=admin", "filter[active]=true"])
+    test "list of 2-tuples at top level preserves order" do
+      assert encode_body([{"a", 1}, {"b", 2}, {"c", 3}], encode: :brackets) == "a=1&b=2&c=3"
     end
 
-    test "keyword list inside array encodes as nested object" do
-      assert encode_body(%{users: [[name: "a"], [name: "b"]]}, encode: :brackets)
-             |> as_pairs() ==
-               MapSet.new(["users[0][name]=a", "users[1][name]=b"])
+    test "list of 2-tuples at top level allows duplicate keys" do
+      assert encode_body([{"tag", "a"}, {"tag", "b"}, {"tag", "c"}], encode: :brackets) ==
+               "tag=a&tag=b&tag=c"
+    end
+
+    test "list of 2-tuples at top level allows non-atom keys mixed with values" do
+      assert encode_body([{"a b", "hello world"}, {"c", "d"}], encode: :brackets) ==
+               "a+b=hello+world&c=d"
     end
 
     test "deeply nested map+list mix" do
@@ -394,16 +406,14 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
     ]
 
     for {label, input, expected} <- @php_corpus do
-      @input input
-      @expected expected
       test "matches PHP http_build_query: #{label}" do
         actual =
-          %Tesla.Env{body: @input}
+          %Tesla.Env{body: unquote(Macro.escape(input))}
           |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
           |> Map.fetch!(:body)
           |> sort_pairs()
 
-        assert actual == @expected
+        assert actual == unquote(expected)
       end
     end
 
@@ -505,18 +515,16 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
     ]
 
     for {label, input, expected} <- @php_boolean_corpus do
-      @input input
-      @expected expected
       test "matches PHP http_build_query with boolean_as: :integer: #{label}" do
         actual =
-          %Tesla.Env{body: @input}
+          %Tesla.Env{body: unquote(Macro.escape(input))}
           |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
           |> Map.fetch!(:body)
           |> String.split("&")
           |> Enum.sort()
           |> Enum.join("&")
 
-        assert actual == @expected
+        assert actual == unquote(expected)
       end
     end
   end

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -377,26 +377,118 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
       end
     end
 
-    test "boolean true encodes as 'true' (PHP emits '1')" do
+    test "default: boolean true encodes as 'true' (Stripe V2 convention)" do
       assert (%Tesla.Env{body: %{"key" => true}}
               |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
               |> Map.fetch!(:body)) == "key=true"
     end
 
-    test "boolean false encodes as 'false' (PHP emits '0')" do
+    test "default: boolean false encodes as 'false' (Stripe V2 convention)" do
       assert (%Tesla.Env{body: %{"key" => false}}
               |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
               |> Map.fetch!(:body)) == "key=false"
     end
 
-    test "list of booleans uses true/false (PHP emits 1/0)" do
+    test "default: list of booleans uses true/false" do
       assert (%Tesla.Env{body: %{"flags" => [true, false, true]}}
               |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
               |> Map.fetch!(:body)) == "flags[0]=true&flags[1]=false&flags[2]=true"
     end
 
+    test "boolean_as: :string is identical to the default" do
+      assert (%Tesla.Env{body: %{"key" => true}}
+              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :string})
+              |> Map.fetch!(:body)) == "key=true"
+    end
+
+    test "boolean_as: :integer opts into PHP http_build_query parity (true → 1)" do
+      assert (%Tesla.Env{body: %{"key" => true}}
+              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
+              |> Map.fetch!(:body)) == "key=1"
+    end
+
+    test "boolean_as: :integer opts into PHP http_build_query parity (false → 0)" do
+      assert (%Tesla.Env{body: %{"key" => false}}
+              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
+              |> Map.fetch!(:body)) == "key=0"
+    end
+
+    test "boolean_as: :integer encodes a list of booleans as 1/0 (matches PHP exactly)" do
+      assert (%Tesla.Env{body: %{"flags" => [true, false, true]}}
+              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
+              |> Map.fetch!(:body)) == "flags[0]=1&flags[1]=0&flags[2]=1"
+    end
+
+    test "boolean_as: :integer recurses into nested maps" do
+      assert (%Tesla.Env{body: %{"user" => %{"active" => true, "verified" => false}}}
+              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
+              |> Map.fetch!(:body)
+              |> sort_pairs()) == "user[active]=1&user[verified]=0"
+    end
+
+    test "boolean_as: :integer recurses into lists of objects" do
+      assert (%Tesla.Env{body: %{"items" => [%{"flag" => true}, %{"flag" => false}]}}
+              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
+              |> Map.fetch!(:body)) == "items[0][flag]=1&items[1][flag]=0"
+    end
+
+    test "boolean_as: :integer leaves non-boolean values untouched" do
+      assert (%Tesla.Env{body: %{"name" => "alice", "age" => 30, "score" => 1.5, "tag" => :ok}}
+              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
+              |> Map.fetch!(:body)
+              |> sort_pairs()) == "age=30&name=alice&score=1.5&tag=ok"
+    end
+
+    test "{:brackets, []} with no sub-options behaves like :brackets" do
+      assert (%Tesla.Env{body: %{"key" => true}}
+              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, []})
+              |> Map.fetch!(:body)) == "key=true"
+    end
+
+    test "invalid :boolean_as value raises" do
+      assert_raise ArgumentError, ~r/invalid :boolean_as :nope/, fn ->
+        %Tesla.Env{body: %{"k" => true}}
+        |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :nope})
+      end
+    end
+
+    test "unknown sub-option key raises" do
+      assert_raise ArgumentError, ~r/unknown option\(s\) \[:weird\]/, fn ->
+        %Tesla.Env{body: %{"k" => true}}
+        |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, weird: true})
+      end
+    end
+
     defp sort_pairs(""), do: ""
     defp sort_pairs(encoded), do: encoded |> String.split("&") |> Enum.sort() |> Enum.join("&")
+  end
+
+  describe "encode: {:brackets, boolean_as: :integer} full PHP parity" do
+    # The three cases that diverged from PHP under the default Stripe-flavored
+    # boolean handling. With boolean_as: :integer, output matches PHP
+    # http_build_query byte-for-byte (after the standard %5B/%5D → [/] decode
+    # and top-level pair sort applied in the main parity corpus above).
+    @php_boolean_corpus [
+      {"scalar/bool_true", %{"key" => true}, "key=1"},
+      {"scalar/bool_false", %{"key" => false}, "key=0"},
+      {"list/of_bools", %{"flags" => [true, false, true]}, "flags[0]=1&flags[1]=0&flags[2]=1"}
+    ]
+
+    for {label, input, expected} <- @php_boolean_corpus do
+      @input input
+      @expected expected
+      test "matches PHP http_build_query with boolean_as: :integer: #{label}" do
+        actual =
+          %Tesla.Env{body: @input}
+          |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
+          |> Map.fetch!(:body)
+          |> String.split("&")
+          |> Enum.sort()
+          |> Enum.join("&")
+
+        assert actual == @expected
+      end
+    end
   end
 
   describe "Encode / Decode" do

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -124,6 +124,129 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
     assert env.body == "decodedbody"
   end
 
+  describe "encode: :deep_object end-to-end through middleware" do
+    defmodule NestedClient do
+      use Tesla
+
+      plug Tesla.Middleware.FormUrlencoded, encode: :deep_object
+
+      adapter fn env ->
+        {:ok, %{env | status: 201, headers: [{"content-type", "text/html"}], body: env.body}}
+      end
+    end
+
+    test "encodes nested bodies with bracket-indexed lists" do
+      body = %{
+        expand: ["objects"],
+        objects: %{customers: ["cus_123", "cus_456"]},
+        validation_behavior: :fix
+      }
+
+      assert {:ok, env} = NestedClient.post("/post", body)
+
+      assert env.body |> String.split("&") |> MapSet.new() ==
+               MapSet.new([
+                 "expand[0]=objects",
+                 "objects[customers][0]=cus_123",
+                 "objects[customers][1]=cus_456",
+                 "validation_behavior=fix"
+               ])
+    end
+  end
+
+  describe "encode: :deep_object encoder behavior" do
+    defmodule Profile do
+      defstruct [:name, :age]
+    end
+
+    test "indexes flat list items" do
+      assert encode_body(%{ids: ["a", "b"]}, encode: :deep_object) == "ids[0]=a&ids[1]=b"
+    end
+
+    test "brackets nested map keys" do
+      assert encode_body(%{user: %{name: "a"}}, encode: :deep_object) == "user[name]=a"
+    end
+
+    test "indexes lists of objects" do
+      assert encode_body(%{users: [%{name: "a"}, %{name: "b"}]}, encode: :deep_object)
+             |> as_pairs() ==
+               MapSet.new(["users[0][name]=a", "users[1][name]=b"])
+    end
+
+    test "drops nil at the top level" do
+      assert encode_body(%{a: 1, b: nil, c: 2}, encode: :deep_object) |> as_pairs() ==
+               MapSet.new(["a=1", "c=2"])
+    end
+
+    test "drops nil inside nested maps" do
+      assert encode_body(%{user: %{name: "a", email: nil}}, encode: :deep_object) ==
+               "user[name]=a"
+    end
+
+    test "drops nil from lists and renumbers indices" do
+      assert encode_body(%{ids: [1, nil, 2, nil, 3]}, encode: :deep_object) ==
+               "ids[0]=1&ids[1]=2&ids[2]=3"
+    end
+
+    test "encodes booleans as true/false" do
+      assert encode_body(%{a: true, b: false}, encode: :deep_object) |> as_pairs() ==
+               MapSet.new(["a=true", "b=false"])
+    end
+
+    test "encodes atom values via Atom.to_string/1" do
+      assert encode_body(%{state: :active}, encode: :deep_object) == "state=active"
+    end
+
+    test "encodes integers and floats" do
+      assert encode_body(%{count: 42, ratio: 1.5}, encode: :deep_object) |> as_pairs() ==
+               MapSet.new(["count=42", "ratio=1.5"])
+    end
+
+    test "URI-encodes special characters in values" do
+      assert encode_body(%{q: "a&b=c%d e"}, encode: :deep_object) == "q=a%26b%3Dc%25d+e"
+    end
+
+    test "URI-encodes special characters in keys" do
+      assert encode_body(%{"weird key" => "v"}, encode: :deep_object) == "weird+key=v"
+    end
+
+    test "unwraps top-level structs via Map.from_struct/1" do
+      assert encode_body(%Profile{name: "Alice", age: 30}, encode: :deep_object) |> as_pairs() ==
+               MapSet.new(["name=Alice", "age=30"])
+    end
+
+    test "unwraps nested structs" do
+      assert encode_body(%{profile: %Profile{name: "Alice", age: 30}}, encode: :deep_object)
+             |> as_pairs() ==
+               MapSet.new(["profile[name]=Alice", "profile[age]=30"])
+    end
+
+    test "empty map encodes to empty string" do
+      assert encode_body(%{}, encode: :deep_object) == ""
+    end
+
+    test "empty list value emits nothing" do
+      assert encode_body(%{ids: []}, encode: :deep_object) == ""
+    end
+
+    test "keyword list at top level encodes in given order" do
+      assert encode_body([a: 1, b: 2, c: 3], encode: :deep_object) == "a=1&b=2&c=3"
+    end
+
+    test "deeply nested map+list mix" do
+      assert encode_body(%{a: %{b: [%{c: 1}, %{c: 2}]}}, encode: :deep_object) |> as_pairs() ==
+               MapSet.new(["a[b][0][c]=1", "a[b][1][c]=2"])
+    end
+
+    defp encode_body(body, opts) do
+      %Tesla.Env{body: body}
+      |> Tesla.Middleware.FormUrlencoded.encode(opts)
+      |> Map.fetch!(:body)
+    end
+
+    defp as_pairs(encoded), do: encoded |> String.split("&") |> MapSet.new()
+  end
+
   describe "Encode / Decode" do
     defmodule EncodeDecodeFormUrlencodedClient do
       use Tesla

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -491,6 +491,28 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
     end
   end
 
+  describe "encode: :brackets wire format is parseable" do
+    test "URI.decode_query round-trips bracket-keyed pairs" do
+      body = %{
+        "expand" => ["objects"],
+        "objects" => %{"customers" => ["cus_123", "cus_456"]},
+        "validation_behavior" => "fix"
+      }
+
+      encoded =
+        %Tesla.Env{body: body}
+        |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
+        |> Map.fetch!(:body)
+
+      assert URI.decode_query(encoded) == %{
+               "expand[0]" => "objects",
+               "objects[customers][0]" => "cus_123",
+               "objects[customers][1]" => "cus_456",
+               "validation_behavior" => "fix"
+             }
+    end
+  end
+
   describe "Encode / Decode" do
     defmodule EncodeDecodeFormUrlencodedClient do
       use Tesla

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -210,31 +210,22 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
       assert encode_body(%{"weird key" => "v"}, encode: :deep_object) == "weird+key=v"
     end
 
-    test "unwraps top-level structs via Map.from_struct/1" do
-      assert encode_body(%Profile{name: "Alice", age: 30}, encode: :deep_object) |> as_pairs() ==
-               MapSet.new(["name=Alice", "age=30"])
+    test "raises on top-level struct" do
+      assert_raise ArgumentError, ~r/cannot encode .*Profile struct/, fn ->
+        encode_body(%Profile{name: "Alice", age: 30}, encode: :deep_object)
+      end
     end
 
-    test "unwraps nested structs without String.Chars" do
-      assert encode_body(%{profile: %Profile{name: "Alice", age: 30}}, encode: :deep_object)
-             |> as_pairs() ==
-               MapSet.new(["profile[name]=Alice", "profile[age]=30"])
+    test "raises on nested struct" do
+      assert_raise ArgumentError, ~r/cannot encode DateTime struct/, fn ->
+        encode_body(%{at: ~U[2024-01-02 03:04:05Z]}, encode: :deep_object)
+      end
     end
 
-    test "stringifies nested structs that implement String.Chars" do
-      assert encode_body(%{day: ~D[2024-01-02]}, encode: :deep_object) ==
-               "day=2024-01-02"
-
-      assert encode_body(%{at: ~U[2024-01-02 03:04:05Z]}, encode: :deep_object) ==
-               "at=2024-01-02+03%3A04%3A05Z"
-
-      assert encode_body(%{target: URI.parse("https://example.com/p?x=1")}, encode: :deep_object) ==
-               "target=https%3A%2F%2Fexample.com%2Fp%3Fx%3D1"
-    end
-
-    test "stringifies String.Chars structs inside lists" do
-      assert encode_body(%{days: [~D[2024-01-01], ~D[2024-01-02]]}, encode: :deep_object) ==
-               "days[0]=2024-01-01&days[1]=2024-01-02"
+    test "raises on struct inside a list" do
+      assert_raise ArgumentError, ~r/cannot encode Date struct/, fn ->
+        encode_body(%{days: [~D[2024-01-01], ~D[2024-01-02]]}, encode: :deep_object)
+      end
     end
 
     test "empty map encodes to empty string" do

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -252,6 +252,26 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
       end
     end
 
+    test "string-keyed proplist is not treated as a keyword list and raises tuple error" do
+      assert_raise ArgumentError, ~r/cannot encode tuple \{"a", 1\}/, fn ->
+        encode_body(%{user: [{"a", 1}, {"b", 2}]}, encode: :brackets)
+      end
+    end
+
+    test "boolean_as: :integer does not rewrite arbitrary 2-tuple values before erroring" do
+      assert_raise ArgumentError, ~r/cannot encode tuple \{1, true\}/, fn ->
+        encode_body(%{point: {1, true}}, encode: {:brackets, boolean_as: :integer})
+      end
+    end
+
+    test "boolean_as: :integer still rewrites booleans inside atom-keyed keyword lists" do
+      assert encode_body(%{filter: [active: true, admin: false]},
+               encode: {:brackets, boolean_as: :integer}
+             )
+             |> as_pairs() ==
+               MapSet.new(["filter[active]=1", "filter[admin]=0"])
+    end
+
     test "keyword list at top level encodes in given order" do
       assert encode_body([a: 1, b: 2, c: 3], encode: :brackets) == "a=1&b=2&c=3"
     end

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -228,6 +228,12 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
       end
     end
 
+    test "raises on tuple value with a clear error" do
+      assert_raise ArgumentError, ~r/cannot encode tuple \{1, 2\}/, fn ->
+        encode_body(%{point: {1, 2}}, encode: :brackets)
+      end
+    end
+
     test "empty map encodes to empty string" do
       assert encode_body(%{}, encode: :brackets) == ""
     end

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -183,9 +183,9 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
                "user[name]=a"
     end
 
-    test "drops nil from lists and renumbers indices" do
+    test "drops nil from lists and preserves original indices" do
       assert encode_body(%{ids: [1, nil, 2, nil, 3]}, encode: :deep_object) ==
-               "ids[0]=1&ids[1]=2&ids[2]=3"
+               "ids[0]=1&ids[2]=2&ids[4]=3"
     end
 
     test "encodes booleans as true/false" do

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -215,10 +215,26 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
                MapSet.new(["name=Alice", "age=30"])
     end
 
-    test "unwraps nested structs" do
+    test "unwraps nested structs without String.Chars" do
       assert encode_body(%{profile: %Profile{name: "Alice", age: 30}}, encode: :deep_object)
              |> as_pairs() ==
                MapSet.new(["profile[name]=Alice", "profile[age]=30"])
+    end
+
+    test "stringifies nested structs that implement String.Chars" do
+      assert encode_body(%{day: ~D[2024-01-02]}, encode: :deep_object) ==
+               "day=2024-01-02"
+
+      assert encode_body(%{at: ~U[2024-01-02 03:04:05Z]}, encode: :deep_object) ==
+               "at=2024-01-02+03%3A04%3A05Z"
+
+      assert encode_body(%{target: URI.parse("https://example.com/p?x=1")}, encode: :deep_object) ==
+               "target=https%3A%2F%2Fexample.com%2Fp%3Fx%3D1"
+    end
+
+    test "stringifies String.Chars structs inside lists" do
+      assert encode_body(%{days: [~D[2024-01-01], ~D[2024-01-02]]}, encode: :deep_object) ==
+               "days[0]=2024-01-01&days[1]=2024-01-02"
     end
 
     test "empty map encodes to empty string" do
@@ -233,9 +249,27 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
       assert encode_body([a: 1, b: 2, c: 3], encode: :deep_object) == "a=1&b=2&c=3"
     end
 
+    test "keyword list inside map encodes as nested object" do
+      assert encode_body(%{filter: [role: "admin", active: true]}, encode: :deep_object)
+             |> as_pairs() ==
+               MapSet.new(["filter[role]=admin", "filter[active]=true"])
+    end
+
+    test "keyword list inside array encodes as nested object" do
+      assert encode_body(%{users: [[name: "a"], [name: "b"]]}, encode: :deep_object)
+             |> as_pairs() ==
+               MapSet.new(["users[0][name]=a", "users[1][name]=b"])
+    end
+
     test "deeply nested map+list mix" do
       assert encode_body(%{a: %{b: [%{c: 1}, %{c: 2}]}}, encode: :deep_object) |> as_pairs() ==
                MapSet.new(["a[b][0][c]=1", "a[b][1][c]=2"])
+    end
+
+    test "raises clear error for unknown encoder option" do
+      assert_raise ArgumentError, ~r/unknown :encode option :unknown/, fn ->
+        encode_body(%{a: 1}, encode: :unknown)
+      end
     end
 
     defp encode_body(body, opts) do

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -378,71 +378,71 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
     end
 
     test "default: boolean true encodes as 'true' (Stripe V2 convention)" do
-      assert (%Tesla.Env{body: %{"key" => true}}
-              |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
-              |> Map.fetch!(:body)) == "key=true"
+      assert %Tesla.Env{body: %{"key" => true}}
+             |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
+             |> Map.fetch!(:body) == "key=true"
     end
 
     test "default: boolean false encodes as 'false' (Stripe V2 convention)" do
-      assert (%Tesla.Env{body: %{"key" => false}}
-              |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
-              |> Map.fetch!(:body)) == "key=false"
+      assert %Tesla.Env{body: %{"key" => false}}
+             |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
+             |> Map.fetch!(:body) == "key=false"
     end
 
     test "default: list of booleans uses true/false" do
-      assert (%Tesla.Env{body: %{"flags" => [true, false, true]}}
-              |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
-              |> Map.fetch!(:body)) == "flags[0]=true&flags[1]=false&flags[2]=true"
+      assert %Tesla.Env{body: %{"flags" => [true, false, true]}}
+             |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
+             |> Map.fetch!(:body) == "flags[0]=true&flags[1]=false&flags[2]=true"
     end
 
     test "boolean_as: :string is identical to the default" do
-      assert (%Tesla.Env{body: %{"key" => true}}
-              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :string})
-              |> Map.fetch!(:body)) == "key=true"
+      assert %Tesla.Env{body: %{"key" => true}}
+             |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :string})
+             |> Map.fetch!(:body) == "key=true"
     end
 
     test "boolean_as: :integer opts into PHP http_build_query parity (true → 1)" do
-      assert (%Tesla.Env{body: %{"key" => true}}
-              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
-              |> Map.fetch!(:body)) == "key=1"
+      assert %Tesla.Env{body: %{"key" => true}}
+             |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
+             |> Map.fetch!(:body) == "key=1"
     end
 
     test "boolean_as: :integer opts into PHP http_build_query parity (false → 0)" do
-      assert (%Tesla.Env{body: %{"key" => false}}
-              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
-              |> Map.fetch!(:body)) == "key=0"
+      assert %Tesla.Env{body: %{"key" => false}}
+             |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
+             |> Map.fetch!(:body) == "key=0"
     end
 
     test "boolean_as: :integer encodes a list of booleans as 1/0 (matches PHP exactly)" do
-      assert (%Tesla.Env{body: %{"flags" => [true, false, true]}}
-              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
-              |> Map.fetch!(:body)) == "flags[0]=1&flags[1]=0&flags[2]=1"
+      assert %Tesla.Env{body: %{"flags" => [true, false, true]}}
+             |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
+             |> Map.fetch!(:body) == "flags[0]=1&flags[1]=0&flags[2]=1"
     end
 
     test "boolean_as: :integer recurses into nested maps" do
-      assert (%Tesla.Env{body: %{"user" => %{"active" => true, "verified" => false}}}
-              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
-              |> Map.fetch!(:body)
-              |> sort_pairs()) == "user[active]=1&user[verified]=0"
+      assert %Tesla.Env{body: %{"user" => %{"active" => true, "verified" => false}}}
+             |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
+             |> Map.fetch!(:body)
+             |> sort_pairs() == "user[active]=1&user[verified]=0"
     end
 
     test "boolean_as: :integer recurses into lists of objects" do
-      assert (%Tesla.Env{body: %{"items" => [%{"flag" => true}, %{"flag" => false}]}}
-              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
-              |> Map.fetch!(:body)) == "items[0][flag]=1&items[1][flag]=0"
+      assert %Tesla.Env{body: %{"items" => [%{"flag" => true}, %{"flag" => false}]}}
+             |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
+             |> Map.fetch!(:body) == "items[0][flag]=1&items[1][flag]=0"
     end
 
     test "boolean_as: :integer leaves non-boolean values untouched" do
-      assert (%Tesla.Env{body: %{"name" => "alice", "age" => 30, "score" => 1.5, "tag" => :ok}}
-              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
-              |> Map.fetch!(:body)
-              |> sort_pairs()) == "age=30&name=alice&score=1.5&tag=ok"
+      assert %Tesla.Env{body: %{"name" => "alice", "age" => 30, "score" => 1.5, "tag" => :ok}}
+             |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, boolean_as: :integer})
+             |> Map.fetch!(:body)
+             |> sort_pairs() == "age=30&name=alice&score=1.5&tag=ok"
     end
 
     test "{:brackets, []} with no sub-options behaves like :brackets" do
-      assert (%Tesla.Env{body: %{"key" => true}}
-              |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, []})
-              |> Map.fetch!(:body)) == "key=true"
+      assert %Tesla.Env{body: %{"key" => true}}
+             |> Tesla.Middleware.FormUrlencoded.encode(encode: {:brackets, []})
+             |> Map.fetch!(:body) == "key=true"
     end
 
     test "invalid :boolean_as value raises" do

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -278,6 +278,127 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
     defp as_pairs(encoded), do: encoded |> String.split("&") |> MapSet.new()
   end
 
+  describe "encode: :brackets PHP http_build_query parity" do
+    # Each tuple: {label, input, expected}.
+    #
+    # Expected outputs were captured from PHP 8.3's http_build_query and
+    # then normalized two ways before comparison:
+    #
+    #   * `%5B`/`%5D` rewritten to literal `[`/`]` — Tesla emits literal
+    #     brackets while PHP percent-encodes them. Both forms URL-decode to
+    #     the same key, so any conformant parser (Rack, Plug.Conn.Query,
+    #     PHP parse_str) treats them as equivalent.
+    #   * Top-level `key=value` pairs sorted alphabetically — Elixir maps
+    #     don't preserve insertion order, so the test normalizes both sides
+    #     by sorting before comparing.
+    #
+    # Booleans are excluded here and tested separately below: PHP emits
+    # `1`/`0`, Tesla emits `true`/`false` (the convention Stripe's API
+    # requires; stripe-php normalizes booleans before calling
+    # http_build_query, so the SDK-level output also uses `true`/`false`).
+    @php_corpus [
+      {"scalar/string", %{"key" => "hello"}, "key=hello"},
+      {"scalar/integer", %{"key" => 42}, "key=42"},
+      {"scalar/zero", %{"key" => 0}, "key=0"},
+      {"scalar/negative", %{"key" => -5}, "key=-5"},
+      {"scalar/float", %{"key" => 1.5}, "key=1.5"},
+      {"scalar/empty_string", %{"key" => ""}, "key="},
+      {"nil/top_level_only_nil", %{"key" => nil}, ""},
+      {"nil/top_level_mixed", %{"a" => 1, "b" => nil, "c" => 2}, "a=1&c=2"},
+      {"nil/all_nil", %{"a" => nil, "b" => nil}, ""},
+      {"nil/in_nested_map", %{"user" => %{"name" => "a", "email" => nil}}, "user[name]=a"},
+      {"nil/in_list_middle", %{"ids" => ["a", nil, "b"]}, "ids[0]=a&ids[2]=b"},
+      {"nil/in_list_leading", %{"ids" => [nil, "a", "b"]}, "ids[1]=a&ids[2]=b"},
+      {"nil/in_list_trailing", %{"ids" => ["a", "b", nil]}, "ids[0]=a&ids[1]=b"},
+      {"nil/in_list_all_nil", %{"ids" => [nil, nil, nil]}, ""},
+      {"nil/multiple_in_list", %{"ids" => [1, nil, 2, nil, 3]}, "ids[0]=1&ids[2]=2&ids[4]=3"},
+      {"nil/in_list_of_objects",
+       %{"users" => [%{"name" => "a", "email" => nil}, %{"name" => "b"}]},
+       "users[0][name]=a&users[1][name]=b"},
+      {"empty/map", %{}, ""},
+      {"empty/empty_list_value", %{"ids" => []}, ""},
+      {"empty/empty_map_value", %{"user" => %{}}, ""},
+      {"list/single", %{"ids" => ["a"]}, "ids[0]=a"},
+      {"list/multi", %{"ids" => ["a", "b", "c"]}, "ids[0]=a&ids[1]=b&ids[2]=c"},
+      {"list/of_ints", %{"nums" => [1, 2, 3]}, "nums[0]=1&nums[1]=2&nums[2]=3"},
+      {"list/of_objects", %{"users" => [%{"name" => "a"}, %{"name" => "b"}]},
+       "users[0][name]=a&users[1][name]=b"},
+      {"list/nested_list", %{"matrix" => [[1, 2], [3, 4]]},
+       "matrix[0][0]=1&matrix[0][1]=2&matrix[1][0]=3&matrix[1][1]=4"},
+      {"nested/one_level", %{"user" => %{"name" => "a"}}, "user[name]=a"},
+      {"nested/two_levels", %{"a" => %{"b" => %{"c" => 1}}}, "a[b][c]=1"},
+      {"nested/three_levels", %{"a" => %{"b" => %{"c" => %{"d" => "x"}}}}, "a[b][c][d]=x"},
+      {"mixed/object_in_list", %{"users" => [%{"name" => "a", "age" => 30}]},
+       "users[0][age]=30&users[0][name]=a"},
+      {"mixed/list_in_object", %{"user" => %{"tags" => ["x", "y"]}},
+       "user[tags][0]=x&user[tags][1]=y"},
+      {"mixed/list_object_list", %{"users" => [%{"tags" => ["x", "y"]}]},
+       "users[0][tags][0]=x&users[0][tags][1]=y"},
+      {"mixed/stripe_expand", %{"expand" => ["customers", "subscriptions"]},
+       "expand[0]=customers&expand[1]=subscriptions"},
+      {"mixed/stripe_complex",
+       %{
+         "expand" => ["objects"],
+         "objects" => %{"customers" => ["cus_123", "cus_456"]},
+         "validation_behavior" => "fix"
+       },
+       "expand[0]=objects&objects[customers][0]=cus_123&objects[customers][1]=cus_456&validation_behavior=fix"},
+      {"encoding/space_in_value", %{"q" => "hello world"}, "q=hello+world"},
+      {"encoding/space_in_key", %{"weird key" => "v"}, "weird+key=v"},
+      {"encoding/ampersand_value", %{"q" => "a&b"}, "q=a%26b"},
+      {"encoding/equals_value", %{"q" => "a=b"}, "q=a%3Db"},
+      {"encoding/percent_value", %{"q" => "a%b"}, "q=a%25b"},
+      {"encoding/plus_value", %{"q" => "a+b"}, "q=a%2Bb"},
+      {"encoding/hash_value", %{"q" => "a#b"}, "q=a%23b"},
+      {"encoding/qmark_value", %{"q" => "a?b"}, "q=a%3Fb"},
+      {"encoding/slash_value", %{"q" => "a/b"}, "q=a%2Fb"},
+      {"encoding/special_combo", %{"q" => "a&b=c%d e"}, "q=a%26b%3Dc%25d+e"},
+      {"encoding/unicode_value", %{"q" => "café"}, "q=caf%C3%A9"},
+      {"encoding/unicode_emoji", %{"q" => "🚀"}, "q=%F0%9F%9A%80"},
+      {"encoding/newline_value", %{"q" => "line1\nline2"}, "q=line1%0Aline2"},
+      {"encoding/tab_value", %{"q" => "a\tb"}, "q=a%09b"},
+      {"encoding/quote_value", %{"q" => "he said \"hi\""}, "q=he+said+%22hi%22"},
+      {"deep/four_levels", %{"a" => %{"b" => %{"c" => %{"d" => 1}}}}, "a[b][c][d]=1"},
+      {"deep/list_of_lists_of_maps", %{"x" => [[%{"k" => 1}], [%{"k" => 2}]]},
+       "x[0][0][k]=1&x[1][0][k]=2"}
+    ]
+
+    for {label, input, expected} <- @php_corpus do
+      @input input
+      @expected expected
+      test "matches PHP http_build_query: #{label}" do
+        actual =
+          %Tesla.Env{body: @input}
+          |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
+          |> Map.fetch!(:body)
+          |> sort_pairs()
+
+        assert actual == @expected
+      end
+    end
+
+    test "boolean true encodes as 'true' (PHP emits '1')" do
+      assert (%Tesla.Env{body: %{"key" => true}}
+              |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
+              |> Map.fetch!(:body)) == "key=true"
+    end
+
+    test "boolean false encodes as 'false' (PHP emits '0')" do
+      assert (%Tesla.Env{body: %{"key" => false}}
+              |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
+              |> Map.fetch!(:body)) == "key=false"
+    end
+
+    test "list of booleans uses true/false (PHP emits 1/0)" do
+      assert (%Tesla.Env{body: %{"flags" => [true, false, true]}}
+              |> Tesla.Middleware.FormUrlencoded.encode(encode: :brackets)
+              |> Map.fetch!(:body)) == "flags[0]=true&flags[1]=false&flags[2]=true"
+    end
+
+    defp sort_pairs(""), do: ""
+    defp sort_pairs(encoded), do: encoded |> String.split("&") |> Enum.sort() |> Enum.join("&")
+  end
+
   describe "Encode / Decode" do
     defmodule EncodeDecodeFormUrlencodedClient do
       use Tesla

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -124,11 +124,11 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
     assert env.body == "decodedbody"
   end
 
-  describe "encode: :deep_object end-to-end through middleware" do
+  describe "encode: :brackets end-to-end through middleware" do
     defmodule NestedClient do
       use Tesla
 
-      plug Tesla.Middleware.FormUrlencoded, encode: :deep_object
+      plug Tesla.Middleware.FormUrlencoded, encode: :brackets
 
       adapter fn env ->
         {:ok, %{env | status: 201, headers: [{"content-type", "text/html"}], body: env.body}}
@@ -154,106 +154,106 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
     end
   end
 
-  describe "encode: :deep_object encoder behavior" do
+  describe "encode: :brackets encoder behavior" do
     defmodule Profile do
       defstruct [:name, :age]
     end
 
     test "indexes flat list items" do
-      assert encode_body(%{ids: ["a", "b"]}, encode: :deep_object) == "ids[0]=a&ids[1]=b"
+      assert encode_body(%{ids: ["a", "b"]}, encode: :brackets) == "ids[0]=a&ids[1]=b"
     end
 
     test "brackets nested map keys" do
-      assert encode_body(%{user: %{name: "a"}}, encode: :deep_object) == "user[name]=a"
+      assert encode_body(%{user: %{name: "a"}}, encode: :brackets) == "user[name]=a"
     end
 
     test "indexes lists of objects" do
-      assert encode_body(%{users: [%{name: "a"}, %{name: "b"}]}, encode: :deep_object)
+      assert encode_body(%{users: [%{name: "a"}, %{name: "b"}]}, encode: :brackets)
              |> as_pairs() ==
                MapSet.new(["users[0][name]=a", "users[1][name]=b"])
     end
 
     test "drops nil at the top level" do
-      assert encode_body(%{a: 1, b: nil, c: 2}, encode: :deep_object) |> as_pairs() ==
+      assert encode_body(%{a: 1, b: nil, c: 2}, encode: :brackets) |> as_pairs() ==
                MapSet.new(["a=1", "c=2"])
     end
 
     test "drops nil inside nested maps" do
-      assert encode_body(%{user: %{name: "a", email: nil}}, encode: :deep_object) ==
+      assert encode_body(%{user: %{name: "a", email: nil}}, encode: :brackets) ==
                "user[name]=a"
     end
 
     test "drops nil from lists and preserves original indices" do
-      assert encode_body(%{ids: [1, nil, 2, nil, 3]}, encode: :deep_object) ==
+      assert encode_body(%{ids: [1, nil, 2, nil, 3]}, encode: :brackets) ==
                "ids[0]=1&ids[2]=2&ids[4]=3"
     end
 
     test "encodes booleans as true/false" do
-      assert encode_body(%{a: true, b: false}, encode: :deep_object) |> as_pairs() ==
+      assert encode_body(%{a: true, b: false}, encode: :brackets) |> as_pairs() ==
                MapSet.new(["a=true", "b=false"])
     end
 
     test "encodes atom values via Atom.to_string/1" do
-      assert encode_body(%{state: :active}, encode: :deep_object) == "state=active"
+      assert encode_body(%{state: :active}, encode: :brackets) == "state=active"
     end
 
     test "encodes integers and floats" do
-      assert encode_body(%{count: 42, ratio: 1.5}, encode: :deep_object) |> as_pairs() ==
+      assert encode_body(%{count: 42, ratio: 1.5}, encode: :brackets) |> as_pairs() ==
                MapSet.new(["count=42", "ratio=1.5"])
     end
 
     test "URI-encodes special characters in values" do
-      assert encode_body(%{q: "a&b=c%d e"}, encode: :deep_object) == "q=a%26b%3Dc%25d+e"
+      assert encode_body(%{q: "a&b=c%d e"}, encode: :brackets) == "q=a%26b%3Dc%25d+e"
     end
 
     test "URI-encodes special characters in keys" do
-      assert encode_body(%{"weird key" => "v"}, encode: :deep_object) == "weird+key=v"
+      assert encode_body(%{"weird key" => "v"}, encode: :brackets) == "weird+key=v"
     end
 
     test "raises on top-level struct" do
       assert_raise ArgumentError, ~r/cannot encode .*Profile struct/, fn ->
-        encode_body(%Profile{name: "Alice", age: 30}, encode: :deep_object)
+        encode_body(%Profile{name: "Alice", age: 30}, encode: :brackets)
       end
     end
 
     test "raises on nested struct" do
       assert_raise ArgumentError, ~r/cannot encode DateTime struct/, fn ->
-        encode_body(%{at: ~U[2024-01-02 03:04:05Z]}, encode: :deep_object)
+        encode_body(%{at: ~U[2024-01-02 03:04:05Z]}, encode: :brackets)
       end
     end
 
     test "raises on struct inside a list" do
       assert_raise ArgumentError, ~r/cannot encode Date struct/, fn ->
-        encode_body(%{days: [~D[2024-01-01], ~D[2024-01-02]]}, encode: :deep_object)
+        encode_body(%{days: [~D[2024-01-01], ~D[2024-01-02]]}, encode: :brackets)
       end
     end
 
     test "empty map encodes to empty string" do
-      assert encode_body(%{}, encode: :deep_object) == ""
+      assert encode_body(%{}, encode: :brackets) == ""
     end
 
     test "empty list value emits nothing" do
-      assert encode_body(%{ids: []}, encode: :deep_object) == ""
+      assert encode_body(%{ids: []}, encode: :brackets) == ""
     end
 
     test "keyword list at top level encodes in given order" do
-      assert encode_body([a: 1, b: 2, c: 3], encode: :deep_object) == "a=1&b=2&c=3"
+      assert encode_body([a: 1, b: 2, c: 3], encode: :brackets) == "a=1&b=2&c=3"
     end
 
     test "keyword list inside map encodes as nested object" do
-      assert encode_body(%{filter: [role: "admin", active: true]}, encode: :deep_object)
+      assert encode_body(%{filter: [role: "admin", active: true]}, encode: :brackets)
              |> as_pairs() ==
                MapSet.new(["filter[role]=admin", "filter[active]=true"])
     end
 
     test "keyword list inside array encodes as nested object" do
-      assert encode_body(%{users: [[name: "a"], [name: "b"]]}, encode: :deep_object)
+      assert encode_body(%{users: [[name: "a"], [name: "b"]]}, encode: :brackets)
              |> as_pairs() ==
                MapSet.new(["users[0][name]=a", "users[1][name]=b"])
     end
 
     test "deeply nested map+list mix" do
-      assert encode_body(%{a: %{b: [%{c: 1}, %{c: 2}]}}, encode: :deep_object) |> as_pairs() ==
+      assert encode_body(%{a: %{b: [%{c: 1}, %{c: 2}]}}, encode: :brackets) |> as_pairs() ==
                MapSet.new(["a[b][0][c]=1", "a[b][1][c]=2"])
     end
 

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -124,17 +124,17 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
     assert env.body == "decodedbody"
   end
 
-  describe "encode: :brackets end-to-end through middleware" do
-    defmodule NestedClient do
-      use Tesla
+  defmodule NestedClient do
+    use Tesla
 
-      plug Tesla.Middleware.FormUrlencoded, encode: :brackets
+    plug Tesla.Middleware.FormUrlencoded, encode: :brackets
 
-      adapter fn env ->
-        {:ok, %{env | status: 201, headers: [{"content-type", "text/html"}], body: env.body}}
-      end
+    adapter fn env ->
+      {:ok, %{env | status: 201, headers: [{"content-type", "text/html"}], body: env.body}}
     end
+  end
 
+  describe "encode: :brackets end-to-end through middleware" do
     test "encodes nested bodies with bracket-indexed lists" do
       body = %{
         expand: ["objects"],

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -242,6 +242,16 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
       assert encode_body(%{ids: []}, encode: :brackets) == ""
     end
 
+    test "empty list inside nested map drops the parent key" do
+      assert encode_body(%{user: %{tags: []}}, encode: :brackets) == ""
+    end
+
+    test "raises clear error for non-enumerable root value" do
+      assert_raise ArgumentError, ~r/cannot encode 42 with :brackets/, fn ->
+        encode_body(42, encode: :brackets)
+      end
+    end
+
     test "keyword list at top level encodes in given order" do
       assert encode_body([a: 1, b: 2, c: 3], encode: :brackets) == "a=1&b=2&c=3"
     end


### PR DESCRIPTION
- Native `URI.encode_query/1` rejects nested maps and lists, which forces callers integrating with APIs like Stripe to hand-roll bracket-notation encoders or pull in `Plug.Conn.Query` just for the form-encoded case.
- Aligns Tesla with the de-facto convention used by Stripe's official SDKs (node/python/ruby) and PHP's `http_build_query` so users can pass nested payloads directly without a custom encoder.
- Opt-in via `encode: :brackets`; default behavior is unchanged.