### PR TITLE
fix(finch-adapter): surface the reason a streamed response stopped

### DIFF
--- a/lib/tesla/adapter/finch.ex
+++ b/lib/tesla/adapter/finch.ex
@@ -46,6 +46,28 @@ if Code.ensure_loaded?(Finch) do
         + `nil` or not specified - Responds without streaming using
           `Finch.request/3`.
 
+    ## Streamed response failures
+
+    When `response: :stream` is used, failures that happen after the response
+    headers arrived cannot be returned as `{:error, reason}`, because the
+    request already succeeded from the caller point of view. Such failures raise
+    `Tesla.Error` while the body stream is being consumed, so that a truncated
+    response is never mistaken for a complete one:
+
+    ```elixir
+    try do
+      Enum.each(env.body, &handle_chunk/1)
+    rescue
+      e in Tesla.Error ->
+        # e.reason is, for example, :closed or :timeout
+        {:error, e.reason}
+    end
+    ```
+
+    Waiting longer than `:receive_timeout` for the next chunk raises with reason
+    `:timeout`. A server that ends the response early without failing the
+    connection is not an error, and the stream simply ends.
+
     ## [Finch build options](https://hexdocs.pm/finch/Finch.html#build/5)
 
       * `:unix_socket` - Path to a Unix domain socket to connect to instead of the
@@ -90,7 +112,7 @@ if Code.ensure_loaded?(Finch) do
       build_opts = Keyword.take(opts, [:unix_socket, :pool_tag])
       req = build(format_method(env.method), url, env.headers, env.body, build_opts)
 
-      case request(req, name, req_opts, opts) do
+      case request(req, name, req_opts, opts, env) do
         {:ok, %Finch.Response{status: status, headers: headers, body: body}} ->
           {:ok, %Tesla.Env{env | status: status, headers: headers, body: body}}
 
@@ -125,15 +147,15 @@ if Code.ensure_loaded?(Finch) do
       Finch.build(method, url, headers, body, opts)
     end
 
-    defp request(req, name, req_opts, opts) do
+    defp request(req, name, req_opts, opts, env) do
       case opts[:response] do
-        :stream -> stream(req, name, req_opts)
+        :stream -> stream(req, name, req_opts, env)
         nil -> Finch.request(req, name, req_opts)
         other -> raise "Unknown response option: #{inspect(other)}"
       end
     end
 
-    defp stream(req, name, opts) do
+    defp stream(req, name, opts, env) do
       owner = self()
       ref = make_ref()
 
@@ -166,13 +188,13 @@ if Code.ensure_loaded?(Finch) do
                   Task.await(task)
                   nil
 
-                {^ref, {:error, _error}} ->
+                {^ref, {:error, error}} ->
                   Task.shutdown(task, :brutal_kill)
-                  nil
+                  raise Tesla.Error, env: env, reason: unwrap_error(error)
               after
                 opts[:receive_timeout] ->
                   Task.shutdown(task, :brutal_kill)
-                  nil
+                  raise Tesla.Error, env: env, reason: :timeout
               end
             end)
 

--- a/test/tesla/adapter/finch_test.exs
+++ b/test/tesla/adapter/finch_test.exs
@@ -64,4 +64,66 @@ defmodule Tesla.Adapter.FinchTest do
                receive_timeout: 1000
              )
   end
+
+  describe "streamed response failures" do
+    test "raises with the transport reason when the connection drops mid stream" do
+      url = start_chunked_server(fn socket -> :gen_tcp.close(socket) end)
+
+      assert {:ok, env} =
+               call(%Env{method: :get, url: url}, response: :stream, receive_timeout: 200)
+
+      assert_raise Tesla.Error, ~r/^:closed /, fn -> Enum.to_list(env.body) end
+    end
+
+    test "raises with :timeout when the next chunk takes longer than :receive_timeout" do
+      url = start_chunked_server(fn _socket -> Process.sleep(1_000) end)
+
+      assert {:ok, env} =
+               call(%Env{method: :get, url: url}, response: :stream, receive_timeout: 200)
+
+      assert_raise Tesla.Error, ~r/^:timeout /, fn -> Enum.to_list(env.body) end
+    end
+
+    test "ends the stream without raising when the response completes" do
+      url = start_chunked_server(fn socket -> :gen_tcp.send(socket, "0\r\n\r\n") end)
+
+      assert {:ok, env} =
+               call(%Env{method: :get, url: url}, response: :stream, receive_timeout: 200)
+
+      assert Enum.to_list(env.body) == ["hello"]
+    end
+  end
+
+  # Sends a chunked response with a single "hello" chunk, then hands the socket
+  # over to `after_chunk` to decide how the response ends.
+  defp start_chunked_server(after_chunk) do
+    {:ok, listen} =
+      :gen_tcp.listen(0,
+        ip: {127, 0, 0, 1},
+        mode: :binary,
+        packet: :raw,
+        active: false,
+        reuseaddr: true
+      )
+
+    {:ok, port} = :inet.port(listen)
+
+    spawn_link(fn ->
+      {:ok, socket} = :gen_tcp.accept(listen, 5_000)
+      {:ok, _request} = :gen_tcp.recv(socket, 0, 5_000)
+
+      :gen_tcp.send(socket, [
+        "HTTP/1.1 200 OK\r\n",
+        "content-type: text/event-stream\r\n",
+        "transfer-encoding: chunked\r\n\r\n",
+        "5\r\nhello\r\n"
+      ])
+
+      after_chunk.(socket)
+      # Keep the socket owner alive so the last bytes are not lost on exit.
+      Process.sleep(500)
+    end)
+
+    "http://127.0.0.1:#{port}/"
+  end
 end


### PR DESCRIPTION
Closes #912

- A streamed response that broke halfway through was indistinguishable from one that finished, so callers accepted truncated data as a complete answer.
- A dropped connection and an exhausted `:receive_timeout` need to be told apart to decide whether retrying is worthwhile.
- Failures after the headers arrived cannot be returned as `{:error, reason}`, since the request already succeeded from the caller point of view, so they are raised while the body is consumed instead.
- Keeping stream elements as binaries leaves `Tesla.Middleware.SSE` and any other consumer that concatenates chunks untouched.
- Matches how the Mint adapter already reports mid-stream failures.