### PR TITLE
chore(ci): let PR checks work on fork pull requests

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -1,0 +1,40 @@
+name: PR Labels
+
+# Runs on `pull_request_target` so that labels can be applied to pull requests
+# opened from forks, which only get a read-only token on `pull_request`.
+# Nothing from the head branch is checked out or executed here.
+on:
+  pull_request_target:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  Labels:
+    name: Assign Labels
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: mauroalderete/action-assign-labels@671a4ca2da0f900464c58b8b5540a1e07133e915 # v1
+        with:
+          pull-request-number: ${{ github.event.pull_request.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          conventional-commits: |
+            conventional-commits:
+              - type: 'fix'
+                nouns: ['FIX', 'Fix', 'fix']
+                labels: ['bug']
+              - type: 'feature'
+                nouns: ['FEAT', 'Feat', 'feat']
+                labels: ['feature :sparkles:']
+              - type: 'chore'
+                nouns: ['CHORE', 'Chore', 'chore']
+                labels: ['chore']
+              - type: 'docs'
+                nouns: ['DOCS', 'Docs', 'docs']
+                labels: ['docs']

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,7 +35,6 @@ jobs:
 
     permissions:
       pull-requests: read
-      statuses: write
 
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
@@ -52,36 +51,4 @@ jobs:
             The subject "{subject}" found in the pull request title "{title}"
             did not match the configured pattern. Please ensure that the subject
             does not start with an uppercase character.
-          wip: true
           validateSingleCommit: false
-
-  Labels:
-    name: Assign Labels
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
-
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: mauroalderete/action-assign-labels@671a4ca2da0f900464c58b8b5540a1e07133e915 # v1
-        with:
-          pull-request-number: ${{ github.event.pull_request.number }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          conventional-commits: |
-            conventional-commits:
-              - type: 'fix'
-                nouns: ['FIX', 'Fix', 'fix']
-                labels: ['bug']
-              - type: 'feature'
-                nouns: ['FEAT', 'Feat', 'feat']
-                labels: ['feature :sparkles:']
-              - type: 'chore'
-                nouns: ['CHORE', 'Chore', 'chore']
-                labels: ['chore']
-              - type: 'docs'
-                nouns: ['DOCS', 'Docs', 'docs']
-                labels: ['docs']


### PR DESCRIPTION
- Pull requests opened from forks only ever receive a read-only token on `pull_request`, so the `permissions:` block on those jobs could never be honored. Every outside contribution failed the required `Semantic PR Title` check and the labeler with `Resource not accessible by integration`, which made the red X look like a problem with the contribution rather than with our own configuration.
- The commit status the title check was writing existed only to support the `[WIP]` prefix convention, which draft pull requests already cover, so paying for it with a write scope we cannot get on forks was not worth it.
- Labeling genuinely needs a write scope, so it moves to the event that can grant one. It stays in a separate file that never checks out or runs anything from the head branch, so that boundary is visible rather than implied.
