### PR TITLE
chore(adapter): assert request bodies arrive intact

### DIFF
--- a/test/support/adapter_case/basic.ex
+++ b/test/support/adapter_case/basic.ex
@@ -8,6 +8,7 @@ defmodule Tesla.AdapterCase.Basic do
                                    :connection_refused_reason,
                                    :econnrefused
                                  )
+      @empty_response_body Keyword.get(unquote(opts), :empty_response_body, "")
 
       describe "Basic" do
         test "HEAD request" do
@@ -18,7 +19,7 @@ defmodule Tesla.AdapterCase.Basic do
 
           assert {:ok, %Env{} = response} = call(request)
           assert response.status == 200
-          assert to_string(response.body) == ""
+          assert response.body == @empty_response_body
         end
 
         test "GET request" do

--- a/test/support/adapter_case/basic.ex
+++ b/test/support/adapter_case/basic.ex
@@ -1,7 +1,13 @@
 defmodule Tesla.AdapterCase.Basic do
-  defmacro __using__(_) do
+  defmacro __using__(opts \\ []) do
     quote do
       alias Tesla.Env
+
+      @connection_refused_reason Keyword.get(
+                                   unquote(opts),
+                                   :connection_refused_reason,
+                                   :econnrefused
+                                 )
 
       describe "Basic" do
         test "HEAD request" do
@@ -12,6 +18,7 @@ defmodule Tesla.AdapterCase.Basic do
 
           assert {:ok, %Env{} = response} = call(request)
           assert response.status == 200
+          assert to_string(response.body) == ""
         end
 
         test "GET request" do
@@ -35,7 +42,7 @@ defmodule Tesla.AdapterCase.Basic do
           assert {:ok, %Env{} = response} = call(request)
           assert response.status == 200
           assert Tesla.get_header(response, "content-type") == "application/json"
-          assert Regex.match?(~r/some-post-data/, response.body)
+          assert echoed_request_body(response.body) == "some-post-data"
         end
 
         test "unicode" do
@@ -49,7 +56,23 @@ defmodule Tesla.AdapterCase.Basic do
           assert {:ok, %Env{} = response} = call(request)
           assert response.status == 200
           assert Tesla.get_header(response, "content-type") == "application/json"
-          assert Regex.match?(~r/1 ø 2 đ 1 ø 2 đ/, response.body)
+          assert echoed_request_body(response.body) == "1 \u00F8 2 \u0111 1 \u00F8 2 \u0111"
+        end
+
+        test "POST request with control bytes" do
+          body = for byte <- 0..127, into: "", do: <<byte>>
+
+          request = %Env{
+            method: :post,
+            url: "#{@http}/post",
+            body: body,
+            headers: [{"content-type", "application/octet-stream"}]
+          }
+
+          assert {:ok, %Env{} = response} = call(request)
+          assert response.status == 200
+          assert echoed_request_body(response.body) == body
+          assert echoed_request_header(response.body, "content-length") == "128"
         end
 
         test "passing query params" do
@@ -121,9 +144,22 @@ defmodule Tesla.AdapterCase.Basic do
             url: "http://localhost:1234"
           }
 
-          assert {:error, _} = call(request)
+          assert {:error, reason} = call(request)
+          assert unwrap_reason(reason) == @connection_refused_reason
         end
       end
+
+      defp echoed_request_body(response_body) do
+        response_body |> to_string() |> Jason.decode!() |> Map.fetch!("data")
+      end
+
+      defp echoed_request_header(response_body, name) do
+        response_body |> to_string() |> Jason.decode!() |> get_in(["headers", name])
+      end
+
+      defp unwrap_reason(%{reason: reason}), do: unwrap_reason(reason)
+      defp unwrap_reason({:error, reason}), do: unwrap_reason(reason)
+      defp unwrap_reason(reason), do: reason
     end
   end
 end

--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -2,7 +2,7 @@ defmodule Tesla.Adapter.GunTest do
   use ExUnit.Case
 
   use Tesla.AdapterCase, adapter: Tesla.Adapter.Gun
-  use Tesla.AdapterCase.Basic
+  use Tesla.AdapterCase.Basic, connection_refused_reason: :timeout
   use Tesla.AdapterCase.Multipart
   use Tesla.AdapterCase.StreamRequestBody
   use Tesla.AdapterCase.Query

--- a/test/tesla/adapter/mint_test.exs
+++ b/test/tesla/adapter/mint_test.exs
@@ -6,7 +6,7 @@ defmodule Tesla.Adapter.MintTest do
   @push_promise_listener_ref :"mint-push-promise"
 
   use Tesla.AdapterCase, adapter: Tesla.Adapter.Mint
-  use Tesla.AdapterCase.Basic
+  use Tesla.AdapterCase.Basic, empty_response_body: nil
   use Tesla.AdapterCase.Multipart
   use Tesla.AdapterCase.StreamRequestBody
   use Tesla.AdapterCase.Query


### PR DESCRIPTION
- The shared adapter suite checked echoed request bodies with `Regex.match?`, a substring test against the whole JSON envelope. Wrapping every outgoing body in `"GARBAGE"`/`"TRAILER"` inside the mint adapter left all Basic tests green, so the suite could not detect request-body corruption at all. Corrupting the *response* body instead failed 27 of 66 mint tests, so the gap was one-sided.
- This is the same blind spot that let the streamed-body truncation in #923 survive for eight years, and `Tesla.Adapter.Shared` was at 100% line coverage the whole time, so coverage was never going to surface it.
- The connection-refused case asserted only `{:error, _}`, which any failure satisfies including an adapter crash. Pinning the reason surfaced that the gun adapter reports `:timeout` rather than `:econnrefused`; that is declared explicitly at gun's call site rather than hidden behind a permissive matcher.