### PR TITLE
chore(gun): cover the connection, proxy and reply routing paths

### DIFF
--- a/test/support/adapter_case/basic.ex
+++ b/test/support/adapter_case/basic.ex
@@ -1,6 +1,7 @@
 defmodule Tesla.AdapterCase.Basic do
   defmacro __using__(opts \\ []) do
     quote do
+      alias Tesla.AdapterCase.Echo
       alias Tesla.Env
 
       @connection_refused_reason Keyword.get(
@@ -43,7 +44,7 @@ defmodule Tesla.AdapterCase.Basic do
           assert {:ok, %Env{} = response} = call(request)
           assert response.status == 200
           assert Tesla.get_header(response, "content-type") == "application/json"
-          assert echoed_request_body(response.body) == "some-post-data"
+          assert Echo.request_body(response.body) == "some-post-data"
         end
 
         test "unicode" do
@@ -57,7 +58,7 @@ defmodule Tesla.AdapterCase.Basic do
           assert {:ok, %Env{} = response} = call(request)
           assert response.status == 200
           assert Tesla.get_header(response, "content-type") == "application/json"
-          assert echoed_request_body(response.body) == "1 \u00F8 2 \u0111 1 \u00F8 2 \u0111"
+          assert Echo.request_body(response.body) == "1 \u00F8 2 \u0111 1 \u00F8 2 \u0111"
         end
 
         test "POST request with control bytes" do
@@ -72,8 +73,8 @@ defmodule Tesla.AdapterCase.Basic do
 
           assert {:ok, %Env{} = response} = call(request)
           assert response.status == 200
-          assert echoed_request_body(response.body) == body
-          assert echoed_request_header(response.body, "content-length") == "128"
+          assert Echo.request_body(response.body) == body
+          assert Echo.request_header(response.body, "content-length") == "128"
         end
 
         test "passing query params" do
@@ -148,14 +149,6 @@ defmodule Tesla.AdapterCase.Basic do
           assert {:error, reason} = call(request)
           assert unwrap_reason(reason) == @connection_refused_reason
         end
-      end
-
-      defp echoed_request_body(response_body) do
-        response_body |> to_string() |> Jason.decode!() |> Map.fetch!("data")
-      end
-
-      defp echoed_request_header(response_body, name) do
-        response_body |> to_string() |> Jason.decode!() |> get_in(["headers", name])
       end
 
       defp unwrap_reason(%{reason: reason}), do: unwrap_reason(reason)

--- a/test/support/adapter_case/echo.ex
+++ b/test/support/adapter_case/echo.ex
@@ -1,0 +1,17 @@
+defmodule Tesla.AdapterCase.Echo do
+  @moduledoc """
+  Reads back what the httparrot echo endpoints report about a request.
+  """
+
+  def request_body(response_body) do
+    response_body |> decode() |> Map.fetch!("data")
+  end
+
+  def request_header(response_body, name) do
+    response_body |> decode() |> get_in(["headers", name])
+  end
+
+  defp decode(response_body) do
+    response_body |> to_string() |> Jason.decode!()
+  end
+end

--- a/test/support/adapter_case/stream_request_body.ex
+++ b/test/support/adapter_case/stream_request_body.ex
@@ -1,6 +1,7 @@
 defmodule Tesla.AdapterCase.StreamRequestBody do
   defmacro __using__(_) do
     quote do
+      alias Tesla.AdapterCase.Echo
       alias Tesla.Env
 
       describe "Stream Request" do
@@ -48,14 +49,7 @@ defmodule Tesla.AdapterCase.StreamRequestBody do
 
         assert {:ok, %Env{} = response} = call(request)
         assert response.status == 200
-        assert echoed_request_body(response.body) == Enum.join(body)
-      end
-
-      defp echoed_request_body(response_body) do
-        response_body
-        |> to_string()
-        |> Jason.decode!()
-        |> Map.fetch!("data")
+        assert Echo.request_body(response.body) == Enum.join(body)
       end
     end
   end

--- a/test/support/tcp_proxy.ex
+++ b/test/support/tcp_proxy.ex
@@ -1,0 +1,70 @@
+defmodule Tesla.TestSupport.TcpProxy do
+  @moduledoc false
+
+  def start(opts) do
+    report_to = Keyword.fetch!(opts, :report_to)
+    on_connect = Keyword.fetch!(opts, :on_connect)
+
+    {:ok, listen} =
+      :gen_tcp.listen(0, [:binary, ip: {127, 0, 0, 1}, active: false, reuseaddr: true])
+
+    {:ok, port} = :inet.port(listen)
+    pid = spawn(fn -> serve(listen, report_to, on_connect) end)
+
+    {:ok, pid, port}
+  end
+
+  defp serve(listen, report_to, on_connect) do
+    {:ok, socket} = :gen_tcp.accept(listen)
+    :gen_tcp.close(listen)
+
+    send(report_to, {:tcp_proxy_request, read_request(socket, "")})
+
+    case on_connect do
+      {:reject, status, reason} ->
+        body = "denied"
+
+        :gen_tcp.send(socket, [
+          "HTTP/1.1 #{status} #{reason}\r\n",
+          "content-length: #{byte_size(body)}\r\n",
+          "\r\n",
+          body
+        ])
+
+        :gen_tcp.close(socket)
+
+      {:tunnel, host, port} ->
+        {:ok, upstream} = :gen_tcp.connect(host, port, [:binary, active: true])
+        :gen_tcp.send(socket, "HTTP/1.1 200 Connection established\r\n\r\n")
+        :ok = :inet.setopts(socket, active: true)
+        relay(socket, upstream)
+    end
+  end
+
+  defp read_request(socket, acc) do
+    if String.contains?(acc, "\r\n\r\n") do
+      acc
+    else
+      {:ok, data} = :gen_tcp.recv(socket, 0)
+      read_request(socket, acc <> data)
+    end
+  end
+
+  defp relay(client, upstream) do
+    receive do
+      {:tcp, ^client, data} ->
+        :gen_tcp.send(upstream, data)
+        relay(client, upstream)
+
+      {:tcp, ^upstream, data} ->
+        :gen_tcp.send(client, data)
+        relay(client, upstream)
+
+      {:tcp_closed, _socket} ->
+        :ok
+
+      {:tcp_error, _socket, _reason} ->
+        :ok
+    end
+  end
+end

--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -1,3 +1,7 @@
+defmodule ReplyToCollector do
+  def collect(message, pid), do: send(pid, {:collected, message})
+end
+
 defmodule Tesla.Adapter.GunTest do
   use ExUnit.Case
 
@@ -255,6 +259,135 @@ defmodule Tesla.Adapter.GunTest do
     Gun.close(pid)
   end
 
+  test "keeps the reply_to untouched when the stream owner is the request owner" do
+    test_pid = self()
+
+    request = %Env{
+      method: :get,
+      url: "#{@http}/stream-bytes/10",
+      private: %{tesla_gun_stream_owner: test_pid}
+    }
+
+    reply_to = spawn_forwarder(test_pid, :reply_to)
+    on_exit(fn -> Process.exit(reply_to, :kill) end)
+
+    assert {:error, :recv_response_timeout} =
+             call(request, body_as: :chunks, reply_to: reply_to, timeout: 100)
+
+    assert_receive {:reply_to, {:gun_response, pid, stream, :nofin, 200, _headers}}
+    assert_receive {:reply_to, {:gun_data, ^pid, ^stream, _, _}}
+    refute_received {:gun_response, ^pid, ^stream, :nofin, 200, _headers}
+
+    Gun.close(pid)
+  end
+
+  test "routes to a pid reply_to when stream ownership is handed off" do
+    test_pid = self()
+
+    stream_owner = spawn_forwarder(test_pid, :stream_owner)
+    reply_to = spawn_forwarder(test_pid, :reply_to)
+    on_exit(fn -> Enum.each([stream_owner, reply_to], &Process.exit(&1, :kill)) end)
+
+    request = %Env{
+      method: :get,
+      url: "#{@http}/stream-bytes/10",
+      private: %{tesla_gun_stream_owner: stream_owner}
+    }
+
+    assert {:ok, %Env{status: 200, body: %{pid: pid, stream: stream}}} =
+             call(request, body_as: :chunks, reply_to: reply_to, timeout: 5_000)
+
+    assert_receive {:reply_to, {:gun_response, ^pid, ^stream, :nofin, 200, _headers}}
+    assert_receive {:reply_to, {:gun_data, ^pid, ^stream, _, _}}
+    assert_receive {:stream_owner, {:gun_data, ^pid, ^stream, _, _}}
+    assert_receive {:gun_data, ^pid, ^stream, _, _}
+
+    Gun.close(pid)
+  end
+
+  test "routes to a module function reply_to when stream ownership is handed off" do
+    test_pid = self()
+
+    stream_owner = spawn_forwarder(test_pid, :stream_owner)
+    on_exit(fn -> Process.exit(stream_owner, :kill) end)
+
+    request = %Env{
+      method: :get,
+      url: "#{@http}/stream-bytes/10",
+      private: %{tesla_gun_stream_owner: stream_owner}
+    }
+
+    assert {:ok, %Env{status: 200, body: %{pid: pid, stream: stream}}} =
+             call(request,
+               body_as: :chunks,
+               reply_to: {ReplyToCollector, :collect, [test_pid]},
+               timeout: 5_000
+             )
+
+    assert_receive {:collected, {:gun_response, ^pid, ^stream, :nofin, 200, _headers}}
+    assert_receive {:collected, {:gun_data, ^pid, ^stream, _, _}}
+
+    Gun.close(pid)
+  end
+
+  test "routes to a function reply_to carrying extra arguments" do
+    test_pid = self()
+
+    stream_owner = spawn_forwarder(test_pid, :stream_owner)
+    on_exit(fn -> Process.exit(stream_owner, :kill) end)
+
+    request = %Env{
+      method: :get,
+      url: "#{@http}/stream-bytes/10",
+      private: %{tesla_gun_stream_owner: stream_owner}
+    }
+
+    collect = fn message, pid -> send(pid, {:collected, message}) end
+
+    assert {:ok, %Env{status: 200, body: %{pid: pid, stream: stream}}} =
+             call(request, body_as: :chunks, reply_to: {collect, [test_pid]}, timeout: 5_000)
+
+    assert_receive {:collected, {:gun_response, ^pid, ^stream, :nofin, 200, _headers}}
+    assert_receive {:collected, {:gun_data, ^pid, ^stream, _, _}}
+
+    Gun.close(pid)
+  end
+
+  test "delivers once when the reply_to is also the stream owner" do
+    test_pid = self()
+
+    stream_owner = spawn_forwarder(test_pid, :stream_owner)
+    on_exit(fn -> Process.exit(stream_owner, :kill) end)
+
+    request = %Env{
+      method: :get,
+      url: "#{@http}/stream-bytes/10",
+      private: %{tesla_gun_stream_owner: stream_owner}
+    }
+
+    assert {:ok, %Env{status: 200, body: %{pid: pid, stream: stream}}} =
+             call(request, body_as: :chunks, reply_to: stream_owner, timeout: 5_000)
+
+    assert_receive {:stream_owner, {:gun_response, ^pid, ^stream, :nofin, 200, _headers}}
+    assert_receive {:stream_owner, {:gun_data, ^pid, ^stream, :fin, _}}
+
+    refute_receive {:stream_owner, {:gun_data, ^pid, ^stream, :fin, _}}
+
+    Gun.close(pid)
+  end
+
+  defp spawn_forwarder(test_pid, tag) do
+    spawn(fn -> forward_messages(test_pid, tag) end)
+  end
+
+  defp forward_messages(test_pid, tag) do
+    receive do
+      message ->
+        send(test_pid, {tag, message})
+        forward_messages(test_pid, tag)
+    end
+  end
+
   defp forward_messages(test_pid) do
     receive do
       message ->
@@ -298,6 +431,205 @@ defmodule Tesla.Adapter.GunTest do
       assert {:error, "socks protocol is not supported"} ==
                call(request, proxy: {:socks5, ~c"localhost", 1234})
     end
+  end
+
+  describe "read_chunk/3" do
+    test "returns the error gun reported for the stream" do
+      stream = make_ref()
+      send(self(), {:gun_error, self(), stream, :closed})
+
+      assert {:error, :closed} == Gun.read_chunk(self(), stream, close_conn: false)
+    end
+
+    test "returns the reason the connection went down" do
+      stream = make_ref()
+      send(self(), {:DOWN, make_ref(), :process, self(), :killed})
+
+      assert {:error, :killed} == Gun.read_chunk(self(), stream, close_conn: false)
+    end
+  end
+
+  test "returns the option error gun rejected the connection with" do
+    request = %Env{
+      method: :get,
+      url: "#{@http}/ip"
+    }
+
+    assert {:error, {:options, {:protocols, [:bogus]}}} == call(request, protocols: [:bogus])
+  end
+
+  test "raises when the response stream stops receiving chunks" do
+    uri = URI.parse(@http)
+    {:ok, conn} = :gun.open(to_charlist(uri.host), uri.port)
+    {:ok, _} = :gun.await_up(conn)
+    on_exit(fn -> Gun.close(conn) end)
+
+    request = %Env{
+      method: :get,
+      url: "#{@http}/stream-bytes/10"
+    }
+
+    assert {:ok, %Env{status: 200, body: stream}} =
+             call(request, body_as: :stream, conn: conn, close_conn: false, timeout: 100)
+
+    Process.sleep(200)
+    :ok = :gun.flush(conn)
+
+    assert_raise RuntimeError, ":recv_chunk_timeout", fn -> Enum.join(stream) end
+  end
+
+  test "reuses a connection opened to an ip address" do
+    {:ok, conn} = :gun.open({127, 0, 0, 1}, Application.get_env(:httparrot, :http_port))
+    {:ok, _} = :gun.await_up(conn)
+    on_exit(fn -> Gun.close(conn) end)
+
+    request = %Env{
+      method: :get,
+      url: "http://127.0.0.1:#{Application.get_env(:httparrot, :http_port)}/ip"
+    }
+
+    assert {:ok, %Env{status: 200}} = call(request, conn: conn, close_conn: false)
+    assert Process.alive?(conn)
+  end
+
+  test "streams a request body given as a bare enumerable function" do
+    body =
+      Stream.unfold(5, fn
+        0 -> nil
+        n -> {to_string(n), n - 1}
+      end)
+
+    assert is_function(body)
+
+    request = %Env{
+      method: :post,
+      url: "#{@http}/post",
+      headers: [{"content-type", "text/plain"}],
+      body: body
+    }
+
+    assert {:ok, %Env{status: 200} = response} = call(request)
+    assert response.body |> Jason.decode!() |> Map.fetch!("data") == "54321"
+  end
+
+  test "reads the tls options from the tls_opts key" do
+    request = %Env{
+      method: :get,
+      url: "#{@https}"
+    }
+
+    assert {:ok, %Env{status: 200}} =
+             call(request,
+               tls_opts: [
+                 verify: :verify_peer,
+                 cacertfile: "#{:code.priv_dir(:httparrot)}/ssl/server-ca.crt"
+               ]
+             )
+  end
+
+  test "returns the connection error gun reported while reading the response" do
+    uri = URI.parse(@http)
+    {:ok, conn} = :gun.open(to_charlist(uri.host), uri.port)
+    {:ok, _} = :gun.await_up(conn)
+    on_exit(fn -> Gun.close(conn) end)
+
+    request = %Env{method: :get, url: "#{@http}/ip"}
+
+    send(self(), {:gun_error, conn, :boom})
+
+    assert {:error, :boom} == call(request, conn: conn, close_conn: false)
+  end
+
+  test "returns the reason the connection went down while reading the response" do
+    uri = URI.parse(@http)
+    {:ok, conn} = :gun.open(to_charlist(uri.host), uri.port)
+    {:ok, _} = :gun.await_up(conn)
+    on_exit(fn -> Gun.close(conn) end)
+
+    request = %Env{method: :get, url: "#{@http}/ip"}
+
+    send(self(), {:DOWN, make_ref(), :process, conn, :killed})
+
+    assert {:error, :killed} == call(request, conn: conn, close_conn: false)
+  end
+
+  describe "proxy" do
+    setup do
+      {:ok, http_port: Application.get_env(:httparrot, :http_port)}
+    end
+
+    test "returns unauthorized when the proxy forbids the tunnel", %{http_port: http_port} do
+      proxy = start_tcp_proxy({:reject, 403, "Forbidden"})
+      request = %Env{method: :get, url: "#{@http}/ip"}
+
+      assert {:error, :unauthorized} == call(request, proxy: proxy, timeout: 2_000)
+
+      assert_receive {:tcp_proxy_request, connect}
+      assert connect =~ "CONNECT localhost:#{http_port} HTTP/1.1"
+      refute connect =~ "proxy-authorization"
+    end
+
+    test "sends the tunnel credentials it was given" do
+      proxy = start_tcp_proxy({:reject, 407, "Proxy Authentication Required"})
+      request = %Env{method: :get, url: "#{@http}/ip"}
+
+      assert {:error, :proxy_auth_failed} ==
+               call(request, proxy: proxy, proxy_auth: {"user", "pass"}, timeout: 2_000)
+
+      credentials = Base.encode64("user:pass")
+
+      assert_receive {:tcp_proxy_request, connect}
+      assert connect =~ "proxy-authorization: Basic #{credentials}"
+    end
+
+    test "asks the proxy to tunnel the https target" do
+      proxy = start_tcp_proxy({:reject, 500, "Internal Server Error"})
+      request = %Env{method: :get, url: "#{@https}/ip"}
+
+      assert {:response, :nofin, 500, _headers} = call(request, proxy: proxy, timeout: 2_000)
+
+      assert_receive {:tcp_proxy_request, connect}
+      assert connect =~ "CONNECT localhost:#{Application.get_env(:httparrot, :https_port)}"
+    end
+
+    test "surfaces the socks version gun rejected" do
+      request = %Env{method: :get, url: "#{@http}/ip"}
+      proxy = {:socks4, ~c"localhost", Application.get_env(:httparrot, :http_port)}
+
+      assert {:error, {:options, {:socks, {:version, 4}}}} ==
+               call(request, proxy: proxy, retry: 0, connect_timeout: 500, timeout: 1_000)
+    end
+
+    test "opens a socks5 tunnel" do
+      request = %Env{method: :get, url: "#{@http}/ip"}
+      proxy = {:socks5, ~c"localhost", Application.get_env(:httparrot, :http_port)}
+
+      assert {:error, :recv_response_timeout} ==
+               call(request, proxy: proxy, retry: 0, connect_timeout: 500, timeout: 500)
+    end
+
+    test "merges the socks options it was given over the tunnel defaults" do
+      request = %Env{method: :get, url: "#{@http}/ip"}
+      proxy = {:socks5, ~c"localhost", Application.get_env(:httparrot, :http_port)}
+
+      assert {:error, {:options, {:socks, {:version, 4}}}} ==
+               call(request,
+                 proxy: proxy,
+                 socks_opts: %{version: 4},
+                 retry: 0,
+                 connect_timeout: 500,
+                 timeout: 500
+               )
+    end
+  end
+
+  defp start_tcp_proxy(on_connect) do
+    {:ok, pid, port} =
+      Tesla.TestSupport.TcpProxy.start(report_to: self(), on_connect: on_connect)
+
+    on_exit(fn -> Process.exit(pid, :kill) end)
+
+    {~c"127.0.0.1", port}
   end
 
   defp read_body(pid, stream, opts, acc \\ "") do

--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -21,6 +21,8 @@ defmodule Tesla.Adapter.GunTest do
 
   import ExUnit.CaptureLog
 
+  @gun2 Application.spec(:gun, :vsn) |> List.to_string() |> Version.match?("~> 2.0")
+
   test "fallback adapter timeout option" do
     request = %Env{
       method: :get,
@@ -421,7 +423,7 @@ defmodule Tesla.Adapter.GunTest do
   end
 
   # Gun 1.0 backwards compatibility tests
-  if not (Application.spec(:gun, :vsn) |> List.to_string() |> Version.match?("~> 2.0")) do
+  if not @gun2 do
     test "error on socks proxy" do
       request = %Env{
         method: :get,
@@ -592,34 +594,36 @@ defmodule Tesla.Adapter.GunTest do
       assert connect =~ "CONNECT localhost:#{Application.get_env(:httparrot, :https_port)}"
     end
 
-    test "surfaces the socks version gun rejected" do
-      request = %Env{method: :get, url: "#{@http}/ip"}
-      proxy = {:socks4, ~c"localhost", Application.get_env(:httparrot, :http_port)}
+    if @gun2 do
+      test "surfaces the socks version gun rejected" do
+        request = %Env{method: :get, url: "#{@http}/ip"}
+        proxy = {:socks4, ~c"localhost", Application.get_env(:httparrot, :http_port)}
 
-      assert {:error, {:options, {:socks, {:version, 4}}}} ==
-               call(request, proxy: proxy, retry: 0, connect_timeout: 500, timeout: 1_000)
-    end
+        assert {:error, {:options, {:socks, {:version, 4}}}} ==
+                 call(request, proxy: proxy, retry: 0, connect_timeout: 500, timeout: 1_000)
+      end
 
-    test "opens a socks5 tunnel" do
-      request = %Env{method: :get, url: "#{@http}/ip"}
-      proxy = {:socks5, ~c"localhost", Application.get_env(:httparrot, :http_port)}
+      test "opens a socks5 tunnel" do
+        request = %Env{method: :get, url: "#{@http}/ip"}
+        proxy = {:socks5, ~c"localhost", Application.get_env(:httparrot, :http_port)}
 
-      assert {:error, :recv_response_timeout} ==
-               call(request, proxy: proxy, retry: 0, connect_timeout: 500, timeout: 500)
-    end
+        assert {:error, :recv_response_timeout} ==
+                 call(request, proxy: proxy, retry: 0, connect_timeout: 500, timeout: 500)
+      end
 
-    test "merges the socks options it was given over the tunnel defaults" do
-      request = %Env{method: :get, url: "#{@http}/ip"}
-      proxy = {:socks5, ~c"localhost", Application.get_env(:httparrot, :http_port)}
+      test "merges the socks options it was given over the tunnel defaults" do
+        request = %Env{method: :get, url: "#{@http}/ip"}
+        proxy = {:socks5, ~c"localhost", Application.get_env(:httparrot, :http_port)}
 
-      assert {:error, {:options, {:socks, {:version, 4}}}} ==
-               call(request,
-                 proxy: proxy,
-                 socks_opts: %{version: 4},
-                 retry: 0,
-                 connect_timeout: 500,
-                 timeout: 500
-               )
+        assert {:error, {:options, {:socks, {:version, 4}}}} ==
+                 call(request,
+                   proxy: proxy,
+                   socks_opts: %{version: 4},
+                   retry: 0,
+                   connect_timeout: 500,
+                   timeout: 500
+                 )
+      end
     end
   end
 


### PR DESCRIPTION
- `lib/tesla/adapter/gun.ex` was the least verified module in the repository, so the proxy, reply routing and connection error paths could only regress in production
- the proxy behaviour now runs against a local tunnel server instead of an endpoint that answers every CONNECT the same way, so the credentials and the tunnel target are actually asserted rather than merely executed
- every new assertion was checked by mutating the code under test; the two that a mutation still survives are called out below rather than left to look verified

Two findings the tests deliberately do not paper over:

- an HTTP CONNECT tunnel that succeeds crashes gun 2.x. Once the proxy answers `200`, the request is opened on the connection rather than on the tunnel stream, and gun dies in `dereference_stream_ref/2`, so the call returns `:recv_response_timeout`. There is no passing tunnel test here because there is no passing tunnel.
- `socks_opts[:auth]` is built as a bare `{:username_password, user, pass}` where gun 2.x expects a list, so any socks proxy with credentials raises `{:bad_generator, ...}` before the connection is opened.

Because of the first one, the https branch of `tunnel_tls_opts/3` is executed but its effect is not observable, and a mutation that drops the merge still passes.