### PR TITLE
chore(open-api): close the last coverage gaps

### DIFF
--- a/test/tesla/open_api/cookie_params_test.exs
+++ b/test/tesla/open_api/cookie_params_test.exs
@@ -179,6 +179,21 @@ defmodule Tesla.OpenAPI.CookieParamsTest do
            }) == [{"cookie", "empty_array=; empty_object="}]
   end
 
+  test "cookie style serializes empty arrays and objects as empty cookie values" do
+    for explode <- [false, true] do
+      cookie_params =
+        CookieParams.new!([
+          CookieParam.new!("empty_array", style: :cookie, explode: explode),
+          CookieParam.new!("empty_object", style: :cookie, explode: explode)
+        ])
+
+      assert CookieParams.to_headers(cookie_params, %{
+               "empty_array" => [],
+               "empty_object" => %{}
+             }) == [{"cookie", "empty_array=; empty_object="}]
+    end
+  end
+
   test "raises on duplicate cookie parameter definitions" do
     assert_raise ArgumentError, ~r/duplicate cookie parameter "session_id"/, fn ->
       CookieParams.new!([

--- a/test/tesla/open_api/path_template_test.exs
+++ b/test/tesla/open_api/path_template_test.exs
@@ -92,6 +92,12 @@ defmodule Tesla.OpenAPI.PathTemplateTest do
     end
   end
 
+  test "rejects an empty path" do
+    assert_raise ArgumentError, ~r/start with \//, fn ->
+      PathTemplate.new!("")
+    end
+  end
+
   test "rejects query strings" do
     assert_raise ArgumentError, ~r/not to include query or fragment/, fn ->
       PathTemplate.new!("/items/{id}?x=1")

--- a/test/tesla/open_api/query_string_test.exs
+++ b/test/tesla/open_api/query_string_test.exs
@@ -68,6 +68,12 @@ defmodule Tesla.OpenAPI.QueryStringTest do
              "https://api.example.com/search"
   end
 
+  test "empty query strings leave URLs with a fragment unchanged" do
+    assert QueryString.raw!("")
+           |> QueryString.append_to_url("https://api.example.com/search#section") ==
+             "https://api.example.com/search#section"
+  end
+
   test "empty query strings still reject URLs with existing query params" do
     query_string = QueryString.raw!("")
 


### PR DESCRIPTION
- Every module under `lib/tesla/open_api/` is now at 100% line coverage, so the namespace can be held there from here on instead of drifting one uncovered clause at a time.
- Only four lines were missing and all four were empty or rejected inputs, which is exactly where a value object is supposed to be strict: an empty path template, an empty query string appended to a URL carrying a fragment, and empty arrays and objects under the `cookie` serialization style.
- The `cookie` style cases are asserted for both `explode: false` and `explode: true`. With `explode: false` the empty-collection clauses are indistinguishable from the general ones, so only the `explode: true` half actually pins them.
- Verified by mutation: 5 mutations were applied across the three modules and all 5 fail the suite, including deleting each empty-collection clause outright.
- `lib/tesla/open_api/response.ex` still reports 0.0%. It is a `__using__` macro, so its generated functions are attributed to the module that uses it, not to the file. It has no relevant lines to cover and `response_test.exs` already exercises the generated code.
