### PR TITLE
chore: close the remaining coverage gaps

### DIFF
--- a/lib/tesla/adapter/finch.ex
+++ b/lib/tesla/adapter/finch.ex
@@ -99,6 +99,8 @@ if Code.ensure_loaded?(Finch) do
       receive_timeout: 15_000
     ]
 
+    @finch_version :finch |> Application.spec(:vsn) |> to_string()
+
     @impl Tesla.Adapter
     def call(%Tesla.Env{} = env, opts) do
       opts = Tesla.Adapter.opts(@defaults, env, opts)
@@ -125,7 +127,11 @@ if Code.ensure_loaded?(Finch) do
     # the reasons callers matched on before, so the adapter behaves the same on both.
     defp unwrap_error(error) when is_struct(error, Finch.TransportError), do: error.reason
     defp unwrap_error(error) when is_struct(error, Finch.HTTPError), do: error.source || error
-    defp unwrap_error(%Mint.TransportError{reason: reason}), do: reason
+
+    if Version.match?(@finch_version, "< 0.22.0") do
+      defp unwrap_error(%Mint.TransportError{reason: reason}), do: reason
+    end
+
     defp unwrap_error(error), do: error
 
     defp build(method, url, headers, %Multipart{} = mp, opts) do
@@ -164,8 +170,12 @@ if Code.ensure_loaded?(Finch) do
         {:headers, headers}, status -> send(owner, {ref, {:status, status, headers}})
         {:data, data}, _acc -> send(owner, {ref, {:data, data}})
         {:trailers, trailers}, _acc -> trailers
-        # Handle errors passed to callback (e.g., proxy errors like {:proxy, {:unexpected_status, 403}})
+        # No released Finch hands an error to this callback, it reports one through the
+        # return value instead. Without these clauses such an entry would raise inside
+        # the task and the caller would see a timeout rather than the error.
+        # coveralls-ignore-next-line
         {:error, error}, _acc -> send(owner, {ref, {:error, error}})
+        # coveralls-ignore-next-line
         {:error, error, _}, _acc -> send(owner, {ref, {:error, error}})
       end
 
@@ -214,7 +224,6 @@ if Code.ensure_loaded?(Finch) do
       send(owner, {ref, :eof})
     end
 
-    @finch_version :finch |> Application.spec(:vsn) |> to_string()
     if Version.match?(@finch_version, ">= 0.20.0") do
       defp handle_stream_response({:error, error, _acc}, ref, owner) do
         send(owner, {ref, {:error, error}})

--- a/lib/tesla/adapter/gun.ex
+++ b/lib/tesla/adapter/gun.ex
@@ -240,18 +240,7 @@ if Code.ensure_loaded?(:gun) do
          when is_pid(conn) do
       info = :gun.info(conn)
 
-      conn_scheme =
-        case info do
-          # gun master branch support, which has `origin_scheme` in connection info
-          %{origin_scheme: scheme} ->
-            scheme
-
-          %{transport: :tls} ->
-            "https"
-
-          _ ->
-            "http"
-        end
+      conn_scheme = conn_scheme(info)
 
       conn_host =
         case :inet.ntoa(info.origin_host) do
@@ -368,11 +357,7 @@ if Code.ensure_loaded?(:gun) do
            {:ok, _} <- :gun.await_up(pid) do
         {:ok, pid}
       else
-        {:error, {:options, {:protocols, [:socks]}}} ->
-          {:error, "socks protocol is not supported"}
-
-        error ->
-          error
+        error -> socks_open_error(error)
       end
     end
 
@@ -390,11 +375,7 @@ if Code.ensure_loaded?(:gun) do
       with {:ok, pid} <- gun_open(host, uri.port, opts_with_master_keys, opts) do
         {:ok, pid}
       else
-        {:error, {:options, {key, _}}} when key in [:tcp_opts, :tls_opts] ->
-          gun_open(host, uri.port, Map.put(gun_opts, :transport_opts, tls_opts), opts)
-
-        error ->
-          error
+        error -> retry_open_conn(error, host, uri.port, gun_opts, tls_opts, opts)
       end
     end
 
@@ -462,12 +443,35 @@ if Code.ensure_loaded?(:gun) do
     defp reply_to(opts), do: opts[:reply_to] || self()
 
     if Application.spec(:gun, :vsn) |> List.to_string() |> Version.match?("~> 2.0") do
+      defp conn_scheme(%{origin_scheme: scheme}), do: scheme
+
+      defp socks_open_error(error), do: error
+
+      defp retry_open_conn(error, _host, _port, _gun_opts, _tls_opts, _opts), do: error
+
       defp wrap_reply_to(request_owner, stream_owner, original_reply_to) do
         fn message ->
           route_reply_message(request_owner, stream_owner, original_reply_to, message)
         end
       end
     else
