### PR TITLE
chore: warn that credential middleware must precede FollowRedirects

### DIFF
--- a/lib/tesla/middleware/follow_redirects.ex
+++ b/lib/tesla/middleware/follow_redirects.ex
@@ -18,6 +18,37 @@ defmodule Tesla.Middleware.FollowRedirects do
   ## Options
 
   - `:max_redirects` - limit number of redirects (default: `5`)
+
+  ## Middleware order matters for credentials
+
+  On a redirect that crosses origins this middleware strips `authorization`,
+  `proxy-authorization`, `cookie` and other origin-bound headers, so they are not
+  sent to the new host. It can only strip headers that are already on the request
+  when it runs, which means **any middleware that sets credentials must be listed
+  before `Tesla.Middleware.FollowRedirects`.**
+
+  Middleware listed after it runs on every hop, including the redirected one, and
+  re-adds its headers to a request this middleware has already filtered. A static
+  credential set that way is sent to whatever host the `location` header names.
+
+  ```elixir
+  # Safe: the token is on the request before the redirect is followed, so it is
+  # stripped when the redirect crosses origins.
+  Tesla.client([
+    {Tesla.Middleware.BearerAuth, token: token},
+    Tesla.Middleware.FollowRedirects
+  ])
+
+  # Unsafe: BearerAuth runs again on the redirected request and re-adds the
+  # token after the stripping has happened.
+  Tesla.client([
+    Tesla.Middleware.FollowRedirects,
+    {Tesla.Middleware.BearerAuth, token: token}
+  ])
+  ```
+
+  The same applies to `Tesla.Middleware.BasicAuth`, `Tesla.Middleware.DigestAuth`
+  and to a `Tesla.Middleware.Headers` carrying a static credential.
   """
 
   @behaviour Tesla.Middleware
@@ -112,6 +143,11 @@ defmodule Tesla.Middleware.FollowRedirects do
   # Resource-, origin-, and proxy-specific headers are stripped on cross-origin
   # redirects to avoid leaking credentials or sending values bound to the
   # previous origin.
+  #
+  # Only headers present when this middleware runs can be stripped. A middleware
+  # listed after FollowRedirects re-adds its headers on the redirected hop, after
+  # this list has been applied. See the "Middleware order matters for
+  # credentials" section of the moduledoc.
   @cross_origin_strip ~w(
     authorization
     cookie


### PR DESCRIPTION
Follow-up to the private advisory discussion, where the conclusion was that this is a documentation problem rather than a vulnerability. @yordis asked for it as a PR, so here it is, scoped to documentation only.

## What this documents

`FollowRedirects` strips `authorization`, `proxy-authorization`, `cookie` and the other origin-bound headers when a redirect crosses origins. It can only strip what is on the request by the time it runs. Middleware listed **after** it runs again on the redirected hop and re-adds its headers after the filtering has happened, so a static credential set that way is sent to whatever host the `location` header names.

```elixir
# Safe
Tesla.client([
  {Tesla.Middleware.BearerAuth, token: token},
  Tesla.Middleware.FollowRedirects
])

# Unsafe: the token is re-added after stripping
Tesla.client([
  Tesla.Middleware.FollowRedirects,
  {Tesla.Middleware.BearerAuth, token: token}
])
```

## Why the comment above the strip list also changed

The moduledoc previously documented only `:max_redirects`. Meanwhile `@cross_origin_strip` lists `authorization` and `proxy-authorization` under a comment saying they are stripped "to avoid leaking credentials or sending values bound to the previous origin".

Read on its own, that list looks like an unconditional guarantee, and it is the thing someone checks when they want to know whether they are covered. So the pointer goes there as well as in the moduledoc, rather than only in the guides. That was the one substantive point I had in the advisory thread and it is the reason the change is in two places rather than one.

## Scope

Documentation only. No behaviour change, no new option, one file touched.

I have deliberately not included the value-comparison idea from the advisory thread (keep the header value sent to the previous origin, strip only when the outgoing value is byte-identical, so a per-host request signer survives while a static token does not). That is a behaviour change and belongs in its own PR if you want it at all. Happy to write it separately, and happy to add tests pinning both orderings if you would like the behaviour locked down rather than just described.

Wording is yours to change freely. I named `BasicAuth`, `DigestAuth` and `Headers` alongside `BearerAuth` because the same thing applies to any middleware that sets a static credential, but trim that if it reads as noise.

One note on verification: I could not run `mix format` here because there is no Erlang runtime on this machine. The change is entirely inside a `@moduledoc` heredoc and one comment block, neither of which the formatter rewrites, so I do not expect a diff, but worth saying rather than implying I checked.
