### PR TITLE
fix(httpc-adapter): let the multipart content type win over the request one

### DIFF
--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -82,14 +82,10 @@ defmodule Tesla.Adapter.Httpc do
   end
 
   defp request(method, url, headers, _content_type, %Multipart{} = mp, opts) do
-    headers = headers ++ Multipart.headers(mp)
+    headers = Multipart.headers(mp) ++ headers
     headers = for {key, value} <- headers, do: {to_charlist(key), to_charlist(value)}
 
-    {content_type, headers} =
-      case List.keytake(headers, ~c"content-type", 0) do
-        nil -> {~c"text/plain", headers}
-        {{_, ct}, headers} -> {ct, headers}
-      end
+    {{_, content_type}, headers} = List.keytake(headers, ~c"content-type", 0)
 
     body = stream_to_fun(Multipart.body(mp))
 

--- a/test/tesla/adapter/httpc_test.exs
+++ b/test/tesla/adapter/httpc_test.exs
@@ -30,6 +30,45 @@ defmodule Tesla.Adapter.HttpcTest do
     end
   end
 
+  test "Multipart content-type wins over a request supplied content-type" do
+    mp = Multipart.new() |> Multipart.add_field("field1", "foo")
+
+    env = %Env{
+      method: :post,
+      url: "#{@http}/post",
+      headers: [{"content-type", "application/json"}],
+      body: mp
+    }
+
+    assert {:ok, %Env{} = response} = call(env)
+    assert response.status == 200
+
+    {:ok, data} = Jason.decode(response.body)
+
+    assert data["headers"]["content-type"] == "multipart/form-data; boundary=#{mp.boundary}"
+    assert data["form"] == %{"field1" => "foo"}
+  end
+
+  test "Multipart content-type wins regardless of the request header casing" do
+    mp = Multipart.new() |> Multipart.add_field("field1", "foo")
+
+    env = %Env{
+      method: :post,
+      url: "#{@http}/post",
+      headers: [{"Content-Type", "application/json"}, {"x-keep", "yes"}],
+      body: mp
+    }
+
+    assert {:ok, %Env{} = response} = call(env)
+    assert response.status == 200
+
+    {:ok, data} = Jason.decode(response.body)
+
+    assert data["headers"]["content-type"] == "multipart/form-data; boundary=#{mp.boundary}"
+    assert data["headers"]["x-keep"] == "yes"
+    assert data["form"] == %{"field1" => "foo"}
+  end
+
   # see https://github.com/teamon/tesla/issues/147
   test "Set content-type for DELETE requests" do
     env = %Env{


### PR DESCRIPTION
- A `content-type` set on the request took precedence over the one `Tesla.Multipart` generates, and only that generated header carries the `boundary`. Without the boundary no server can frame the parts, so the body was unparseable.
- The failure was silent in the worst way: the request still came back `200`, with the entire payload discarded. Nothing in the response told the caller their fields never arrived. Every other adapter answers `415` for the same input, so `httpc` was alone in reporting success for a request that transmitted nothing.
- It also depended on header casing. A lowercase `content-type` triggered it, while `Content-Type` happened to work, which made the behavior look intermittent rather than broken.
- Callers who need to customize the multipart content type already have `Tesla.Multipart.add_content_type_param/2`, so nothing is lost by letting the generated header win.
- The `text/plain` fallback drops out with it. `Tesla.Multipart.headers/1` is a single clause that always returns a `content-type`, so the fallback was unreachable, and had it ever been reached it would have sent a multipart body labelled `text/plain` with no boundary at all.