+      # Gun 1 reports the scheme through the transport, it has no origin_scheme.
+      defp conn_scheme(%{transport: :tls}), do: "https"
+      defp conn_scheme(_info), do: "http"
+
+      defp socks_open_error({:error, {:options, {:protocols, [:socks]}}}),
+        do: {:error, "socks protocol is not supported"}
+
+      defp socks_open_error(error), do: error
+
+      # Gun 1 has no tcp_opts or tls_opts, it takes both as transport_opts.
+      defp retry_open_conn({:error, {:options, {key, _}}}, host, port, gun_opts, tls_opts, opts)
+           when key in [:tcp_opts, :tls_opts] do
+        gun_open(host, port, Map.put(gun_opts, :transport_opts, tls_opts), opts)
+      end
+
+      defp retry_open_conn(error, _host, _port, _gun_opts, _tls_opts, _opts), do: error
+
       defp wrap_reply_to(request_owner, stream_owner, original_reply_to) do
         spawn(fn ->
           request_owner_ref = Process.monitor(request_owner)
@@ -623,9 +627,13 @@ if Code.ensure_loaded?(:gun) do
         {:gun_error, ^pid, reason} ->
           {:error, reason}
 
+        # Gun 1 only. Gun 2 sends gun_down with five elements, so this never matches
+        # there. The Gun 1 CI job exercises it, and that job runs without coverage.
+        # coveralls-ignore-start
         {:gun_down, ^pid, _, _, _, _} when receive? ->
           read_response(pid, stream, opts)
 
+        # coveralls-ignore-stop
         {:DOWN, _, _, _, reason} ->
           {:error, reason}
       after

--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -35,6 +35,8 @@ if Code.ensure_loaded?(:hackney) do
     @behaviour Tesla.Adapter
     alias Tesla.Multipart
 
+    @hackney_version :hackney |> Application.spec(:vsn) |> to_string()
+
     # Hackney 1.x async/stream responses return a `reference()`, 4.x returns a `pid()`.
     defguardp is_hackney_ref(ref) when is_reference(ref) or is_pid(ref)
 
@@ -121,7 +123,10 @@ if Code.ensure_loaded?(:hackney) do
       end)
     end
 
-    defp handle({:connect_error, {:error, reason}}, _opts), do: {:error, reason}
+    if Version.match?(@hackney_version, "< 4.0.0") do
+      defp handle({:connect_error, {:error, reason}}, _opts), do: {:error, reason}
+    end
+
     defp handle({:error, _} = error, _opts), do: error
     defp handle({:ok, status, headers}, _opts), do: {:ok, status, headers, []}
 

--- a/lib/tesla/adapter/mint.ex
+++ b/lib/tesla/adapter/mint.ex
@@ -391,15 +391,8 @@ if Code.ensure_loaded?(Mint.HTTP) do
       stream_request_body(conn, ref, <<chunk>>, opts, acc)
     end
 
-    defp stream_request_body(conn, ref, chunk, opts, acc) when is_list(chunk) do
-      stream_request_body(conn, ref, IO.iodata_to_binary(chunk), opts, acc)
-    end
-
     defp stream_request_body(conn, ref, chunk, opts, acc) do
-      case HTTP.protocol(conn) do
-        :http2 -> stream_request_body(conn, ref, IO.iodata_to_binary(chunk), opts, acc)
-        _ -> send_body_chunk(conn, ref, chunk, opts, acc)
-      end
+      stream_request_body(conn, ref, IO.iodata_to_binary(chunk), opts, acc)
     end
 
     defp stream_request_body_chunk(conn, _ref, "", _opts, acc), do: {:ok, conn, acc}
@@ -502,9 +495,6 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
     defp reduce_response({:error, response_ref, error}, ref, _acc) when response_ref == ref,
       do: {:halt, {:error, error}}
-
-    defp reduce_response({:pong, response_ref}, ref, acc) when response_ref == ref,
-      do: {:cont, acc}
 
     defp reduce_response({:status, _other_ref, _code}, _ref, acc), do: {:cont, acc}
     defp reduce_response({:headers, _other_ref, _headers}, _ref, acc), do: {:cont, acc}

--- a/lib/tesla/middleware/compression.ex
+++ b/lib/tesla/middleware/compression.ex
@@ -205,9 +205,8 @@ defmodule Tesla.Middleware.Compression do
       :zlib.inflateEnd(z)
       result
     catch
-      :error, reason
-      when reason == :data_error or (is_tuple(reason) and elem(reason, 0) == :data_error) ->
-        reraise Error, [reason: {:zlib, reason}], __STACKTRACE__
+      :error, :data_error ->
+        reraise Error, [reason: {:zlib, :data_error}], __STACKTRACE__
     after
       :zlib.close(z)
     end

--- a/lib/tesla/middleware/compression.ex
+++ b/lib/tesla/middleware/compression.ex
@@ -205,10 +205,8 @@ defmodule Tesla.Middleware.Compression do
       :zlib.inflateEnd(z)
       result
     catch
-      :error, :data_error ->
-        reraise Error, [reason: {:zlib, :data_error}], __STACKTRACE__
-
-      :error, {:data_error, _} = reason ->
+      :error, reason
+      when reason == :data_error or (is_tuple(reason) and elem(reason, 0) == :data_error) ->
         reraise Error, [reason: {:zlib, reason}], __STACKTRACE__
     after
       :zlib.close(z)

