### PR TITLE
chore(test): cover the Tesla.Test assertion helpers

### DIFF
--- a/test/tesla/test_test.exs
+++ b/test/tesla/test_test.exs
@@ -1,6 +1,8 @@
 defmodule Tesla.TestTest do
   use ExUnit.Case, async: true
 
+  import Mox
+
   require Tesla.Test
 
   describe "html/2" do
@@ -101,6 +103,240 @@ defmodule Tesla.TestTest do
           adapter: Tesla.TeslaMox
         )
       end
+    end
+  end
+
+  describe "put_headers/2" do
+    test "sets the headers when the env carries none" do
+      env = Tesla.Test.text(%Tesla.Env{headers: nil}, "Hello, world!")
+      assert env.headers == [{"content-type", "text/plain; charset=utf-8"}]
+    end
+
+    test "appends to the headers the env already carries" do
+      env = Tesla.Test.text(%Tesla.Env{headers: [{"x-request-id", "abc"}]}, "Hello, world!")
+
+      assert env.headers == [
+               {"x-request-id", "abc"},
+               {"content-type", "text/plain; charset=utf-8"}
+             ]
+    end
+  end
+
+  describe "assert_tesla_env/3 body decoding" do
+    test "decodes an application/json body into an atom-keyed map" do
+      given =
+        %Tesla.Env{body: ~s({"some":"data"})}
+        |> Tesla.put_header("content-type", "application/json")
+
+      Tesla.Test.assert_tesla_env(given, %Tesla.Env{
+        body: %{some: "data"},
+        headers: [{"content-type", "application/json"}]
+      })
+    end
+
+    test "decodes an application/x-www-form-urlencoded body into a string-keyed map" do
+      given =
+        %Tesla.Env{body: "name=tesla&lang=elixir"}
+        |> Tesla.put_header("content-type", "application/x-www-form-urlencoded")
+
+      Tesla.Test.assert_tesla_env(given, %Tesla.Env{
+        body: %{"name" => "tesla", "lang" => "elixir"},
+        headers: [{"content-type", "application/x-www-form-urlencoded"}]
+      })
+    end
+
+    test "leaves a content-type carrying parameters undecoded" do
+      given = Tesla.Test.json(%Tesla.Env{}, %{some: "data"})
+
+      Tesla.Test.assert_tesla_env(given, %Tesla.Env{
+        body: ~s({"some":"data"}),
+        headers: [{"content-type", "application/json; charset=utf-8"}]
+      })
+
+      assert_raise ExUnit.AssertionError, fn ->
+        Tesla.Test.assert_tesla_env(given, %Tesla.Env{
+          body: %{some: "data"},
+          headers: [{"content-type", "application/json; charset=utf-8"}]
+        })
+      end
+    end
+
+    test "leaves a body without a content-type undecoded" do
+      Tesla.Test.assert_tesla_env(%Tesla.Env{body: "raw"}, %Tesla.Env{body: "raw"})
+    end
+  end
+
+  describe "assert_tesla_env/3 mismatches" do
+    test "fails on a different method" do
+      assert_raise ExUnit.AssertionError, fn ->
+        Tesla.Test.assert_tesla_env(%Tesla.Env{method: :post}, %Tesla.Env{method: :get})
+      end
+    end
+
+    test "fails on a different url" do
+      assert_raise ExUnit.AssertionError, fn ->
+        Tesla.Test.assert_tesla_env(
+          %Tesla.Env{url: "https://acme.com"},
+          %Tesla.Env{url: "https://example.com"}
+        )
+      end
+    end
+
+    test "fails on a different query" do
+      assert_raise ExUnit.AssertionError, fn ->
+        Tesla.Test.assert_tesla_env(%Tesla.Env{query: [page: 1]}, %Tesla.Env{query: [page: 2]})
+      end
+    end
+
+    test "fails on a different body" do
+      assert_raise ExUnit.AssertionError, fn ->
+        Tesla.Test.assert_tesla_env(%Tesla.Env{body: "given"}, %Tesla.Env{body: "expected"})
+      end
+    end
+
+    test "fails on a header the expectation does not carry" do
+      given = Tesla.put_header(%Tesla.Env{}, "traceparent", "00-0af7-b7ad-01")
+
+      assert_raise ExUnit.AssertionError, fn ->
+        Tesla.Test.assert_tesla_env(given, %Tesla.Env{})
+      end
+    end
+
+    test "fails on a header excluded under a different key" do
+      given = Tesla.put_header(%Tesla.Env{}, "traceparent", "00-0af7-b7ad-01")
+
+      assert_raise ExUnit.AssertionError, fn ->
+        Tesla.Test.assert_tesla_env(given, %Tesla.Env{}, exclude_headers: ["authorization"])
+      end
+    end
+  end
+
+  describe "expect_tesla_call/1" do
+    setup :verify_on_exit!
+
+    test "merges the returned status, body and headers onto the request env" do
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: %Tesla.Env{status: 201, body: "OK", headers: [{"x-trace", "1"}]},
+        adapter: Tesla.TestSupport.MockAdapter
+      )
+
+      assert {:ok, env} = Tesla.post(client(), "https://acme.com/users", "some-data")
+      assert env.status == 201
+      assert env.body == "OK"
+      assert env.headers == [{"x-trace", "1"}]
+      assert env.method == :post
+      assert env.url == "https://acme.com/users"
+    end
+
+    test "delegates to the returned function" do
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn given_env, given_opts ->
+          {:ok, %{given_env | status: 200, body: {given_env.url, given_opts}}}
+        end,
+        adapter: Tesla.TestSupport.MockAdapter
+      )
+
+      assert {:ok, env} = Tesla.get(client(), "https://acme.com/users")
+      assert env.body == {"https://acme.com/users", []}
+    end
+
+    test "returns the given error" do
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: {:error, :econnrefused},
+        adapter: Tesla.TestSupport.MockAdapter
+      )
+
+      assert {:error, :econnrefused} = Tesla.get(client(), "https://acme.com/users")
+    end
+
+    test "expects the call the given number of times" do
+      Tesla.Test.expect_tesla_call(
+        times: 2,
+        returns: %Tesla.Env{status: 200},
+        adapter: Tesla.TestSupport.MockAdapter
+      )
+
+      assert {:ok, _} = Tesla.get(client(), "https://acme.com/users")
+      assert {:ok, _} = Tesla.get(client(), "https://acme.com/users")
+
+      Tesla.Test.assert_received_tesla_call(_env, _opts, adapter: Tesla.TestSupport.MockAdapter)
+      Tesla.Test.assert_received_tesla_call(_env, _opts, adapter: Tesla.TestSupport.MockAdapter)
+      Tesla.Test.assert_tesla_empty_mailbox()
+    end
+
+    test "sends the call to the given process" do
+      parent = self()
+
+      collector =
+        spawn_link(fn ->
+          receive do
+            message -> send(parent, {:collected, message})
+          end
+        end)
+
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: %Tesla.Env{status: 200},
+        send_to: collector,
+        adapter: Tesla.TestSupport.MockAdapter
+      )
+
+      assert {:ok, _} = Tesla.get(client(), "https://acme.com/users")
+
+      assert_receive {:collected, {Tesla.Test, {Tesla.TestSupport.MockAdapter, :call, [env, []]}}}
+
+      assert env.url == "https://acme.com/users"
+
+      Tesla.Test.assert_tesla_empty_mailbox()
+    end
+
+    test "sends nothing when send_to is nil" do
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: %Tesla.Env{status: 200},
+        send_to: nil,
+        adapter: Tesla.TestSupport.MockAdapter
+      )
+
+      assert {:ok, _} = Tesla.get(client(), "https://acme.com/users")
+
+      Tesla.Test.assert_tesla_empty_mailbox()
+    end
+  end
+
+  defp client, do: Tesla.client([], Tesla.TestSupport.MockAdapter)
+end
+
+defmodule Tesla.TestAdapterResolutionTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  setup do
+    on_exit(fn -> Application.delete_env(:tesla, :adapter) end)
+    :ok
+  end
+
+  test "falls back to the adapter configured for the application" do
+    Application.put_env(:tesla, :adapter, Tesla.TestSupport.MockAdapter)
+
+    Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200})
+
+    client = Tesla.client([], Tesla.TestSupport.MockAdapter)
+    assert {:ok, env} = Tesla.get(client, "https://acme.com/users")
+    assert env.status == 200
+
+    verify!(Tesla.TestSupport.MockAdapter)
+  end
+
+  test "raises when no adapter is configured" do
+    Application.delete_env(:tesla, :adapter)
+
+    assert_raise ArgumentError, ~r/expected :adapter to be defined/, fn ->
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200})
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,6 @@
 clients = [:ibrowse, :hackney, :gun, :finch, :castore, :mint]
 Enum.map(clients, &Application.ensure_all_started/1)
+
+Mox.defmock(Tesla.TestSupport.MockAdapter, for: Tesla.Adapter)
+
 ExUnit.start()


### PR DESCRIPTION
- `Tesla.Test` is public API that downstream suites build their own assertions on, so a regression in it silently weakens every suite depending on it
- `expect_tesla_call/1`, adapter resolution and request body decoding were entirely unverified, which is the part users hit first
- every new assertion was checked by mutating the code under test, so the tests are known to fail when the behaviour changes rather than merely executing it