### PR TITLE
chore: harden coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,11 @@ on:
       - master
   workflow_dispatch:
 
+# Coverage reporting forwards this token to a third party, so cap it here rather
+# than inheriting whatever the organisation default happens to be.
+permissions:
+  contents: read
+
 concurrency:
   group: CI ${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -125,7 +130,13 @@ jobs:
         run: mix compile --warnings-as-errors
 
       - name: Test
+        if: matrix.versions.elixir != '1.19.0'
         run: mix test
+
+      # Enforces :minimum_coverage, which the reporting task below does not check.
+      - name: Test and enforce coverage
+        if: matrix.versions.elixir == '1.19.0'
+        run: mix coveralls
 
       # One entry reports, so the matrix does not post three times for one commit.
       # Reporting never gates the job: excoveralls raises when the upload fails, and

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,5 +1,8 @@
 {
   "skip_files": [
     "test/support"
-  ]
+  ],
+  "coverage_options": {
+    "minimum_coverage": 100
+  }
 }

--- a/test/tesla/adapter/gun_test.exs
+++ b/test/tesla/adapter/gun_test.exs
@@ -482,6 +482,28 @@ defmodule Tesla.Adapter.GunTest do
     stream
   end
 
+  test "streams a chunked body that arrives in more than one part" do
+    url =
+      start_raw_server(fn socket ->
+        :gen_tcp.send(socket, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n")
+        Process.sleep(50)
+        :gen_tcp.send(socket, "5\r\nfirst\r\n")
+        Process.sleep(50)
+        :gen_tcp.send(socket, "6\r\nsecond\r\n")
+        Process.sleep(50)
+        :gen_tcp.send(socket, "0\r\n\r\n")
+        Process.sleep(50)
+        :gen_tcp.close(socket)
+      end)
+
+    request = %Env{method: :get, url: url}
+
+    assert {:ok, %Env{status: 200, body: stream}} =
+             call(request, body_as: :stream, timeout: 2_000)
+
+    assert Enum.join(stream) == "firstsecond"
+  end
+
   defp start_raw_server(on_request, opts \\ []) do
     {:ok, listen_socket} =
       :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])


### PR DESCRIPTION
- Coverage reporting forwards the workflow token to a third party, and the workflow pinned no permissions of its own. The token is read-only today only because that is the current organisation default, so a settings change elsewhere could widen what leaves the machine without anyone touching this repository.
- A badge cannot fail a build, so by itself it documents regressions rather than preventing them. A threshold turns the number into something that has to hold.
- The threshold is only safe to set at full coverage because the streamed multi-chunk path is no longer covered by accident. It previously depended on whether the test server happened to split a body across frames, which left real coverage just under the mark on some runs and would have made the gate flake rather than protect anything.
- The reporting task does not check the threshold itself, so the entry that reports now runs the reporter that does, keeping the cost the same as before.