--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -460,6 +460,28 @@ defmodule Tesla.Adapter.GunTest do
              call(request, timeout: 1_500, retry: 5, retry_timeout: 50)
   end
 
+  # Leaves the caller holding a response stream with nothing left to read and an
+  # empty mailbox, so a test can decide what the next chunk read finds there.
+  defp drained_response_stream do
+    uri = URI.parse(@http)
+    {:ok, conn} = :gun.open(to_charlist(uri.host), uri.port)
+    {:ok, _} = :gun.await_up(conn)
+    on_exit(fn -> Gun.close(conn) end)
+
+    request = %Env{
+      method: :get,
+      url: "#{@http}/stream-bytes/10"
+    }
+
+    assert {:ok, %Env{status: 200, body: stream}} =
+             call(request, body_as: :stream, conn: conn, close_conn: false, timeout: 100)
+
+    Process.sleep(200)
+    :ok = :gun.flush(conn)
+
+    stream
+  end
+
   defp start_raw_server(on_request, opts \\ []) do
     {:ok, listen_socket} =
       :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
@@ -571,23 +593,23 @@ defmodule Tesla.Adapter.GunTest do
   end
 
   test "raises when the response stream stops receiving chunks" do
-    uri = URI.parse(@http)
-    {:ok, conn} = :gun.open(to_charlist(uri.host), uri.port)
-    {:ok, _} = :gun.await_up(conn)
-    on_exit(fn -> Gun.close(conn) end)
-
-    request = %Env{
-      method: :get,
-      url: "#{@http}/stream-bytes/10"
-    }
-
-    assert {:ok, %Env{status: 200, body: stream}} =
-             call(request, body_as: :stream, conn: conn, close_conn: false, timeout: 100)
-
-    Process.sleep(200)
-    :ok = :gun.flush(conn)
+    stream = drained_response_stream()
 
     assert_raise RuntimeError, ":recv_chunk_timeout", fn -> Enum.join(stream) end
+  end
+
+  test "reraises the exception the response stream failed with" do
+    stream = drained_response_stream()
+    send(self(), {:DOWN, make_ref(), :process, self(), %RuntimeError{message: "connection died"}})
+
+    assert_raise RuntimeError, "connection died", fn -> Enum.join(stream) end
+  end
+
+  test "raises the message the response stream failed with" do
+    stream = drained_response_stream()
+    send(self(), {:DOWN, make_ref(), :process, self(), "connection died"})
+
+    assert_raise RuntimeError, "connection died", fn -> Enum.join(stream) end
   end
 
   test "reuses a connection opened to an ip address" do

--- a/test/tesla/middleware/compression_test.exs
+++ b/test/tesla/middleware/compression_test.exs
@@ -129,6 +129,57 @@ defmodule Tesla.Middleware.CompressionTest do
     end
   end
 
+  describe "zlib error contract" do
+    # The middleware catches :data_error as a bare atom. These pin that shape so a
+    # future OTP raising something else fails here instead of escaping the middleware.
+    test "empty gzip stream raises the bare atom" do
+      assert catch_zlib_error("", 47) == :data_error
+    end
+
+    test "garbage gzip stream raises the bare atom" do
+      assert catch_zlib_error("not gzip at all", 47) == :data_error
+    end
+
+    test "truncated gzip stream raises the bare atom" do
+      complete = :zlib.gzip("some body worth truncating")
+
+      assert catch_zlib_error(binary_part(complete, 0, byte_size(complete) - 5), 47) ==
+               :data_error
+    end
+
+    test "empty deflate stream raises the bare atom" do
+      assert catch_zlib_error("", 15) == :data_error
+    end
+
+    test "garbage deflate stream raises the bare atom" do
+      assert catch_zlib_error("not deflate at all", 15) == :data_error
+    end
+  end
+
+  test "surfaces the zlib reason on an undecompressable response" do
+    error =
+      assert_raise Tesla.Middleware.Compression.Error, fn ->
+        CompressionResponseClient.get("/response-empty")
+      end
+
+    assert error.reason == {:zlib, :data_error}
+  end
+
+  defp catch_zlib_error(body, window_bits) do
+    z = :zlib.open()
+
+    try do
+      :zlib.inflateInit(z, window_bits)
+      _ = :zlib.safeInflate(z, body)
+      :zlib.inflateEnd(z)
+      :no_error
+    catch
+      :error, reason -> reason
+    after
+      :zlib.close(z)
+    end
+  end
+
   test "updates existing content-length header" do
     expected_body = "decompressed gzip"
     assert {:ok, env} = CompressionResponseClient.get("/response-with-content-length")


### PR DESCRIPTION
- Lines no test could reach hid whether they were dead, wrong, or merely untested, so the coverage number said less than it appeared to.
- Some of those lines turned out to be provably redundant with a clause already covered, so keeping them meant carrying code no behavior depended on.
- Others only compile under a specific dependency version, and gating them makes that requirement explicit instead of leaving them looking permanently unreachable.
- Two clauses stay guarded because no released dependency version can reach them, and losing them would turn a reported error into a timeout.