### PR TITLE
fix(hackney): restore hackney 1.x support

### DIFF
--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -3,7 +3,7 @@ if Code.ensure_loaded?(:hackney) do
     @moduledoc """
     Adapter for [hackney](https://github.com/benoitc/hackney).
 
-    Remember to add `{:hackney, "~> 4.0"}` to dependencies (and `:hackney` to applications in `mix.exs`)
+    Remember to add `{:hackney, "~> 1.21 or ~> 4.0 and >= 4.0.2"}` to dependencies (and `:hackney` to applications in `mix.exs`)
     Also, you need to recompile tesla after adding `:hackney` dependency:
 
     ```shell
@@ -27,14 +27,16 @@ if Code.ensure_loaded?(:hackney) do
 
     ## Adapter specific options
 
-    - `:max_body` - Max response body size in bytes. Only applied when the
-      response is streamed (`async: true` or streaming request body). For sync
-      requests hackney always reads the full body inline and this option has
-      no effect. Actual response may be bigger because hackney stops after the
-      last chunk that surpasses `:max_body`.
+    - `:max_body` - Max response body size in bytes.
+      Works for hackney 1.x and 4.x when streaming the response.
+      Actual response may be bigger
+      because hackney stops after the last chunk that surpasses `:max_body`.
     """
     @behaviour Tesla.Adapter
     alias Tesla.Multipart
+
+    # Hackney 1.x async/stream responses return a `reference()`, 4.x returns a `pid()`.
+    defguardp is_hackney_ref(ref) when is_reference(ref) or is_pid(ref)
 
     # Hackney 4.1.0's `request_ret/0` typespec lists `{:ok, reference()}` for the async
     # and stream-upload returns, but the implementation actually returns `{:ok, pid()}`.
@@ -68,7 +70,7 @@ if Code.ensure_loaded?(:hackney) do
 
     defp format_body(data) when is_list(data), do: IO.iodata_to_binary(data)
     defp format_body(data) when is_binary(data), do: data
-    defp format_body(data) when is_pid(data), do: data
+    defp format_body(data) when is_hackney_ref(data), do: data
 
     defp request(env, opts) do
       request(
@@ -123,11 +125,11 @@ if Code.ensure_loaded?(:hackney) do
     defp handle({:error, _} = error, _opts), do: error
     defp handle({:ok, status, headers}, _opts), do: {:ok, status, headers, []}
 
-    defp handle({:ok, ref}, _opts) when is_pid(ref) do
+    defp handle({:ok, ref}, _opts) when is_hackney_ref(ref) do
       handle_async_response({ref, %{status: nil, headers: nil}})
     end
 
-    defp handle({:ok, status, headers, ref}, opts) when is_pid(ref) do
+    defp handle({:ok, status, headers, ref}, opts) when is_hackney_ref(ref) do
       with {:ok, body} <- read_response_body(ref, Keyword.get(opts, :max_body, :infinity)) do
         {:ok, status, headers, body}
       end

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Tesla.Mixfile do
       {:ibrowse, "4.4.2", optional: true},
       # hackney 2.x, 3.x, and 4.0.0 / 4.0.1 are unsupported: they lack exports we rely on
       # (`:hackney.body/1,2`, `:hackney.stream_body/1,2`) or have an incomplete streaming API.
-      {:hackney, "~> 4.0 and >= 4.0.2", optional: true},
+      {:hackney, "~> 1.21 or ~> 4.0 and >= 4.0.2", optional: true},
       {:gun, ">= 1.0.0", optional: true},
       {:finch, "~> 0.13", optional: true},
       {:castore, "~> 0.1 or ~> 1.0", optional: true},

--- a/test/tesla/adapter/hackney_test.exs
+++ b/test/tesla/adapter/hackney_test.exs
@@ -33,7 +33,27 @@ defmodule Tesla.Adapter.HackneyTest do
 
     assert {:ok, %Env{} = response} = call(request, with_body: true, async: true)
     assert response.status == 200
-    assert is_pid(response.body)
+    assert is_reference(response.body) or is_pid(response.body)
+  end
+
+  @hackney_version :hackney |> Application.spec(:vsn) |> to_string()
+
+  if Version.compare(@hackney_version, "4.0.0") == :lt do
+    test "get with `:max_body` option" do
+      body = String.duplicate("long response", 1000)
+
+      request = %Env{
+        method: :post,
+        url: "#{@http}/post",
+        body: body
+      }
+
+      assert {:ok, %Env{} = full_response} = call(request, with_body: true)
+      assert {:ok, %Env{} = limited_response} = call(request, with_body: true, max_body: 100)
+      assert full_response.status == 200
+      assert limited_response.status == 200
+      assert byte_size(limited_response.body) < byte_size(full_response.body)
+    end
   end
 
   test "request timeout error" do


### PR DESCRIPTION
- PR #880 was merged as a breaking change, but hackney 1.x and 4.x can coexist behind a single guard; users on 1.x should not see a spurious major bump.
- `Release-As: 1.18.3` in the commit footer overrides release-please so the next release is a patch, not a major.