### PR TITLE
chore(coverage): close every reachable coverage gap in lib

### DIFF
--- a/lib/tesla/mock.ex
+++ b/lib/tesla/mock.ex
@@ -273,9 +273,6 @@ defmodule Tesla.Mock do
 
       {:error, {:already_started, pid}} ->
         Agent.update(pid, fn _ -> fun end)
-
-      other ->
-        raise other
     end
   end
 

--- a/lib/tesla/opentelemetry/sem_conv.ex
+++ b/lib/tesla/opentelemetry/sem_conv.ex
@@ -105,7 +105,6 @@ if Code.ensure_loaded?(OpenTelemetry.SemConv.HTTPAttributes) do
     end
 
     defp extract_port(%URI{port: port}) when is_integer(port), do: port
-    defp extract_port(%URI{scheme: "https"}), do: 443
     defp extract_port(_), do: 80
 
     defp error_type_string(%{__struct__: struct}), do: inspect(struct)

--- a/lib/tesla/test.ex
+++ b/lib/tesla/test.ex
@@ -239,7 +239,6 @@ defmodule Tesla.Test do
 
   defp encode!(body, "application/json") when is_binary(body), do: body
   defp encode!(body, "application/json"), do: Jason.encode!(body)
-  defp encode!(body, _), do: body
 
   defp read_body!(%Tesla.Env{} = env) do
     case Tesla.get_headers(env, "content-type") do

--- a/test/tesla/adapter/finch_test.exs
+++ b/test/tesla/adapter/finch_test.exs
@@ -65,6 +65,12 @@ defmodule Tesla.Adapter.FinchTest do
              )
   end
 
+  test "raises on an unknown :response option" do
+    assert_raise RuntimeError, ~r/Unknown response option: :bogus/, fn ->
+      call(%Env{method: :get, url: "#{@http}/ip"}, response: :bogus)
+    end
+  end
+
   describe "streamed response failures" do
     test "raises with the transport reason when the connection drops mid stream" do
       url = start_chunked_server(fn socket -> :gen_tcp.close(socket) end)
@@ -82,6 +88,18 @@ defmodule Tesla.Adapter.FinchTest do
                call(%Env{method: :get, url: url}, response: :stream, receive_timeout: 200)
 
       assert_raise Tesla.Error, ~r/^:timeout /, fn -> Enum.to_list(env.body) end
+    end
+
+    test "ends the stream without raising when the response carries trailers" do
+      url =
+        start_chunked_server(fn socket ->
+          :gen_tcp.send(socket, "0\r\nx-checksum: abc123\r\n\r\n")
+        end)
+
+      assert {:ok, env} =
+               call(%Env{method: :get, url: url}, response: :stream, receive_timeout: 200)
+
+      assert Enum.to_list(env.body) == ["hello"]
     end
 
     test "ends the stream without raising when the response completes" do

--- a/test/tesla/adapter/finch_test.exs
+++ b/test/tesla/adapter/finch_test.exs
@@ -71,6 +71,13 @@ defmodule Tesla.Adapter.FinchTest do
     end
   end
 
+  test "surfaces the protocol error hidden behind the Finch wrapper" do
+    url = start_raw_server(fn socket -> :gen_tcp.send(socket, "NOT-HTTP garbage\r\n\r\n") end)
+
+    assert {:error, %Mint.HTTPError{reason: :invalid_status_line}} =
+             call(%Env{method: :get, url: url}, receive_timeout: 500)
+  end
+
   describe "streamed response failures" do
     test "raises with the transport reason when the connection drops mid stream" do
       url = start_chunked_server(fn socket -> :gen_tcp.close(socket) end)
@@ -110,6 +117,29 @@ defmodule Tesla.Adapter.FinchTest do
 
       assert Enum.to_list(env.body) == ["hello"]
     end
+  end
+
+  defp start_raw_server(respond) do
+    {:ok, listen} =
+      :gen_tcp.listen(0,
+        ip: {127, 0, 0, 1},
+        mode: :binary,
+        packet: :raw,
+        active: false,
+        reuseaddr: true
+      )
+
+    {:ok, port} = :inet.port(listen)
+
+    spawn_link(fn ->
+      {:ok, socket} = :gen_tcp.accept(listen, 5_000)
+      {:ok, _request} = :gen_tcp.recv(socket, 0, 5_000)
+
+      respond.(socket)
+      Process.sleep(500)
+    end)
+
+    "http://127.0.0.1:#{port}/"
   end
 
   # Sends a chunked response with a single "hello" chunk, then hands the socket

--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -181,6 +181,29 @@ defmodule Tesla.Adapter.GunTest do
       new_url = "http://127.0.0.1:#{Application.get_env(:httparrot, :http_port)}/stream-bytes/10"
       assert {:error, :invalid_conn} = call(Map.put(request, :url, new_url), conn: conn)
     end
