### PR TITLE
fix(ci): bump release workflow to OTP 28.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       uses: erlef/setup-beam@v1
       with:
         elixir-version: '1.19.0'
-        otp-version: '28.0'
+        otp-version: '28.5'
         version-type: strict
     - name: Restore dependencies cache
       uses: actions/cache@v5


### PR DESCRIPTION
- OTP 28.0 ships a `:re` module that is incompatible with hex 2.4.2 (`:re.import/1` undefined), breaking `mix hex.publish` during the release workflow.