### PR TITLE
fix(retry): ignore Retry-After values that are not valid delay-seconds

### DIFF
--- a/lib/tesla/middleware/retry.ex
+++ b/lib/tesla/middleware/retry.ex
@@ -54,7 +54,8 @@ defmodule Tesla.Middleware.Retry do
       (float between 0 and 1, defaults to 0.2)
   - `:use_retry_after_header` - whether to use the Retry-After header to determine the minimum
       delay before the next retry.  If the delay from the header exceeds max_delay, no further
-      retries are attempted.  Invalid Retry-After headers are ignored.
+      retries are attempted.  A valid header is either a non-negative number of seconds or an
+      HTTP-date; invalid headers are ignored and exponential backoff is used instead.
       (boolean, defaults to false)
   """
 

--- a/lib/tesla/middleware/retry.ex
+++ b/lib/tesla/middleware/retry.ex
@@ -138,10 +138,14 @@ defmodule Tesla.Middleware.Retry do
   # Credits to @wojtekmach
   defp retry_delay_in_ms(delay_value) do
     case Integer.parse(delay_value) do
-      {seconds, ""} ->
+      {seconds, ""} when seconds >= 0 ->
         {:ok, :timer.seconds(seconds)}
 
-      :error ->
+      {_negative_seconds, ""} ->
+        {:error,
+         "cannot parse \"retry-after\" header value #{inspect(delay_value)} as delay, reason: delay-seconds must be non-negative"}
+
+      _ ->
         case parse_http_datetime(delay_value) do
           {:ok, date_time} ->
             {:ok,

--- a/lib/tesla/middleware/retry.ex
+++ b/lib/tesla/middleware/retry.ex
@@ -135,15 +135,22 @@ defmodule Tesla.Middleware.Retry do
     nil
   end
 
+  @typep invalid_retry_after ::
+           {:invalid_delay_seconds, integer()}
+           | {:invalid_month, String.t()}
+           | {:invalid_http_date, atom()}
+           | :unrecognized_format
+
   # Credits to @wojtekmach
+  @spec retry_delay_in_ms(String.t()) ::
+          {:ok, non_neg_integer()} | {:error, invalid_retry_after()}
   defp retry_delay_in_ms(delay_value) do
     case Integer.parse(delay_value) do
       {seconds, ""} when seconds >= 0 ->
         {:ok, :timer.seconds(seconds)}
 
-      {_negative_seconds, ""} ->
-        {:error,
-         "cannot parse \"retry-after\" header value #{inspect(delay_value)} as delay, reason: delay-seconds must be non-negative"}
+      {seconds, ""} ->
+        {:error, {:invalid_delay_seconds, seconds}}
 
       _ ->
         case parse_http_datetime(delay_value) do
@@ -174,13 +181,14 @@ defmodule Tesla.Middleware.Retry do
     "Dec" => "12"
   }
 
+  @spec parse_http_datetime(String.t()) ::
+          {:ok, DateTime.t()} | {:error, invalid_retry_after()}
   defp parse_http_datetime(datetime) do
     case String.split(datetime, " ") do
       [_day_of_week, day, month, year, time, "GMT"] ->
         case @month_numbers[month] do
           nil ->
-            {:error,
-             "cannot parse \"retry-after\" header value #{inspect(datetime)} as datetime, reason: invalid month"}
+            {:error, {:invalid_month, month}}
 
           month_number ->
             date = year <> "-" <> month_number <> "-" <> day
@@ -190,14 +198,12 @@ defmodule Tesla.Middleware.Retry do
                 {:ok, valid_datetime}
 
               {:error, reason} ->
-                {:error,
-                 "cannot parse \"retry-after\" header value #{inspect(datetime)} as datetime, reason: #{reason}"}
+                {:error, {:invalid_http_date, reason}}
             end
         end
 
       _ ->
-        {:error,
-         "cannot parse \"retry-after\" header value #{inspect(datetime)} as datetime, reason: header is not in HTTP-date or integer format"}
+        {:error, :unrecognized_format}
     end
   end
 

--- a/test/tesla/middleware/retry_test.exs
+++ b/test/tesla/middleware/retry_test.exs
@@ -68,6 +68,18 @@ defmodule Tesla.Middleware.RetryTest do
             "/retry_after_invalid_format" ->
               {:ok, %{env | status: 200}}
 
+            "/retry_after_negative_seconds" when retries < 5 ->
+              {:ok, %{env | status: 429, headers: [{"retry-after", "-1"} | env.headers]}}
+
+            "/retry_after_negative_seconds" ->
+              {:ok, %{env | status: 200}}
+
+            "/retry_after_trailing_garbage" when retries < 5 ->
+              {:ok, %{env | status: 429, headers: [{"retry-after", "2 seconds"} | env.headers]}}
+
+            "/retry_after_trailing_garbage" ->
+              {:ok, %{env | status: 200}}
+
             "/retry_after_invalid_month" when retries < 5 ->
               {:ok,
                %{
@@ -266,6 +278,20 @@ defmodule Tesla.Middleware.RetryTest do
   test "ignore Retry-After header if it is not in an expected format" do
     assert {:ok, %Tesla.Env{url: "/retry_after_invalid_format", method: :get, status: 200}} =
              ClientUsingRetryAfterHeader.get("/retry_after_invalid_format")
+
+    assert Agent.get(LaggyAdapter, fn %{retries: retries} -> retries end) == 6
+  end
+
+  test "ignore Retry-After header if it is a negative number of seconds" do
+    assert {:ok, %Tesla.Env{url: "/retry_after_negative_seconds", method: :get, status: 200}} =
+             ClientUsingRetryAfterHeader.get("/retry_after_negative_seconds")
+
+    assert Agent.get(LaggyAdapter, fn %{retries: retries} -> retries end) == 6
+  end
+
+  test "ignore Retry-After header if it has trailing garbage after the number" do
+    assert {:ok, %Tesla.Env{url: "/retry_after_trailing_garbage", method: :get, status: 200}} =
+             ClientUsingRetryAfterHeader.get("/retry_after_trailing_garbage")
 
     assert Agent.get(LaggyAdapter, fn %{retries: retries} -> retries end) == 6
   end


### PR DESCRIPTION
Closes #917

- RFC 9110 defines `delay-seconds` as a non-negative decimal integer, so a negative value is not a valid delay and a server sending one should not be able to crash the calling process.
- The middleware already documents that invalid `Retry-After` headers are ignored, but negative values were slept on and partially numeric values were unmatched, so the documented contract did not hold.
- The parse failure reason is discarded at its only call site, so a structured term costs nothing to build and leaves something to match on if the middleware ever needs to report why a header was ignored.