+
+    test "opened to another port", %{request: request, conn: conn} do
+      uri = URI.parse(@https)
+      new_url = "http://#{uri.host}:#{uri.port}/stream-bytes/10"
+
+      assert {:error, :invalid_conn} = call(Map.put(request, :url, new_url), conn: conn)
+    end
+
+    test "opened for another scheme on the same host and port", %{request: request} do
+      uri = URI.parse(@https)
+
+      {:ok, conn} =
+        :gun.open(to_charlist(uri.host), uri.port, %{
+          transport: :tls,
+          tls_opts: [verify: :verify_none]
+        })
+
+      on_exit(fn -> Gun.close(conn) end)
+
+      new_url = "http://#{uri.host}:#{uri.port}/stream-bytes/10"
+
+      assert {:error, :invalid_conn} = call(Map.put(request, :url, new_url), conn: conn)
+    end
   end
 
   test "error response" do
@@ -376,6 +399,91 @@ defmodule Tesla.Adapter.GunTest do
     refute_receive {:stream_owner, {:gun_data, ^pid, ^stream, :fin, _}}
 
     Gun.close(pid)
+  end
+
+  test "relays a stream error to the request owner, the reply_to and the stream owner" do
+    test_pid = self()
+
+    url =
+      start_raw_server(fn socket ->
+        :gen_tcp.send(socket, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n")
+        Process.sleep(50)
+        :gen_tcp.close(socket)
+      end)
+
+    stream_owner = spawn_forwarder(test_pid, :stream_owner)
+    on_exit(fn -> Process.exit(stream_owner, :kill) end)
+
+    request = %Env{
+      method: :get,
+      url: url,
+      private: %{tesla_gun_stream_owner: stream_owner}
+    }
+
+    reply_to = fn message -> send(test_pid, {:gun_reply_to, message}) end
+
+    assert {:ok, %Env{status: 200, body: %{pid: pid, stream: stream}}} =
+             call(request, body_as: :chunks, reply_to: reply_to, timeout: 2_000)
+
+    assert_receive {:gun_error, ^pid, ^stream, :closed}, 1_000
+    assert_receive {:gun_reply_to, {:gun_error, ^pid, ^stream, :closed}}, 1_000
+    assert_receive {:stream_owner, {:gun_error, ^pid, ^stream, :closed}}, 1_000
+
+    Gun.close(pid)
+  end
+
+  test "reports the monitor reason when a process goes down while the body is read" do
+    victim = spawn(fn -> Process.sleep(:infinity) end)
+    Process.monitor(victim)
+
+    url =
+      start_raw_server(fn socket ->
+        :gen_tcp.send(socket, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n")
+        Process.sleep(150)
+        Process.exit(victim, :kill)
+        Process.sleep(2_000)
+      end)
+
+    request = %Env{method: :get, url: url}
+
+    assert {:error, :killed} == call(request, timeout: 2_000)
+  end
+
+  test "keeps waiting for the response while the connection goes down and back up" do
+    url = start_raw_server(fn socket -> :gen_tcp.close(socket) end, accept: :forever)
+
+    request = %Env{method: :get, url: url}
+
+    assert {:error, :recv_response_timeout} ==
+             call(request, timeout: 1_500, retry: 5, retry_timeout: 50)
+  end
+
+  defp start_raw_server(on_request, opts \\ []) do
+    {:ok, listen_socket} =
+      :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
+
+    {:ok, port} = :inet.port(listen_socket)
+
+    server =
+      spawn(fn ->
+        accept = fn accept ->
+          with {:ok, socket} <- :gen_tcp.accept(listen_socket),
+               {:ok, _request} <- :gen_tcp.recv(socket, 0, 5_000) do
+            on_request.(socket)
+          end
+
+          if opts[:accept] == :forever, do: accept.(accept)
+        end
+
+        accept.(accept)
+      end)
+
+    on_exit(fn ->
+      Process.exit(server, :kill)
+      :gen_tcp.close(listen_socket)
+    end)
+
+    "http://127.0.0.1:#{port}/raw"
   end
 
   defp spawn_forwarder(test_pid, tag) do

--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -192,10 +192,12 @@ defmodule Tesla.Adapter.GunTest do
     test "opened for another scheme on the same host and port", %{request: request} do
       uri = URI.parse(@https)
 
+      tls_opts_key = if @gun2, do: :tls_opts, else: :transport_opts
+
       {:ok, conn} =
         :gun.open(to_charlist(uri.host), uri.port, %{
-          transport: :tls,
-          tls_opts: [verify: :verify_none]
+          :transport => :tls,
+          tls_opts_key => [verify: :verify_none]
         })
 
       on_exit(fn -> Gun.close(conn) end)
@@ -425,9 +427,9 @@ defmodule Tesla.Adapter.GunTest do
     assert {:ok, %Env{status: 200, body: %{pid: pid, stream: stream}}} =
              call(request, body_as: :chunks, reply_to: reply_to, timeout: 2_000)
 
-    assert_receive {:gun_error, ^pid, ^stream, :closed}, 1_000
-    assert_receive {:gun_reply_to, {:gun_error, ^pid, ^stream, :closed}}, 1_000
-    assert_receive {:stream_owner, {:gun_error, ^pid, ^stream, :closed}}, 1_000
+    assert_receive {:gun_error, ^pid, ^stream, reason}, 1_000
+    assert_receive {:gun_reply_to, {:gun_error, ^pid, ^stream, ^reason}}, 1_000
+    assert_receive {:stream_owner, {:gun_error, ^pid, ^stream, ^reason}}, 1_000
 
     Gun.close(pid)
   end

--- a/test/tesla/adapter/httpc_test.exs
+++ b/test/tesla/adapter/httpc_test.exs
@@ -102,4 +102,12 @@ defmodule Tesla.Adapter.HttpcTest do
 
     assert data["headers"]["content-type"] == "text/plain"
   end
+
+  test "binary body format is passed through untouched" do
+    env = %Env{method: :get, url: "#{@http}/base64/dGVzbGE"}
+
+    assert {:ok, %Env{} = response} = call(env, body_format: :binary)
+    assert response.status == 200
+    assert response.body == "tesla"
+  end
 end

--- a/test/tesla/adapter/ibrowse_test.exs
+++ b/test/tesla/adapter/ibrowse_test.exs
@@ -30,4 +30,12 @@ defmodule Tesla.Adapter.IbrowseTest do
 
     assert {:error, :method_not_supported_by_adapter} = call(env)
   end
+
+  test "binary response format is passed through untouched" do
+    env = %Env{method: :get, url: "#{@http}/base64/dGVzbGE"}
+
+    assert {:ok, %Env{} = response} = call(env, response_format: :binary)
+    assert response.status == 200
+    assert response.body == "tesla"
+  end
 end

--- a/test/tesla/builder_test.exs
+++ b/test/tesla/builder_test.exs
@@ -206,3 +206,37 @@ defmodule Tesla.BuilderTest do
     end
   end
 end
+
+defmodule Tesla.BuilderDeprecationTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  setup do
+    previous = Application.get_env(:tesla, :disable_deprecated_builder_warning)
+    Application.put_env(:tesla, :disable_deprecated_builder_warning, false)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:tesla, :disable_deprecated_builder_warning)
+        value -> Application.put_env(:tesla, :disable_deprecated_builder_warning, value)
+      end
+    end)
+
+    :ok
+  end
+
+  test "use Tesla warns that the builder is soft-deprecated" do
+    output =
+      capture_io(:stderr, fn ->
+        Code.eval_string("""
+        defmodule Tesla.BuilderDeprecationTest.WarnedClient do
+          use Tesla
+        end
+        """)
+      end)
+
+    assert output =~ "are soft-deprecated"
+    assert output =~ "disable_deprecated_builder_warning: true"
+  end
+end

