### PR TITLE
feat: add support for the HTTP QUERY method (RFC 10008)

### DIFF
--- a/guides/cheatsheets/general.cheatmd
+++ b/guides/cheatsheets/general.cheatmd
@@ -22,6 +22,9 @@ Tesla.post("https://httpbin.org/post", "body")
 Tesla.put("https://httpbin.org/put", "body")
 Tesla.patch("https://httpbin.org/patch", "body")
 Tesla.delete("https://httpbin.org/anything")
+
+# QUERY (RFC 10008) - not supported by the httpc and ibrowse adapters
+Tesla.query("https://httpbin.org/anything", "select=name&limit=10")
 ```
 
 ### Query Params

--- a/guides/cheatsheets/general.cheatmd
+++ b/guides/cheatsheets/general.cheatmd
@@ -23,7 +23,7 @@ Tesla.put("https://httpbin.org/put", "body")
 Tesla.patch("https://httpbin.org/patch", "body")
 Tesla.delete("https://httpbin.org/anything")
 
-# QUERY (RFC 10008) - not supported by the httpc and ibrowse adapters
+# QUERY (RFC 10008) - not supported by ibrowse, nor by httpc as of OTP 29
 Tesla.query("https://httpbin.org/anything", "select=name&limit=10")
 ```
 

--- a/guides/explanations/3.adapter.md
+++ b/guides/explanations/3.adapter.md
@@ -73,6 +73,21 @@ You can pass options to adapters in several ways:
   Tesla.get(client, "/", opts: [adapter: [recv_timeout: 30_000]])
   ```
 
+## Method Support
+
+All adapters support the standard HTTP methods: HEAD, GET, DELETE, TRACE,
+OPTIONS, POST, PUT, and PATCH.
+
+The QUERY method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) is
+supported by the `Hackney`, `Gun`, `Mint`, and `Finch` adapters. The clients
+underlying the remaining adapters accept only a fixed set of methods, so QUERY
+requests fail with an error:
+
+- `Tesla.Adapter.Httpc` returns `{:error, :invalid_method}`. The error comes
+  from `:httpc` itself, so QUERY will start working automatically once OTP
+  adds support for it.
+- `Tesla.Adapter.Ibrowse` returns `{:error, :method_not_supported_by_adapter}`.
+
 ## About :httpc adapter and security issues
 
 [People have complained about `:httpc` adapter in `Tesla` due to

--- a/lib/tesla/adapter/finch.ex
+++ b/lib/tesla/adapter/finch.ex
@@ -70,6 +70,7 @@ if Code.ensure_loaded?(Finch) do
 
     """
     @behaviour Tesla.Adapter
+    import Tesla.Adapter.Shared, only: [format_method: 1]
     alias Tesla.Multipart
 
     @defaults [
@@ -87,7 +88,7 @@ if Code.ensure_loaded?(Finch) do
         Keyword.take(opts, [:pool_timeout, :receive_timeout, :request_timeout, :pool_strategy])
 
       build_opts = Keyword.take(opts, [:unix_socket, :pool_tag])
-      req = build(env.method, url, env.headers, env.body, build_opts)
+      req = build(format_method(env.method), url, env.headers, env.body, build_opts)
 
       case request(req, name, req_opts, opts) do
         {:ok, %Finch.Response{status: status, headers: headers, body: body}} ->

--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -6,6 +6,10 @@ defmodule Tesla.Adapter.Httpc do
 
   **NOTE** Tesla overrides default autoredirect value with false to ensure
   consistency between adapters
+
+  **NOTE** `:httpc` accepts only a fixed set of HTTP methods and does not
+  support QUERY (RFC 10008) - such requests return `{:error, :invalid_method}`.
+  Use the Hackney, Gun, Mint, or Finch adapter instead.
   """
 
   @behaviour Tesla.Adapter

--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -7,9 +7,11 @@ defmodule Tesla.Adapter.Httpc do
   **NOTE** Tesla overrides default autoredirect value with false to ensure
   consistency between adapters
 
-  **NOTE** `:httpc` accepts only a fixed set of HTTP methods and does not
-  support QUERY (RFC 10008) - such requests return `{:error, :invalid_method}`.
-  Use the Hackney, Gun, Mint, or Finch adapter instead.
+  **NOTE** `:httpc` accepts only a fixed set of HTTP methods, which as of
+  OTP 29 does not include QUERY (RFC 10008) - such requests return
+  `{:error, :invalid_method}`. The error comes from `:httpc` itself, so QUERY
+  starts working automatically on OTP versions that add support for it. Until
+  then, use the Hackney, Gun, Mint, or Finch adapter for QUERY requests.
   """
 
   @behaviour Tesla.Adapter

--- a/lib/tesla/adapter/ibrowse.ex
+++ b/lib/tesla/adapter/ibrowse.ex
@@ -60,7 +60,8 @@ if Code.ensure_loaded?(:ibrowse) do
     defp format_body(data) when is_list(data), do: IO.iodata_to_binary(data)
     defp format_body(data) when is_binary(data), do: data
 
-    defp request(%{method: :query}, _opts), do: {:error, :method_not_supported_by_adapter}
+    defp request(%Tesla.Env{method: :query}, _opts),
+      do: {:error, :method_not_supported_by_adapter}
 
     defp request(env, opts) do
       body = env.body || []

--- a/lib/tesla/adapter/ibrowse.ex
+++ b/lib/tesla/adapter/ibrowse.ex
@@ -24,6 +24,10 @@ if Code.ensure_loaded?(:ibrowse) do
       end
     end
     ```
