### PR TITLE
chore(hackney-adapter): cover the streamed request path

### DIFF
--- a/test/tesla/adapter/hackney_test.exs
+++ b/test/tesla/adapter/hackney_test.exs
@@ -83,4 +83,89 @@ defmodule Tesla.Adapter.HackneyTest do
 
     assert {:error, :fake_error} = call(request)
   end
+
+  describe "streamed request bodies" do
+    test "surfaces the error hackney reported when opening the request" do
+      request = %Env{
+        method: :post,
+        url: "http://localhost:1/post",
+        headers: [{"content-type", "text/plain"}],
+        body: Stream.map(["ab"], & &1)
+      }
+
+      assert {:error, :econnrefused} = call(request)
+    end
+
+    test "stops reading the response body once `:max_body` is reached" do
+      request = streamed_post(String.duplicate("long response", 1000))
+
+      assert {:ok, %Env{} = full_response} = call(request)
+      assert {:ok, %Env{} = limited_response} = call(request, max_body: 100)
+
+      assert full_response.status == 200
+      assert limited_response.status == 200
+      assert byte_size(limited_response.body) < byte_size(full_response.body)
+    end
+
+    test "reads the whole response body when it stays under `:max_body`" do
+      request = streamed_post(String.duplicate("long response", 1000))
+
+      assert {:ok, %Env{} = full_response} = call(request)
+      assert {:ok, %Env{} = limited_response} = call(request, max_body: 1_000_000)
+
+      assert limited_response.body == full_response.body
+    end
+
+    test "surfaces the error hackney reported while reading the response body" do
+      url = start_stalled_chunked_server()
+
+      request = %Env{
+        method: :post,
+        url: url,
+        headers: [{"content-type", "text/plain"}],
+        body: Stream.map(["ab"], & &1)
+      }
+
+      assert {:error, :timeout} = call(request, max_body: 1_000_000, recv_timeout: 100)
+    end
+  end
+
+  defp streamed_post(body) do
+    %Env{
+      method: :post,
+      url: "#{@http}/post",
+      headers: [{"content-type", "text/plain"}],
+      body: Stream.map([body], & &1)
+    }
+  end
+
+  # Answers with a chunked response that stops after the first chunk without
+  # ever ending, so reading the body stalls part way through.
+  defp start_stalled_chunked_server do
+    {:ok, listen} =
+      :gen_tcp.listen(0,
+        ip: {127, 0, 0, 1},
+        mode: :binary,
+        packet: :raw,
+        active: false,
+        reuseaddr: true
+      )
+
+    {:ok, port} = :inet.port(listen)
+
+    spawn_link(fn ->
+      {:ok, socket} = :gen_tcp.accept(listen, 5_000)
+      {:ok, _request} = :gen_tcp.recv(socket, 0, 5_000)
+
+      :gen_tcp.send(socket, [
+        "HTTP/1.1 200 OK\r\n",
+        "transfer-encoding: chunked\r\n\r\n",
+        "5\r\nhello\r\n"
+      ])
+
+      Process.sleep(5_000)
+    end)
+
+    "http://127.0.0.1:#{port}/"
+  end
 end


### PR DESCRIPTION
- `Tesla.Adapter.Hackney` sat at 80.0% line coverage, and every uncovered line was on the streamed request path, so the `:max_body` limit and the streamed request error handling had no regression net at all.
- The one pre-existing `:max_body` test is gated to hackney < 4.0.0 and neither lockfile pins that, so on CI the limit was never exercised. On hackney 4.x the plain request path returns the body already read, and only `:hackney.start_response/1` hands back a client ref, so `:max_body` is reachable only when the request body is streamed.
- Verified by mutation: 7 single-line mutations were applied to `lib/tesla/adapter/hackney.ex` and 6 fail the suite. The survivor is dropping `:hackney.close(ref)` after the limit is hit, which leaks the connection back to the pool without any observable difference from a test.
- `handle({:connect_error, {:error, reason}}, _opts)` stays uncovered. That clause was added in #754 for hackney 1.22 and the shape no longer exists in hackney 4.x, which is what both lockfiles pin.
- Coverage for the file goes 80.0% to 97.7%; repository total 94.89% to 95.0%.
- The new tests pass on both lockfiles, hackney 4.7.4 and 4.1.0, which differ in how a malformed chunk surfaces.
