### PR TITLE
chore(open-api): pin cookie and path template behavior that mutation testing left unverified

### DIFF
--- a/test/tesla/open_api/cookie_params_test.exs
+++ b/test/tesla/open_api/cookie_params_test.exs
@@ -138,6 +138,26 @@ defmodule Tesla.OpenAPI.CookieParamsTest do
            ]
   end
 
+  test "form style percent-encodes exploded object keys even when allow_reserved is true" do
+    for {allow_reserved, expected} <- [
+          {false, "a%2Fb%20name=x%2Fy%20z"},
+          {true, "a%2Fb%20name=x/y%20z"}
+        ] do
+      cookie_params =
+        CookieParams.new!([
+          CookieParam.new!("filter",
+            style: :form,
+            explode: true,
+            allow_reserved: allow_reserved
+          )
+        ])
+
+      assert CookieParams.to_headers(cookie_params, %{
+               "filter" => %{"a/b name" => "x/y z"}
+             }) == [{"cookie", expected}]
+    end
+  end
+
   test "form style preserves reserved values and percent triples when allow_reserved is true" do
     cookie_params =
       CookieParams.new!([

--- a/test/tesla/open_api/path_template_test.exs
+++ b/test/tesla/open_api/path_template_test.exs
@@ -70,6 +70,7 @@ defmodule Tesla.OpenAPI.PathTemplateTest do
 
   test "fetch_private ignores invalid private data" do
     assert PathTemplate.fetch_private(%{tesla_path_template: :invalid}) == :error
+    assert PathTemplate.fetch_private(%{}) == :error
   end
 
   test "render returns rendered path" do


### PR DESCRIPTION
- `lib/tesla/open_api/cookie_param.ex`, `lib/tesla/open_api/cookie_params.ex`, `lib/tesla/open_api/path_template.ex` and `lib/tesla/open_api/query_string.ex` all report 100% line coverage, so the coverage report gave no signal that some behavior was executed but never asserted on. Mutation testing (69 mutants) found two such spots.
- `Tesla.OpenAPI.PathTemplate.fetch_private/1` never had the missing-key case asserted, so returning a bogus `{:ok, _}` instead of `:error` for a private map with no template would have gone unnoticed. Both `PathParams` and `QueryParams` already assert this case, so the sibling modules disagreed.
- Exploded `form` style cookie object keys are percent-encoded with the unreserved encoder regardless of `:allow_reserved`, while the values honor it. Existing tests only used keys that needed no encoding (`R`, `G`, `B`), so neither dropping the key encoding nor switching it to the reserved encoder failed anything.

### Lib findings, reported only

- `lib/tesla/open_api/path_template.ex:129-131`: the `validate_path!("")` clause is byte-for-byte equivalent to the catch-all at `:137-139`, so deleting it changes no behavior. It is redundant, and no test can distinguish the two. Its line coverage is real but carries no verification value. Left in place since this is a tests-only change.