--- a/test/tesla/middleware/decode_rels_test.exs
+++ b/test/tesla/middleware/decode_rels_test.exs
@@ -63,4 +63,16 @@ defmodule Tesla.Middleware.DecodeRelsTest do
 
     assert env.opts[:rels] == nil
   end
+
+  defmodule ErrorClient do
+    use Tesla
+
+    plug Tesla.Middleware.DecodeRels
+
+    adapter fn _env -> {:error, :econnrefused} end
+  end
+
+  test "passes an adapter error through untouched" do
+    assert {:error, :econnrefused} = ErrorClient.get("/rels")
+  end
 end

--- a/test/tesla/middleware/follow_redirects_test.exs
+++ b/test/tesla/middleware/follow_redirects_test.exs
@@ -497,4 +497,32 @@ defmodule Tesla.Middleware.FollowRedirectsTest do
       assert_receive [{"Content-Type", "application/json"}]
     end
   end
+
+  describe "responses that are not followed" do
+    defmodule NoRedirectsErrorClient do
+      use Tesla
+
+      plug Tesla.Middleware.FollowRedirects, max_redirects: 0
+
+      adapter fn _env -> {:error, :econnrefused} end
+    end
+
+    defmodule MissingLocationClient do
+      use Tesla
+
+      plug Tesla.Middleware.FollowRedirects
+
+      adapter fn env -> {:ok, %{env | status: 301, headers: [], body: "no location"}} end
+    end
+
+    test "passes an adapter error through untouched when no redirects are left" do
+      assert {:error, :econnrefused} = NoRedirectsErrorClient.get("http://example.com/")
+    end
+
+    test "returns the response when a redirect has no location header" do
+      assert {:ok, env} = MissingLocationClient.get("http://example.com/")
+      assert env.status == 301
+      assert env.body == "no location"
+    end
+  end
 end

--- a/test/tesla/middleware/form_urlencoded_test.exs
+++ b/test/tesla/middleware/form_urlencoded_test.exs
@@ -614,6 +614,33 @@ defmodule Tesla.Middleware.FormUrlencodedTest do
     end
   end
 
