### PR TITLE
chore: restore coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,17 @@ jobs:
       - name: Test
         run: mix test
 
+      # One entry reports, so the matrix does not post three times for one commit.
+      # Reporting never gates the job: excoveralls raises when the upload fails, and
+      # a Coveralls outage or a fork PR without secret access must not redden a build
+      # whose tests passed.
+      - name: Report coverage
+        if: matrix.versions.elixir == '1.19.0'
+        continue-on-error: true
+        run: mix coveralls.github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Coverage reporting reads the commit message of the pull request head,
+          # which is a parent of the merge commit checked out here.
+          fetch-depth: 2
 
       - name: Setup Elixir
         id: beam

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Hexdocs.pm](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/tesla/)
 [![Hex.pm](https://img.shields.io/hexpm/dt/tesla.svg)](https://hex.pm/packages/tesla)
 [![Hex.pm](https://img.shields.io/hexpm/dw/tesla.svg)](https://hex.pm/packages/tesla)
-[![codecov](https://codecov.io/gh/elixir-tesla/tesla/branch/master/graph/badge.svg)](https://codecov.io/gh/elixir-tesla/tesla)
+[![Coverage](https://coveralls.io/repos/github/elixir-tesla/tesla/badge.svg?branch=master)](https://coveralls.io/github/elixir-tesla/tesla?branch=master)
 
 `Tesla` is an HTTP client that leverages middleware to streamline HTTP requests
 and responses over a common interface for various adapters.

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,14 @@ defmodule Tesla.Mixfile do
   end
 
   def cli do
-    [preferred_envs: [coveralls: :test, "coveralls.html": :test]]
+    [
+      preferred_envs: [
+        coveralls: :test,
+        "coveralls.html": :test,
+        "coveralls.json": :test,
+        "coveralls.github": :test
+      ]
+    ]
   end
 
   def application do


### PR DESCRIPTION
- The coverage badge stopped reflecting reality when the project moved off Travis in 2021: that migration dropped the upload step and never replaced it, so nothing has reported coverage for about four years.
- Codecov has since deactivated the repository for inactivity, so the badge now points at a service that no longer has data for us. A badge that cannot go red reads as a passing signal, which is worse than showing nothing.
- Coveralls is the lowest-friction way back to a real number here, because the reporting tool is already a dependency and it authenticates with the built-in token rather than a secret someone has to provision and rotate.
- Reporting is deliberately kept off the critical path. The upload raises on failure, and neither a third-party outage nor a contributor working from a fork should be able to redden a build whose tests all passed.
- Only one matrix entry reports, so a single commit does not post three conflicting results.