### PR TITLE
fix: silence compiler warnings on Elixir 1.20.1

### DIFF
--- a/lib/tesla.ex
+++ b/lib/tesla.ex
@@ -64,7 +64,6 @@ defmodule Tesla do
 
   alias Tesla.Env
 
-  require Tesla.Adapter.Httpc
   @default_adapter Tesla.Adapter.Httpc
 
   defmacro __using__(opts \\ []) do

--- a/lib/tesla/adapter/gun.ex
+++ b/lib/tesla/adapter/gun.ex
@@ -527,6 +527,25 @@ if Code.ensure_loaded?(:gun) do
             end
         end
       end
+
+      defp next_reply_state(_state, {:gun_response, _pid, _stream, :nofin, _status, _headers}),
+        do: :streaming
+
+      defp next_reply_state(state, _message), do: state
+
+      defp terminal_reply_message?({:gun_response, _pid, _stream, :fin, _status, _headers}),
+        do: true
+
+      defp terminal_reply_message?({:gun_data, _pid, _stream, :fin, _data}), do: true
+      defp terminal_reply_message?({:gun_error, _pid, _stream, _reason}), do: true
+      defp terminal_reply_message?({:gun_error, _pid, _reason}), do: true
+
+      defp terminal_reply_message?(
+             {:gun_down, _pid, _protocol, _reason, _killed_streams, _unprocessed}
+           ),
+           do: true
+
+      defp terminal_reply_message?(_message), do: false
     end
 
     defp route_reply_message(request_owner, stream_owner, original_reply_to, message) do
@@ -546,25 +565,6 @@ if Code.ensure_loaded?(:gun) do
           notify_reply_to(original_reply_to, request_owner, message)
       end
     end
-
-    defp next_reply_state(_state, {:gun_response, _pid, _stream, :nofin, _status, _headers}),
-      do: :streaming
-
-    defp next_reply_state(state, _message), do: state
-
-    defp terminal_reply_message?({:gun_response, _pid, _stream, :fin, _status, _headers}),
-      do: true
-
-    defp terminal_reply_message?({:gun_data, _pid, _stream, :fin, _data}), do: true
-    defp terminal_reply_message?({:gun_error, _pid, _stream, _reason}), do: true
-    defp terminal_reply_message?({:gun_error, _pid, _reason}), do: true
-
-    defp terminal_reply_message?(
-           {:gun_down, _pid, _protocol, _reason, _killed_streams, _unprocessed}
-         ),
-         do: true
-
-    defp terminal_reply_message?(_message), do: false
 
     defp notify_reply_to(reply_to, request_owner, _message)
          when is_pid(reply_to) and reply_to == request_owner,

--- a/mix.exs
+++ b/mix.exs
@@ -20,9 +20,12 @@ defmodule Tesla.Mixfile do
         plt_add_apps: [:mix, :inets, :idna, :ssl_verify_fun, :ex_unit],
         plt_add_deps: :apps_direct
       ],
-      docs: docs(),
-      preferred_cli_env: [coveralls: :test, "coveralls.html": :test]
+      docs: docs()
     ]
+  end
+
+  def cli do
+    [preferred_envs: [coveralls: :test, "coveralls.html": :test]]
   end
 
   def application do


### PR DESCRIPTION
- preferred_cli_env (Mix 1.20 deprecation): move from `def project` into `def cli [preferred_envs: ...]`.
- Drop unused `require Tesla.Adapter.Httpc` in `lib/tesla.ex` (the module defines no macros, so the require was unnecessary; `@default_adapter` just references the module atom).
- Relocate `next_reply_state/2` and `terminal_reply_message?/1` in `lib/tesla/adapter/gun.ex` into the gun 1.x `else` branch next to their sole caller `reply_router/6` (dead code under gun 2.x — the closure-based `wrap_reply_to` is used instead, so `reply_router` and these helpers were unused code compiled at module top-level).

`mix.lock` is unchanged — HEAD already locks the same dep versions, and no dep is added or removed. Full test suite passes (1034 tests).