### PR TITLE
fix(ci): bump test matrix to OTP 28.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
             experimental: false
             lint: false
           - elixir: '1.19.0'
-            otp: '28.0'
+            otp: '28.5'
             experimental: false
             lint: false
           - elixir: '1.20.0'


### PR DESCRIPTION
- Hex 2.5.0 calls `:re.import/1`, which only exists on OTP 28.1+, so the OTP 28.0 test job crashes during `mix deps.get` before any tests run (see https://github.com/elixir-tesla/tesla/actions/runs/28487042976/job/84435643934). The release workflow was already moved to OTP 28.5 in #888 for the same reason.