+
+    **NOTE** `ibrowse` accepts only a fixed set of HTTP methods and does not
+    support QUERY (RFC 10008) - such requests return
+    `{:error, :method_not_supported_by_adapter}`.
     """
 
     @behaviour Tesla.Adapter
@@ -55,6 +59,8 @@ if Code.ensure_loaded?(:ibrowse) do
 
     defp format_body(data) when is_list(data), do: IO.iodata_to_binary(data)
     defp format_body(data) when is_binary(data), do: data
+
+    defp request(%{method: :query}, _opts), do: {:error, :method_not_supported_by_adapter}
 
     defp request(env, opts) do
       body = env.body || []

--- a/lib/tesla/builder.ex
+++ b/lib/tesla/builder.ex
@@ -1,8 +1,8 @@
 defmodule Tesla.Builder do
   @moduledoc false
 
-  @http_verbs ~w(head get delete trace options post put patch)a
-  @body ~w(post put patch)a
+  @http_verbs ~w(head get delete trace options post put patch query)a
+  @body ~w(post put patch query)a
 
   defmacro __using__(opts \\ []) do
     caller_module = __CALLER__.module
@@ -51,7 +51,7 @@ defmodule Tesla.Builder do
 
         ## Options
 
-        - `:method` - the request method, one of [`:head`, `:get`, `:delete`, `:trace`, `:options`, `:post`, `:put`, `:patch`]
+        - `:method` - the request method, one of [`:head`, `:get`, `:delete`, `:trace`, `:options`, `:post`, `:put`, `:patch`, `:query`]
         - `:url` - either full url e.g. "http://example.com/some/path" or just "/some/path" if using `Tesla.Middleware.BaseUrl`
         - `:query` - a keyword list or nested map of query params, e.g. `[page: 1, per_page: 100]`
         - `:headers` - a keyword list of headers, e.g. `[{"content-type", "text/plain"}]`
@@ -268,7 +268,7 @@ defmodule Tesla.Builder do
       Perform a #{unquote(method |> to_string |> String.upcase())} request.
 
       See `#{unquote(request)}/1` or `#{unquote(request)}/2` for options definition.
-
+      #{unquote(method_note(method))}
           #{unquote(name)}("/users"#{unquote(body)})
           #{unquote(name)}("/users"#{unquote(body)}, query: [scope: "admin"])
           #{unquote(name)}(client, "/users"#{unquote(body)})
@@ -283,6 +283,19 @@ defmodule Tesla.Builder do
       @doc false
     end
   end
+
+  # QUERY shares its name with the `:query` request option - point out the
+  # difference in the generated docs.
+  defp method_note(:query) do
+    """
+
+    QUERY (RFC 10008) is a safe and idempotent method that carries the query
+    in the request body. It is not related to the `:query` option, which sets
+    URL query parameters.
+    """
+  end
+
+  defp method_note(_method), do: ""
 
   defp gen_spec(method, safe, client, opts) do
     quote location: :keep do

--- a/lib/tesla/env.ex
+++ b/lib/tesla/env.ex
@@ -4,7 +4,7 @@ defmodule Tesla.Env do
   """
 
   @type client :: Tesla.Client.t()
