### PR TITLE
chore: drop archived exjsx JSON engine

### DIFF
--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -35,11 +35,9 @@ defmodule Tesla.Middleware.JSON do
         # or
         {Tesla.Middleware.JSON, engine: JSON}
         # or
-        {Tesla.Middleware.JSON, engine: JSX, engine_opts: [strict: [:comments]]},
-        # or
         {Tesla.Middleware.JSON, engine: Poison, engine_opts: [keys: :atoms]},
         # or
-        {Tesla.Middleware.JSON, decode: &JSX.decode/1, encode: &JSX.encode/1}
+        {Tesla.Middleware.JSON, decode: &Jason.decode/1, encode: &Jason.encode/1}
       ])
     end
   end
@@ -50,7 +48,7 @@ defmodule Tesla.Middleware.JSON do
   - `:decode` - decoding function
   - `:encode` - encoding function
   - `:encode_content_type` - content-type to be used in request header
-  - `:engine` - encode/decode engine, e.g `JSON`, `Jason`, `Poison` or `JSX`  (defaults to Jason)
+  - `:engine` - encode/decode engine, e.g `JSON`, `Jason` or `Poison`  (defaults to Jason)
   - `:engine_opts` - optional engine options
   - `:decode_content_types` - list of additional decodable content-types
   """

--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,6 @@ defmodule Tesla.Mixfile do
       # json parsers
       {:jason, ">= 1.0.0", optional: true},
       {:poison, ">= 1.0.0", optional: true},
-      {:exjsx, ">= 3.0.0", optional: true},
 
       # messagepack parsers
       {:msgpax, "~> 2.3", optional: true},

--- a/test/tesla/middleware/json_test.exs
+++ b/test/tesla/middleware/json_test.exs
@@ -295,29 +295,6 @@ defmodule Tesla.Middleware.JsonTest do
     end
   end
 
-  describe "Engine: exjsx" do
-    defmodule JsxClient do
-      use Tesla
-
-      plug Tesla.Middleware.JSON, engine: JSX
-
-      adapter fn env ->
-        {:ok,
-         %{
-           env
-           | status: 200,
-             headers: [{"content-type", "application/json"}],
-             body: ~s|{"value": 123}|
-         }}
-      end
-    end
-
-    test "decode with custom engine options" do
-      assert {:ok, env} = JsxClient.get("/decode")
-      assert env.body == %{"value" => 123}
-    end
-  end
-
   if Code.ensure_loaded?(JSON) do
     describe "Engine: JSON" do
       defmodule JSONClient do


### PR DESCRIPTION
The `exjsx` JSON library is archived and no longer maintained, so drop direct support for it as an engine in Tesla:

- remove the optional `exjsx` dependency
- remove the `engine: JSX` example and update the `:engine` doc in `Tesla.Middleware.JSON`
- replace the remaining `decode: &JSX.decode/1, encode: &JSX.encode/1` doc example with `&Jason.decode/1` / `&Jason.encode/1` (a maintained engine) to keep the `:decode` / `:encode` function example
- remove the `Engine: exjsx` test block

`exjsx` remains in the lockfile only as a transitive dependency of the test-only `httparrot` server. The Elixir 1.20.1 compilation warning fixes (preferred_cli_env, unused require, gun adapter) are split into a separate PR.