### PR TITLE
chore: fix typos in Compression middleware comments

### DIFF
--- a/lib/tesla/middleware/compression.ex
+++ b/lib/tesla/middleware/compression.ex
@@ -268,11 +268,11 @@ defmodule Tesla.Middleware.Compression do
     |> update_content_length(body)
   end
 
-  # The value of the content-length header wil be inaccurate after decompression.
+  # The value of the content-length header will be inaccurate after decompression.
   # But setting it is mandatory or strongly encouraged in HTTP/1.0 and HTTP/1.1.
   # Except, when transfer-encoding is used defining content-length is invalid.
   # Thus we can neither just drop it nor indiscriminately add it, but will update it if it already exist.
-  # Furthermore, content-length is technically allowed to be specified mutliple times if all values match,
+  # Furthermore, content-length is technically allowed to be specified multiple times if all values match,
   # to ensure consistency we must therefore make sure to drop any duplicate definitions while updating.
   defp update_content_length(env, body) when is_binary(body) do
     if Tesla.get_header(env, "content-length") != nil do


### PR DESCRIPTION
Fixes two small typos in `Tesla.Middleware.Compression` code comments: "wil" → "will" and "mutliple" → "multiple".