-  @type method :: :head | :get | :delete | :trace | :options | :post | :put | :patch
+  @type method :: :head | :get | :delete | :trace | :options | :post | :put | :patch | :query
 
   @typedoc """
   Request URL or request target.

--- a/test/support/adapter_case/query.ex
+++ b/test/support/adapter_case/query.ex
@@ -1,0 +1,25 @@
+defmodule Tesla.AdapterCase.Query do
+  defmacro __using__(_) do
+    quote do
+      alias Tesla.Env
+
+      describe "QUERY (RFC 10008)" do
+        # The test server does not implement the QUERY method and rejects it
+        # (currently with 501, but that may vary with the server version).
+        # Receiving an HTTP response (instead of an error) is what proves the
+        # adapter can send QUERY requests over the wire.
+        test "QUERY request" do
+          request = %Env{
+            method: :query,
+            url: "#{@http}/post",
+            body: "select=surname,givenname&limit=10",
+            headers: [{"content-type", "application/x-www-form-urlencoded"}]
+          }
+
+          assert {:ok, %Env{} = response} = call(request)
+          assert response.status in 100..599
+        end
+      end
+    end
+  end
+end

--- a/test/tesla/adapter/finch_test.exs
+++ b/test/tesla/adapter/finch_test.exs
@@ -9,6 +9,7 @@ defmodule Tesla.Adapter.FinchTest do
   use Tesla.AdapterCase.StreamRequestBody
   use Tesla.AdapterCase.StreamResponseBody
   use Tesla.AdapterCase.SSL
+  use Tesla.AdapterCase.Query
 
   setup do
     opts = [

--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -5,6 +5,7 @@ defmodule Tesla.Adapter.GunTest do
   use Tesla.AdapterCase.Basic
   use Tesla.AdapterCase.Multipart
   use Tesla.AdapterCase.StreamRequestBody
+  use Tesla.AdapterCase.Query
 
   use Tesla.AdapterCase.SSL,
     certificates_verification: true,

--- a/test/tesla/adapter/hackney_test.exs
+++ b/test/tesla/adapter/hackney_test.exs
@@ -5,6 +5,7 @@ defmodule Tesla.Adapter.HackneyTest do
   use Tesla.AdapterCase.Basic
   use Tesla.AdapterCase.Multipart
   use Tesla.AdapterCase.StreamRequestBody
+  use Tesla.AdapterCase.Query
 
   use Tesla.AdapterCase.SSL,
     ssl_options: [

--- a/test/tesla/adapter/httpc_test.exs
+++ b/test/tesla/adapter/httpc_test.exs
@@ -12,10 +12,11 @@ defmodule Tesla.Adapter.HttpcTest do
       cacertfile: Path.join([to_string(:code.priv_dir(:httparrot)), "/ssl/server-ca.crt"])
     ]
 
-  # :httpc accepts only a fixed set of method atoms and does not support
-  # QUERY (RFC 10008) - the error is passed through from :httpc, so QUERY
-  # starts working automatically once OTP adds support for it.
-  test "QUERY request returns an error" do
+  # :httpc accepts only a fixed set of method atoms, which as of OTP 29 does
+  # not include QUERY (RFC 10008). The error is passed through from :httpc,
+  # so QUERY starts working automatically once OTP adds support for it -
+  # accept both outcomes to stay green across OTP versions.
+  test "QUERY request" do
     env = %Env{
       method: :query,
       url: "#{@http}/post",
@@ -23,7 +24,10 @@ defmodule Tesla.Adapter.HttpcTest do
       headers: [{"content-type", "application/x-www-form-urlencoded"}]
     }
 
-    assert {:error, :invalid_method} = call(env)
+    case call(env) do
+      {:error, reason} -> assert reason == :invalid_method
+      {:ok, %Env{} = response} -> assert response.status in 100..599
+    end
   end
 
   # see https://github.com/teamon/tesla/issues/147

--- a/test/tesla/adapter/httpc_test.exs
+++ b/test/tesla/adapter/httpc_test.exs
@@ -12,6 +12,20 @@ defmodule Tesla.Adapter.HttpcTest do
       cacertfile: Path.join([to_string(:code.priv_dir(:httparrot)), "/ssl/server-ca.crt"])
     ]
 
+  # :httpc accepts only a fixed set of method atoms and does not support
+  # QUERY (RFC 10008) - the error is passed through from :httpc, so QUERY
+  # starts working automatically once OTP adds support for it.
+  test "QUERY request returns an error" do
+    env = %Env{
+      method: :query,
+      url: "#{@http}/post",
+      body: "select=surname,givenname&limit=10",
+      headers: [{"content-type", "application/x-www-form-urlencoded"}]
+    }
+
+    assert {:error, :invalid_method} = call(env)
+  end
+
   # see https://github.com/teamon/tesla/issues/147
   test "Set content-type for DELETE requests" do
     env = %Env{

--- a/test/tesla/adapter/ibrowse_test.exs
+++ b/test/tesla/adapter/ibrowse_test.exs
@@ -17,4 +17,17 @@ defmodule Tesla.Adapter.IbrowseTest do
   #     verify: :verify_peer,
   #     cacertfile: Path.join([to_string(:code.priv_dir(:httparrot)), "/ssl/server-ca.crt"])
   #   ]
+
+  # ibrowse supports only a fixed set of method atoms and would crash its
+  # connection process on QUERY (RFC 10008), so the adapter rejects it upfront.
+  test "QUERY request returns method_not_supported_by_adapter" do
+    env = %Env{
+      method: :query,
+      url: "#{@http}/post",
+      body: "select=surname,givenname&limit=10",
+      headers: [{"content-type", "application/x-www-form-urlencoded"}]
+    }
+
+    assert {:error, :method_not_supported_by_adapter} = call(env)
+  end
 end

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -9,6 +9,7 @@ defmodule Tesla.Adapter.MintTest do
   use Tesla.AdapterCase.Basic
   use Tesla.AdapterCase.Multipart
   use Tesla.AdapterCase.StreamRequestBody
+  use Tesla.AdapterCase.Query
 
   use Tesla.AdapterCase.SSL,
     transport_opts: [

--- a/test/tesla/builder_test.exs
+++ b/test/tesla/builder_test.exs
@@ -117,6 +117,16 @@ defmodule Tesla.BuilderTest do
       assert function_exported?(TestClient, :post!, 3)
       assert function_exported?(TestClient, :post!, 4)
     end
+
+    test "generate functions for the QUERY method (RFC 10008)" do
+      assert function_exported?(TestClient, :query, 2)
+      assert function_exported?(TestClient, :query, 3)
+      assert function_exported?(TestClient, :query, 4)
+
+      assert function_exported?(TestClient, :query!, 2)
+      assert function_exported?(TestClient, :query!, 3)
+      assert function_exported?(TestClient, :query!, 4)
+    end
   end
 
   describe ":only/:except options" do
@@ -128,7 +138,7 @@ defmodule Tesla.BuilderTest do
       use Tesla.Builder, except: ~w(delete)a
     end
 
-    @http_verbs ~w(head get delete trace options post put patch)a
+    @http_verbs ~w(head get delete trace options post put patch query)a
 
     test "limit generated functions (only)" do
       functions = OnlyGetClient.__info__(:functions) |> Keyword.keys() |> Enum.uniq()

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -203,6 +203,13 @@ defmodule TeslaTest do
       assert response.body == "some-data"
     end
 
+    test "query shortcut function (RFC 10008)" do
+      assert {:ok, response} = SimpleClient.query("/orders", "select=surname&limit=10")
+      assert response.method == :query
+      assert response.url == "/orders"
+      assert response.body == "select=surname&limit=10"
+    end
+
     test "better errors when given nil opts" do
       assert_raise FunctionClauseError, fn ->
         SimpleClient.get("/", nil)


### PR DESCRIPTION
Generate query/query! client helpers (carrying a request body, like post) and extend the Tesla.Env method type with :query.

Adapter support: `hackney`, `gun`, and `mint` pass `QUERY` through already; `finch` now receives the method as an uppercase string, since Finch rejects unknown method atoms (it normalizes atom methods to strings internally, so this is behavior-identical for the other methods). `ibrowse` crashes its connection process on unknown method atoms, so its adapter rejects `QUERY` upfront with `{:error, :method_not_supported_by_adapter}`. `httpc` passes through its own `{:error, :invalid_method}`, so `QUERY` starts working there automatically once OTP adds support for it.