### PR TITLE
fix(form-urlencoded): do not claim a content-type it did not encode

### DIFF
--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -183,6 +183,12 @@ defmodule Tesla.Middleware.FormUrlencoded do
     field on Stripe-style update endpoints.
   - Map keys are not ordered; keyword lists and lists of 2-tuples
     preserve the order you give them.
+  - A body that is already a binary is left untouched and no
+    `content-type` header is added, matching `Tesla.Middleware.JSON`. This
+    is what lets both middlewares share one stack: `JSON` encodes the body
+    and claims `application/json`, and this middleware then sees a binary
+    and stays out of the way rather than appending a second `content-type`.
+    Encode the body yourself and you own its `content-type` too.
   - Decoding stays flat. `Plug.Conn.Query.decode/1` will parse the
     bracket keys into nested maps, but indexed lists come back as maps
     keyed by string indices (`"0"`, `"1"`, …), not as Elixir lists, so
@@ -221,10 +227,10 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   defp encodable?(%{body: {:form_urlencoded, _}}), do: true
   defp encodable?(%{body: nil}), do: false
+  defp encodable?(%{body: body}) when is_binary(body), do: false
   defp encodable?(%{body: %Tesla.Multipart{}}), do: false
   defp encodable?(_), do: true
 
-  defp encode_body(body, _opts) when is_binary(body), do: body
   defp encode_body({:form_urlencoded, data}, opts), do: do_encode(data, opts)
   defp encode_body(body, opts), do: do_encode(body, opts)
 

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -39,9 +39,43 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
     assert env.body == "application/x-www-form-urlencoded"
   end
 
+  test "no content-type is set if body is binary" do
+    assert {:ok, env} = Client.post("/check_incoming_content_type", "data")
+    assert env.body == nil
+  end
+
   test "decode response" do
     assert {:ok, env} = Client.get("/decode_response")
     assert env.body == %{"x" => "1", "y" => "2"}
+  end
+
+  defmodule JsonStackClient do
+    use Tesla
+
+    plug Tesla.Middleware.JSON
+    plug Tesla.Middleware.FormUrlencoded
+
+    adapter fn env ->
+      {:ok,
+       %{
+         env
+         | status: 200,
+           headers: [{"content-type", "text/html"}],
+           body: Tesla.get_headers(env, "content-type")
+       }}
+    end
+  end
+
+  describe "sharing a stack with Tesla.Middleware.JSON" do
+    test "a json body is left with a single application/json content-type" do
+      assert {:ok, env} = JsonStackClient.post("/post", %{"foo" => "bar"})
+      assert env.body == ["application/json"]
+    end
+
+    test "a tagged form body is left with a single form content-type" do
+      assert {:ok, env} = JsonStackClient.post("/post", {:form_urlencoded, %{"foo" => "bar"}})
+      assert env.body == ["application/x-www-form-urlencoded"]
+    end
   end
 
   defmodule MultipartClient do


### PR DESCRIPTION
- `Tesla.Middleware.JSON` and this middleware are meant to share one stack, but #886 only wired up half of that handshake: `JSON` learned to decline form-tagged bodies, while nothing taught this middleware to decline a body `JSON` had already encoded.
- The consequence is two `content-type` headers on every JSON request from any client that also has a single form-encoded operation, and a server is free to reject that.
- Reordering the stack cannot avoid it, because this middleware has to stay after `JSON`: in front of it, a struct body reaches the catch-all and raises.
- Deciding this in `encodable?/1` makes the rule uniform across both middlewares, which is that a middleware claims the `content-type` precisely when it encoded the body.
- One behavior change worth calling out: a body that is already a binary no longer receives a form `content-type`. That path was undocumented, the existing binary test only pinned the body and never the header, and `Tesla.Middleware.JSON` has behaved this way since 9514bd1.