### PR TITLE
chore(ci): bump release workflow to Elixir 1.19 / OTP 28

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       with:
         elixir-version: '1.19.0'
         otp-version: '28.0'
+        version-type: strict
     - name: Restore dependencies cache
       uses: actions/cache@v5
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.15'
-        otp-version: '25.3'
+        elixir-version: '1.19.0'
+        otp-version: '28.0'
     - name: Restore dependencies cache
       uses: actions/cache@v5
       with:


### PR DESCRIPTION
- quic (transitive dep) requires OTP 26+, so the previous Elixir 1.15 / OTP 25.3 pin broke hex publish on release.
- Align with the latest matrix entry in test.yml so the publish toolchain matches what we already exercise in CI.