### PR TITLE
chore(ci): unblock dependency PR checks

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -22,3 +22,7 @@ rules:
     - 2
     - always
     - 100
+  body-max-line-length:
+    - 0
+  footer-max-line-length:
+    - 0

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -28,12 +28,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Enable auto-merge for patch and minor updates
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
- Every dependency PR was failing two required checks, so nothing could land through the normal path.
- Commitlint rejected bodies that Dependabot generates unavoidably, which made the check impossible to satisfy rather than merely strict.
- The approval step depended on a permission the organization does not grant, so it failed on every run and its failure hid the rest of the job.
- Merge safety now comes from the `trunk` ruleset requiring CI to pass, which is a better place for that guarantee than a workflow step.