### PR TITLE
chore(logger): cover the otel attribute fallbacks

### DIFF
--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -535,6 +535,58 @@ defmodule Tesla.Middleware.LoggerTest do
       refute log =~ "url.template="
     end
 
+    test "status is omitted when the adapter did not set one" do
+      client =
+        Tesla.client(
+          [{Tesla.Middleware.Logger, metadata: {:otel, []}}],
+          fn env -> {:ok, env} end
+        )
+
+      log = capture_log(@capture_opts, fn -> Tesla.get(client, "https://api.example.com/x") end)
+
+      assert log =~ "http.request.method=GET"
+      refute log =~ "http.response.status_code="
+      refute log =~ "error.type="
+    end
+
+    test "server.port falls back to 80 for a scheme with no default port" do
+      client =
+        Tesla.client(
+          [{Tesla.Middleware.Logger, metadata: {:otel, []}}],
+          fn env -> {:ok, %{env | status: 200}} end
+        )
+
+      log = capture_log(@capture_opts, fn -> Tesla.get(client, "custom://host.example/path") end)
+
+      assert log =~ "url.scheme=custom"
+      assert log =~ "server.address=host.example"
+      assert log =~ "server.port=80"
+    end
+
+    test "string error reason is used as error.type verbatim" do
+      client =
+        Tesla.client(
+          [{Tesla.Middleware.Logger, metadata: {:otel, []}}],
+          fn _env -> {:error, "adapter exploded"} end
+        )
+
+      log = capture_log(@capture_opts, fn -> Tesla.get(client, "/err") end)
+
+      assert log =~ "error.type=adapter exploded"
+    end
+
+    test "unrecognised error reason falls back to the generic error type" do
+      client =
+        Tesla.client(
+          [{Tesla.Middleware.Logger, metadata: {:otel, []}}],
+          fn _env -> {:error, {:closed, :during_body}} end
+        )
+
+      log = capture_log(@capture_opts, fn -> Tesla.get(client, "/err") end)
+
+      assert log =~ "error.type=_OTHER"
+    end
+
     test "default metadata is keyword list passthrough" do
       client =
         Tesla.client(


### PR DESCRIPTION
- `Tesla.OpenTelemetry.SemConv` sat at 83.7% and the gap was entirely in its fallback clauses, the branches that decide what to emit when an attribute cannot be derived. A wrong default there does not fail loudly, it ships as a silently incorrect telemetry attribute, which is the worst failure mode for observability code.
- Newly covered: a response with no status set at all, `server.port` for a scheme that has no default port, a string error reason, and an error reason that is neither a struct, an atom, nor a string.
- Verified by mutation: 4 single-line mutations were applied to `lib/tesla/opentelemetry/sem_conv.ex` and all 4 fail the suite, including swapping the port fallback from 80 to 443 and emitting a string reason through `inspect/1`.
- Two clauses stay uncovered on purpose. `maybe_put_url/2` falling through on a non-binary URL and `extract_port/1` inferring 443 from an `https` scheme are both unreachable: `Tesla.Env.url` is typed `binary` and defaults to `""`, and `URI.parse/1` always fills the default port for `https`.
- Coverage for the file goes 83.7% to 94.5%; repository total 95.6% to 96.0%.
