### PR TITLE
fix: handle atom header keys in FollowRedirects header filtering

### DIFF
--- a/lib/tesla/middleware/follow_redirects.ex
+++ b/lib/tesla/middleware/follow_redirects.ex
@@ -142,7 +142,7 @@ defmodule Tesla.Middleware.FollowRedirects do
     %{env | headers: Enum.reject(env.headers, &dropped?(&1, drop))}
   end
 
-  defp dropped?({key, _value}, drop), do: String.downcase(key) in drop
+  defp dropped?({key, _value}, drop), do: String.downcase(to_string(key)) in drop
 
   defp add_if(list, true, extra), do: list ++ extra
   defp add_if(list, false, _extra), do: list

--- a/test/tesla/middleware/follow_redirects_test.exs
+++ b/test/tesla/middleware/follow_redirects_test.exs
@@ -325,6 +325,27 @@ defmodule Tesla.Middleware.FollowRedirectsTest do
       ]
     end
 
+    test "Strip authorization header given as an atom key on cross-origin redirect", %{
+      client: client
+    } do
+      assert {:ok, _env} =
+               Tesla.post(client, "http://example.com/drop", "",
+                 headers: [
+                   {"content-type", "text/plain"},
+                   {:Authorization, "Basic Zm9vOmJhcg=="}
+                 ]
+               )
+
+      assert_receive [
+        {"content-type", "text/plain"},
+        {:Authorization, "Basic Zm9vOmJhcg=="}
+      ]
+
+      assert_receive [
+        {"content-type", "text/plain"}
+      ]
+    end
+
     test "Strip Host header (canonical casing) on redirect to a different domain", %{
       client: client
     } do


### PR DESCRIPTION
Fixes #897.

When a request carries a header with an atom key (e.g. `{:Accept, "..."}`), `FollowRedirects` crashes on a redirect with `FunctionClauseError` because `dropped?/2` passes the key straight to `String.downcase/2`, which only accepts a string.

This coerces the key with `to_string/1` before downcasing, matching what the adapters (httpc, hackney, gun, ibrowse) already do when normalizing header keys. Added a regression test that reproduces the crash with an atom key.