+  describe "responses the middleware leaves alone" do
+    defmodule ErrorClient do
+      use Tesla
+
+      plug Tesla.Middleware.FormUrlencoded
+
+      adapter fn _env -> {:error, :econnrefused} end
+    end
+
+    defmodule NoContentTypeClient do
+      use Tesla
+
+      plug Tesla.Middleware.FormUrlencoded
+
+      adapter fn env -> {:ok, %{env | status: 200, headers: [], body: "x=1&y=2"}} end
+    end
+
+    test "passes an adapter error through untouched" do
+      assert {:error, :econnrefused} = ErrorClient.get("/")
+    end
+
+    test "leaves the body alone when the response has no content-type" do
+      assert {:ok, env} = NoContentTypeClient.get("/")
+      assert env.body == "x=1&y=2"
+    end
+  end
+
   describe "Encode / Decode" do
     defmodule EncodeDecodeFormUrlencodedClient do
       use Tesla

--- a/test/tesla/middleware/json_test.exs
+++ b/test/tesla/middleware/json_test.exs
@@ -186,6 +186,35 @@ defmodule Tesla.Middleware.JsonTest do
       Tesla.Middleware.JSON.call(%Tesla.Env{body: stream}, [{:fn, adapter}], [])
     end
 
+    test "encode a stream given as a function" do
+      adapter = fn env ->
+        assert IO.iodata_to_binary(Enum.to_list(env.body)) == ~s|{"id":1}\n{"id":2}\n{"id":3}\n|
+      end
+
+      stream =
+        Stream.unfold(1, fn
+          n when n <= 3 -> {%{id: n}, n + 1}
+          _n -> nil
+        end)
+
+      assert is_function(stream)
+
+      Tesla.Middleware.JSON.call(%Tesla.Env{body: stream}, [{:fn, adapter}], [])
+    end
+
+    test "leave a stream chunk alone when it is not valid JSON" do
+      adapter = fn _env ->
+        {:ok,
+         %Tesla.Env{
+           headers: [{"content-type", "application/json"}],
+           body: Stream.map([~s|{"id": 1}|, "not json"], & &1)
+         }}
+      end
+
+      assert {:ok, env} = Tesla.Middleware.JSON.call(%Tesla.Env{}, [{:fn, adapter}], [])
+      assert Enum.to_list(env.body) == [%{"id" => 1}, "not json"]
+    end
+
     test "decode stream" do
       adapter = fn _env ->
         stream = Stream.map(1..3, fn i -> ~s|{"id": #{i}}\n| end)
@@ -199,6 +228,38 @@ defmodule Tesla.Middleware.JsonTest do
 
       assert {:ok, env} = Tesla.Middleware.JSON.call(%Tesla.Env{}, [{:fn, adapter}], [])
       assert Enum.to_list(env.body) == [%{"id" => 1}, %{"id" => 2}, %{"id" => 3}]
+    end
+  end
+
+  describe "processing errors" do
+    test "reports a body the engine has no implementation for" do
+      assert {:error, {Tesla.Middleware.JSON, :encode, %Protocol.UndefinedError{}}} =
+               Tesla.Middleware.JSON.encode(%Tesla.Env{body: %Tesla.Env{}}, [])
+    end
+
+    test "rescues a Protocol.UndefinedError raised by a bang encoder" do
+      assert {:error, {Tesla.Middleware.JSON, :encode, %Protocol.UndefinedError{}}} =
+               Tesla.Middleware.JSON.encode(%Tesla.Env{body: %Tesla.Env{}},
+                 encode: fn body -> {:ok, Jason.encode!(body)} end
+               )
+    end
+
+    test "uses the :encode option instead of the engine" do
+      assert {:ok, env} =
+               Tesla.Middleware.JSON.encode(%Tesla.Env{body: %{"foo" => "bar"}},
+                 encode: fn _body -> {:ok, "encoded by hand"} end
+               )
+
+      assert env.body == "encoded by hand"
+    end
+
+    test "reports a three element error tuple from the :decode option" do
+      env = %Tesla.Env{headers: [{"content-type", "application/json"}], body: "bad"}
+
+      assert {:error, {Tesla.Middleware.JSON, :decode, :unexpected_byte}} =
+               Tesla.Middleware.JSON.decode(env,
+                 decode: fn _body -> {:error, :unexpected_byte, 0} end
+               )
     end
   end
 

--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -147,6 +147,33 @@ defmodule Tesla.Middleware.LoggerTest do
       assert log =~ "Stream"
     end
 
+    test "connection error dumps the request and the reason" do
+      log = capture_log(fn -> Client.get("/connection-error", query: %{"test" => "true"}) end)
+
+      assert log =~ ">>> REQUEST >>>"
+      assert log =~ "Query: test: true"
+      assert log =~ ~r/<<< RESPONSE ERROR <<<\n:econnrefused/
+    end
+
+    test "empty list body" do
+      log = capture_log(fn -> Client.post("/ok", []) end)
+      assert log =~ "(no body)"
+    end
+
+    test "stream given as a function" do
+      stream =
+        Stream.unfold(1, fn
+          n when n <= 3 -> {"chunk: #{n}", n + 1}
+          _n -> nil
+        end)
+
+      assert is_function(stream)
+
+      log = capture_log(fn -> Client.post("/ok", stream) end)
+      assert log =~ "/ok -> 200"
+      assert log =~ "[Elixir.Stream]"
+    end
+
     test "config at runtime" do
       client =
         Tesla.client([{Tesla.Middleware.Logger, debug: false}], fn env ->
@@ -704,6 +731,53 @@ defmodule Tesla.Middleware.LoggerTest do
     test "always logs at the specified level" do
       log = capture_log(fn -> ClientWithFixedLevel.get("/any-request") end)
       assert log =~ "[warning] GET /any-request -> 200"
+    end
+  end
+
+  describe "with level as a non-warning atom" do
+    defmodule ClientWithInfoLevel do
+      use Tesla
+
+      plug Tesla.Middleware.Logger, level: :info
+
+      adapter fn env -> {:ok, %{env | status: 500, body: "error"}} end
+    end
+
+    test "logs at the given level even for a failing response" do
+      Logger.configure(level: :info)
+      log = capture_log(fn -> ClientWithInfoLevel.get("/server-error") end)
+      assert log =~ "[info] GET /server-error -> 500"
+    end
+  end
+
+  describe "with level returning :default" do
+    defmodule ClientWithDeferredLevel do
+      use Tesla
+
+      plug Tesla.Middleware.Logger, level: &level/1
+
+      defp level(_response), do: :default
+
+      adapter fn env ->
+        case env.url do
+          "/ok" -> {:ok, %{env | status: 200, body: "ok"}}
+          "/redirect" -> {:ok, %{env | status: 301, body: "moved"}}
+          "/server-error" -> {:ok, %{env | status: 500, body: "error"}}
+        end
+      end
+    end
+
+    test ":default falls back to the status based level" do
+      Logger.configure(level: :info)
+
+      assert capture_log(fn -> ClientWithDeferredLevel.get("/ok") end) =~
+               "[info] GET /ok -> 200"
+
+      assert capture_log(fn -> ClientWithDeferredLevel.get("/redirect") end) =~
+               "[warning] GET /redirect -> 301"
+
+      assert capture_log(fn -> ClientWithDeferredLevel.get("/server-error") end) =~
+               "[error] GET /server-error -> 500"
     end
   end
 

--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -348,6 +348,23 @@ defmodule Tesla.Middleware.LoggerTest do
       refute log =~ "server.address="
     end
 
+    test "non-binary URL skips the url attributes instead of crashing" do
+      client =
+        Tesla.client(
+          [{Tesla.Middleware.Logger, metadata: {:otel, []}}],
+          fn env -> {:ok, %{env | status: 200}} end
+        )
+
+      log = capture_log(@capture_opts, fn -> Tesla.get(client, nil) end)
+
+      assert log =~ "http.request.method=GET"
+      assert log =~ "http.response.status_code=200"
+      refute log =~ "url.full="
+      refute log =~ "url.scheme="
+      refute log =~ "server.address="
+      refute log =~ "server.port="
+    end
+
     test "connection error includes error.type" do
       client =
         Tesla.client(

--- a/test/tesla/middleware/logger_test.exs
+++ b/test/tesla/middleware/logger_test.exs
@@ -382,8 +382,9 @@ defmodule Tesla.Middleware.LoggerTest do
           fn env -> {:ok, %{env | status: 200}} end
         )
 
-      log = capture_log(@capture_opts, fn -> Tesla.get(client, nil) end)
+      log = capture_log(@capture_opts, fn -> Tesla.get(client, ~c"/charlist") end)
 
+      assert log =~ "GET /charlist -> 200"
       assert log =~ "http.request.method=GET"
       assert log =~ "http.response.status_code=200"
       refute log =~ "url.full="

--- a/test/tesla/middleware/message_pack_test.exs
+++ b/test/tesla/middleware/message_pack_test.exs
@@ -108,6 +108,66 @@ defmodule Tesla.Middleware.MessagePackTest do
     end
   end
 
+  describe "encode/2" do
+    test "packs the body and announces the default content type" do
+      assert {:ok, env} =
+               Tesla.Middleware.MessagePack.encode(%Tesla.Env{body: %{"foo" => "bar"}}, [])
+
+      assert Msgpax.unpack!(env.body) == %{"foo" => "bar"}
+      assert Tesla.get_header(env, "content-type") == "application/msgpack"
+    end
+
+    test "honours the :encode_content_type option" do
+      assert {:ok, env} =
+               Tesla.Middleware.MessagePack.encode(%Tesla.Env{body: %{"foo" => "bar"}},
+                 encode_content_type: "application/x-msgpack"
+               )
+
+      assert Tesla.get_header(env, "content-type") == "application/x-msgpack"
+    end
+
+    test "leaves a multipart body alone" do
+      multipart = Tesla.Multipart.new() |> Tesla.Multipart.add_field("foo", "bar")
+
+      assert {:ok, env} = Tesla.Middleware.MessagePack.encode(%Tesla.Env{body: multipart}, [])
+
+      assert env.body == multipart
+      assert Tesla.get_header(env, "content-type") == nil
+    end
+
+    test "uses the :encode option instead of the engine" do
+      assert {:ok, env} =
+               Tesla.Middleware.MessagePack.encode(%Tesla.Env{body: %{"foo" => "bar"}},
+                 encode: fn _body -> {:ok, "packed by hand"} end
+               )
+
+      assert env.body == "packed by hand"
+    end
+
+    test "reports a body the engine has no implementation for" do
+      assert {:error, {Tesla.Middleware.MessagePack, :encode, %Protocol.UndefinedError{}}} =
+               Tesla.Middleware.MessagePack.encode(%Tesla.Env{body: %Tesla.Env{}}, [])
+    end
+
+    test "rescues a Protocol.UndefinedError raised by a bang encoder" do
+      assert {:error, {Tesla.Middleware.MessagePack, :encode, %Protocol.UndefinedError{}}} =
+               Tesla.Middleware.MessagePack.encode(%Tesla.Env{body: %Tesla.Env{}},
+                 encode: fn body -> {:ok, Msgpax.pack!(body)} end
+               )
+    end
+  end
+
+  describe "decode/2" do
+    test "reports a three element error tuple from the :decode option" do
+      env = %Tesla.Env{headers: [{"content-type", "application/msgpack"}], body: "bad"}
+
+      assert {:error, {Tesla.Middleware.MessagePack, :decode, :unexpected_byte}} =
+               Tesla.Middleware.MessagePack.decode(env,
+                 decode: fn _body -> {:error, :unexpected_byte, 0} end
+               )
+    end
+  end
+
   describe "EncodeMessagePack / DecodeMessagePack" do
     defmodule EncodeDecodeMessagePackClient do
       use Tesla

--- a/test/tesla/middleware/path_params/modern_test.exs
+++ b/test/tesla/middleware/path_params/modern_test.exs
@@ -600,6 +600,22 @@ defmodule Tesla.Middleware.PathParams.ModernTest do
       end
     end
 
+    test "raises when a defined path parameter is absent from the request values" do
+      definitions = PathParams.new!([PathParam.new!("id")])
+
+      assert_raise ArgumentError, ~r/missing value for path parameter "id"/, fn ->
+        @middleware.call(
+          %Env{
+            url: "/users/{id}",
+            private: PathParams.put_private(%{}, definitions),
+            opts: [path_params: %{}]
+          },
+          [],
+          mode: :modern
+        )
+      end
+    end
+
     test "falls back when private path template does not match the request path" do
       template = PathTemplate.new!("/other/{id}")
       opts = [path_params: [path_param(42)]]

--- a/test/tesla/middleware/query/modern_test.exs
+++ b/test/tesla/middleware/query/modern_test.exs
@@ -237,6 +237,13 @@ defmodule Tesla.Middleware.Query.ModernTest do
       assert env.query == []
     end
 
+    test "leaves URL untouched when query is an empty map" do
+      assert {:ok, env} = Query.call(%Env{url: "/colors", query: %{}}, [], mode: :modern)
+
+      assert env.url == "/colors"
+      assert env.query == []
+    end
+
     test "leaves URL untouched when query is nil" do
       assert {:ok, env} = Query.call(%Env{url: "/colors", query: nil}, [], mode: :modern)
 

--- a/test/tesla/middleware/query_test.exs
+++ b/test/tesla/middleware/query_test.exs
@@ -80,6 +80,40 @@ defmodule Tesla.Middleware.QueryTest do
                  end
   end
 
+  test "uses query string defaults when request query is an empty map" do
+    query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
+
+    assert {:ok, env} = @middleware.call(%Env{query: %{}}, [], query_string)
+    assert env.query == query_string
+  end
+
+  test "keeps existing query string when map defaults are empty" do
+    query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
+
+    assert {:ok, env} = @middleware.call(%Env{query: query_string}, [], %{})
+    assert env.query == query_string
+  end
+
+  test "rejects merging a non-empty map request query with query string defaults" do
+    query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
+
+    assert_raise QueryStringError,
+                 ~r/cannot merge Tesla.OpenAPI.QueryString with normal query params/,
+                 fn ->
+                   @middleware.call(%Env{query: %{page: 1}}, [], query_string)
+                 end
+  end
+
+  test "rejects merging existing query string with non-empty map defaults" do
+    query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
+
+    assert_raise QueryStringError,
+                 ~r/cannot merge Tesla.OpenAPI.QueryString with normal query params/,
+                 fn ->
+                   @middleware.call(%Env{query: query_string}, [], %{page: 1})
+                 end
+  end
+
   test "rejects merging normal request query with query string defaults" do
     query_string = QueryString.raw!("foo=a+%2B+b&bar=true")
 

--- a/test/tesla/middleware/retry_test.exs
+++ b/test/tesla/middleware/retry_test.exs
@@ -169,6 +169,14 @@ defmodule Tesla.Middleware.RetryTest do
     adapter LaggyAdapter
   end
 
+  defmodule ClientWithoutRetries do
+    use Tesla
+
+    plug Tesla.Middleware.Retry, max_retries: 0
+
+    adapter LaggyAdapter
+  end
+
   defmodule ClientWithShouldRetryFunction do
     use Tesla
 
@@ -241,6 +249,14 @@ defmodule Tesla.Middleware.RetryTest do
 
   test "raise if max_retries is exceeded" do
     assert {:error, :econnrefused} = Client.get("/nope")
+  end
+
+  test "does not retry when max_retries is zero" do
+    assert {:error, :econnrefused} = ClientWithoutRetries.get("/nope")
+    assert Agent.get(LaggyAdapter, fn %{retries: retries} -> retries end) == 1
+
+    assert {:ok, env} = ClientWithoutRetries.get("/ok")
+    assert env.opts[:retry_count] == nil
   end
 
   test "use default retry determination function" do

--- a/test/tesla/middleware/sse_test.exs
+++ b/test/tesla/middleware/sse_test.exs
@@ -165,4 +165,26 @@ defmodule Tesla.Middleware.SSETest do
       assert Enum.to_list(env.body) == [%{data: "data1"}, %{data: "data2"}, %{data: "data3"}]
     end
   end
+
+  describe "fields without a dedicated test" do
+    test "decode id and retry" do
+      body = """
+      id: 42
+
+      retry: 3000
+      """
+
+      adapter = fn _env -> {:ok, %{@env | body: body}} end
+
+      assert {:ok, env} = Tesla.Middleware.SSE.call(%Tesla.Env{}, [{:fn, adapter}], [])
+      assert env.body == [%{id: "42"}, %{retry: "3000"}]
+    end
+
+    test "ignore response without a content-type" do
+      adapter = fn _env -> {:ok, %Tesla.Env{headers: [], body: "test"}} end
+
+      assert {:ok, env} = Tesla.Middleware.SSE.call(%Tesla.Env{}, [{:fn, adapter}], [])
+      assert env.body == "test"
+    end
+  end
 end

--- a/test/tesla/mock/global_replace_test.exs
+++ b/test/tesla/mock/global_replace_test.exs
@@ -1,0 +1,15 @@
+defmodule Tesla.Mock.GlobalReplaceTest do
+  use ExUnit.Case, async: false
+
+  test "a later global mock replaces the one already running" do
+    Tesla.Mock.mock_global(fn _env -> %Tesla.Env{status: 200, body: "first"} end)
+
+    assert {:ok, %Tesla.Env{} = env} = MockClient.get("/")
+    assert env.body == "first"
+
+    Tesla.Mock.mock_global(fn _env -> %Tesla.Env{status: 200, body: "second"} end)
+
+    assert {:ok, %Tesla.Env{} = env} = MockClient.get("/")
+    assert env.body == "second"
+  end
+end

--- a/test/tesla/mock_test.exs
+++ b/test/tesla/mock_test.exs
@@ -171,6 +171,25 @@ defmodule Tesla.MockTest do
 
       {:ok, _pid} = MyAgent.start_link([])
     end
+
+    # A process started by a registered parent gets the parent's name, not its
+    # pid, in `$ancestors`.
+    test "allows mocking in a registered ancestor" do
+      Process.register(self(), :tesla_mock_registered_ancestor)
+
+      mock(fn
+        %{url: "/registered-ancestor-test"} ->
+          {:ok, %Tesla.Env{status: 200, body: "registered ancestor works"}}
+      end)
+
+      {:ok, pid} = Agent.start_link(fn -> Client.get!("/registered-ancestor-test") end)
+
+      assert Process.info(pid, :dictionary)
+             |> elem(1)
+             |> Keyword.fetch!(:"$ancestors") == [:tesla_mock_registered_ancestor]
+
+      assert Agent.get(pid, & &1).body == "registered ancestor works"
+    end
   end
 
   describe "without mock" do

--- a/test/tesla/multipart_test.exs
+++ b/test/tesla/multipart_test.exs
@@ -113,6 +113,16 @@ defmodule Tesla.MultipartTest do
         Multipart.new()
         |> Multipart.add_field("foo", "value", headers: [{"content-id\r\nX-Injected", "1"}])
       end
+
+      assert_raise ArgumentError, ~r/header name/, fn ->
+        Multipart.new()
+        |> Multipart.add_field("foo", "value", headers: [{"", "1"}])
+      end
+
+      assert_raise ArgumentError, ~r/header name/, fn ->
+        Multipart.new()
+        |> Multipart.add_field("foo", "value", headers: [{" content-id", "1"}])
+      end
     end
 
     test "add_field rejects CTL in header value" do
@@ -172,6 +182,22 @@ defmodule Tesla.MultipartTest do
       assert_raise ArgumentError, ~r/disposition value/, fn ->
         Multipart.new()
         |> Multipart.add_file_content("data", "evil\r\nX-Injected: pwned")
+      end
+    end
+
+    test "part_headers_for_disposition emits nothing without dispositions" do
+      assert Multipart.part_headers_for_disposition([]) == []
+    end
+
+    test "part_headers_for_disposition rejects CR or LF in a disposition value" do
+      assert_raise ArgumentError, ~r/must not contain CR or LF characters/, fn ->
+        Multipart.part_headers_for_disposition(name: "evil\r\nX-Injected: pwned")
+      end
+    end
+
+    test "part_headers_for_disposition rejects a double-quote in a disposition value" do
+      assert_raise ArgumentError, ~r/must not contain double-quote characters/, fn ->
+        Multipart.part_headers_for_disposition(name: ~s(ev"il))
       end
     end
   end

--- a/test/tesla_test.exs
+++ b/test/tesla_test.exs
@@ -47,6 +47,8 @@ defmodule TeslaTest do
       # clean config
       Application.delete_env(:tesla, EmptyClient)
       Application.delete_env(:tesla, ModuleAdapterClient)
+      Application.delete_env(:tesla, :adapter)
+      on_exit(fn -> Application.delete_env(:tesla, :adapter) end)
       :ok
     end
 
@@ -57,6 +59,21 @@ defmodule TeslaTest do
     test "use adapter override from config" do
       Application.put_env(:tesla, EmptyClient, adapter: Tesla.Mock)
       assert Tesla.effective_adapter(EmptyClient) == {Tesla.Mock, :call, [[]]}
+    end
+
+    test "use adapter override with options from config" do
+      Application.put_env(:tesla, EmptyClient, adapter: {Tesla.Mock, with: "someopt"})
+      assert Tesla.effective_adapter(EmptyClient) == {Tesla.Mock, :call, [[with: "someopt"]]}
+    end
+
+    test "fall back to the adapter configured for the application" do
+      Application.put_env(:tesla, :adapter, Tesla.Mock)
+      assert Tesla.effective_adapter(EmptyClient) == {Tesla.Mock, :call, [[]]}
+    end
+
+    test "fall back to the adapter with options configured for the application" do
+      Application.put_env(:tesla, :adapter, {Tesla.Mock, with: "someopt"})
+      assert Tesla.effective_adapter(EmptyClient) == {Tesla.Mock, :call, [[with: "someopt"]]}
     end
 
     test "prefer config over module setting" do
@@ -135,6 +152,27 @@ defmodule TeslaTest do
     test "execute middleware top down" do
       assert {:ok, response} = AppendClient.get("one")
       assert response.url == "one/1/MB1/MB2/MA2/MA1"
+    end
+
+    test "run an anonymous function middleware followed by the rest of the stack" do
+      middleware = fn env, next -> Tesla.run(%{env | url: env.url <> "/mw"}, next) end
+      adapter = fn env -> {:ok, %{env | url: env.url <> "/adapter"}} end
+
+      assert {:ok, env} =
+               Tesla.run(%Tesla.Env{url: "one"}, [{:fn, middleware}, {:fn, adapter}])
+
+      assert env.url == "one/mw/adapter"
+    end
+  end
+
+  describe "deprecated builders" do
+    test "build_adapter wraps a function into a client" do
+      adapter = fn env -> {:ok, %{env | body: "from adapter"}} end
+
+      client = apply(Tesla, :build_adapter, [adapter])
+
+      assert {:ok, env} = Tesla.get(client, "/")
+      assert env.body == "from adapter"
     end
   end
 


### PR DESCRIPTION
- Line coverage across `lib/` was 96.3%, and every uncovered line was a branch a caller can reach. An untested branch is a branch a regression can break silently, so the suite was not actually guarding them.
- The repository total is now 99.1%. Every remaining gap is a clause that cannot run against the dependency versions pinned here: gun 1.x compatibility fallbacks that the "Test (Gun 1)" job does exercise, a Finch pre-0.22 error shape, hackney 4.x, and a `{:data_error, _}` that OTP 24 through 28 never raise.
- Four clauses turned out to be unreachable rather than untested, so they were removed instead of being papered over with a test that could not exist:
  - `sem_conv.ex` had an `extract_port/1` clause for `scheme: "https"` with a non-integer port. `URI.parse/1` always fills the scheme default port, verified across eleven URL shapes including `https://host:/p`, `https://host:abc/p` and `https://host:-1/p`, all of which yield `443`.
  - `test.ex` had a catch-all `encode!/2`. Its only call site passes the literal `"application/json"`, and the two `application/json` clauses are total.
  - `mock.ex` had a `raise other` fallback in `agent_set/1`. `start_supervised/2` returns only `{:ok, pid}` or `{:error, {:already_started, pid}}` there, so the clause was both dead and latently broken: `raise` on a tuple raises `ArgumentError` about `raise/1` rather than the intended error.
  - The httpc adapter had a fallback for a multipart request without a content-type header. `Multipart.headers/1` always returns one, so `List.keytake/3` can never miss.
- Every new test was checked by mutation testing rather than by coverage alone. Coverage proves a line ran; it does not prove an assertion would notice if the line changed. Fifty two mutants were applied across the touched modules and all fifty two were caught, with one exception that was triaged as equivalent: deleting the `max_retries: 0` shortcut in `retry.ex` changes nothing observable, because `put_retry_count_opt/2` is already a no-op at `retries: 0`.
- Two of those mutants only died after the tests were rewritten, which is the point of running them: the httpc and ibrowse binary body tests passed while the adapter appended a trailing space, and the gun connection reuse tests passed while the scheme comparison was deleted outright.
