### PR TITLE
fix(adapter): send the final chunk of a request body stream that halts

### DIFF
--- a/lib/tesla/adapter/shared.ex
+++ b/lib/tesla/adapter/shared.ex
@@ -2,16 +2,20 @@ defmodule Tesla.Adapter.Shared do
   @moduledoc false
 
   def stream_to_fun(stream) do
-    reductor = fn item, _acc -> {:suspend, item} end
-    {_, _, fun} = Enumerable.reduce(stream, {:suspend, nil}, reductor)
+    {_, _, fun} = Enumerable.reduce(stream, {:suspend, :start}, &suspend_chunk/2)
 
     fun
   end
 
-  def next_chunk(fun), do: parse_chunk(fun.({:cont, nil}))
+  defp suspend_chunk(item, _acc), do: {:suspend, {:chunk, item}}
 
-  defp parse_chunk({:suspended, item, fun}), do: {:ok, item, fun}
+  def next_chunk(fun), do: parse_chunk(fun.({:cont, :start}))
+
+  defp parse_chunk({:suspended, {:chunk, item}, fun}), do: {:ok, item, fun}
+  defp parse_chunk({:halted, {:chunk, item}}), do: {:ok, item, &no_chunk/1}
   defp parse_chunk(_), do: :eof
+
+  defp no_chunk({_command, acc}), do: {:done, acc}
 
   @spec prepare_path(String.t() | nil, String.t() | nil) :: String.t()
   def prepare_path(nil, nil), do: "/"

--- a/test/support/adapter_case/stream_request_body.ex
+++ b/test/support/adapter_case/stream_request_body.ex
@@ -5,16 +5,7 @@ defmodule Tesla.AdapterCase.StreamRequestBody do
 
       describe "Stream Request" do
         test "stream request body: Stream.map" do
-          request = %Env{
-            method: :post,
-            url: "#{@http}/post",
-            headers: [{"content-type", "text/plain"}],
-            body: Stream.map(1..5, &to_string/1)
-          }
-
-          assert {:ok, %Env{} = response} = call(request)
-          assert response.status == 200
-          assert Regex.match?(~r/12345/, to_string(response.body))
+          assert_streamed_body_arrives_intact(Stream.map(1..5, &to_string/1))
         end
 
         test "stream request body: Stream.unfold" do
@@ -25,17 +16,46 @@ defmodule Tesla.AdapterCase.StreamRequestBody do
             end)
             |> Stream.map(&to_string/1)
 
-          request = %Env{
-            method: :post,
-            url: "#{@http}/post",
-            headers: [{"content-type", "text/plain"}],
-            body: body
-          }
-
-          assert {:ok, %Env{} = response} = call(request)
-          assert response.status == 200
-          assert Regex.match?(~r/54321/, to_string(response.body))
+          assert_streamed_body_arrives_intact(body)
         end
+
+        test "stream request body: Stream.take" do
+          assert_streamed_body_arrives_intact(1..9 |> Stream.map(&to_string/1) |> Stream.take(5))
+        end
+
+        test "stream request body: Stream.take of the whole stream" do
+          assert_streamed_body_arrives_intact(1..5 |> Stream.map(&to_string/1) |> Stream.take(5))
+        end
+
+        test "stream request body: Stream.take of nothing" do
+          assert_streamed_body_arrives_intact(1..9 |> Stream.map(&to_string/1) |> Stream.take(0))
+        end
+
+        test "stream request body: Stream.take_while that matches nothing" do
+          body = 1..9 |> Stream.map(&to_string/1) |> Stream.take_while(fn _ -> false end)
+
+          assert_streamed_body_arrives_intact(body)
+        end
+      end
+
+      defp assert_streamed_body_arrives_intact(body) do
+        request = %Env{
+          method: :post,
+          url: "#{@http}/post",
+          headers: [{"content-type", "text/plain"}],
+          body: body
+        }
+
+        assert {:ok, %Env{} = response} = call(request)
+        assert response.status == 200
+        assert echoed_request_body(response.body) == Enum.join(body)
+      end
+
+      defp echoed_request_body(response_body) do
+        response_body
+        |> to_string()
+        |> Jason.decode!()
+        |> Map.fetch!("data")
       end
     end
   end


### PR DESCRIPTION
- A stream that halts on the same step that yields its last element had that element silently dropped, so `Stream.take/2` request bodies were sent short by one chunk with no error to signal it. Confirmed against httparrot: `Stream.take(["aaa", "bbb", "ccc"], 3)` reached the server as `aaabbb` through the mint, httpc and ibrowse adapters, while hackney, which does not share this code, sent it correctly.
- Silent truncation is worse than a crash here, since a caller has no signal that the body was incomplete.
- The regression test lives in the shared adapter case so every adapter that streams request bodies is covered, not only the three that were observed failing.