### PR TITLE
feat: redact middleware and adapter options when inspecting Tesla.Client

### DIFF
--- a/guides/explanations/0.client.md
+++ b/guides/explanations/0.client.md
@@ -159,3 +159,27 @@ depends on your specific needs:
 Understanding these patterns helps you design applications and libraries that
 are flexible and maintainable, aligning with best practices in software
 development.
+
+## Inspecting a client
+
+Middleware options often contain secrets (an `Authorization` header passed
+to `Tesla.Middleware.Headers`, an API key in `Tesla.Middleware.Query`), and a
+`%Tesla.Env{}` carries its client as `__client__`. So `inspect/1` on a client
+or an env redacts middleware and adapter options by default and shows only
+the module names:
+
+```elixir
+iex> client = Tesla.client([{Tesla.Middleware.Headers, [{"authorization", "Bearer s3cret"}]}])
+iex> inspect(client)
+"#Tesla.Client<adapter: nil, middleware: [{Tesla.Middleware.Headers, :redacted}]>"
+```
+
+Opt back in to the full rendering while debugging:
+
+```elixir
+config :tesla, inspect: :full
+```
+
+`Tesla.Client.middleware/1` and `Tesla.Client.adapter/1` always return the
+full configuration for use from code.
+

--- a/lib/tesla/client.ex
+++ b/lib/tesla/client.ex
@@ -1,4 +1,31 @@
 defmodule Tesla.Client do
+  @moduledoc ~S"""
+  A client is the middleware stack and adapter a request runs through.
+
+  ## Inspecting a client
+
+  Middleware options routinely hold secrets: an `Authorization` header given
+  to `Tesla.Middleware.Headers`, an API key in `Tesla.Middleware.Query`, a
+  token in a custom middleware. Because `%Tesla.Env{}` embeds the client as
+  `__client__`, those values would otherwise appear whenever an env or a
+  client is passed to `inspect/1` — which is exactly what happens in the
+  common `Logger.error("request failed: #{inspect(env)}")` pattern.
+
+  For that reason `inspect/1` shows middleware and adapter *modules* but
+  redacts their options by default:
+
+      iex> client = Tesla.client([{Tesla.Middleware.Headers, [{"authorization", "Bearer s3cret"}]}, Tesla.Middleware.JSON])
+      iex> inspect(client)
+      "#Tesla.Client<adapter: nil, middleware: [{Tesla.Middleware.Headers, :redacted}, Tesla.Middleware.JSON]>"
+
+  To see the full options while debugging, opt in:
+
+      config :tesla, inspect: :full
+
+  The rendering is for humans; use `Tesla.Client.middleware/1` and
+  `Tesla.Client.adapter/1` to read a client's configuration from code.
+  """
+
   @type adapter :: module | {module, any} | (Tesla.Env.t() -> Tesla.Env.result())
   @type middleware :: module | {module, any}
 
@@ -156,4 +183,44 @@ defmodule Tesla.Client do
   defp unruntime({module, :call, [[]]}) when is_atom(module), do: module
   defp unruntime({module, :call, [opts]}) when is_atom(module), do: {module, opts}
   defp unruntime({:fn, fun}) when is_function(fun), do: fun
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%Tesla.Client{} = client, opts) do
+      mode = Application.get_env(:tesla, :inspect, :redacted)
+
+      fields =
+        [adapter: adapter_entry(client, mode), middleware: middleware_entries(client.pre, mode)] ++
+          post_entries(client.post, mode)
+
+      container_doc("#Tesla.Client<", fields, ">", opts, &field_doc/2,
+        separator: ",",
+        break: :strict
+      )
+    end
+
+    defp field_doc({key, value}, opts),
+      do: concat([Atom.to_string(key), ": ", to_doc(value, opts)])
+
+    defp adapter_entry(%{adapter: nil}, _mode), do: nil
+    defp adapter_entry(client, :full), do: Tesla.Client.adapter(client)
+    defp adapter_entry(%{adapter: adapter}, _redacted), do: redact(adapter)
+
+    defp middleware_entries(stack, :full), do: unruntime(stack)
+    defp middleware_entries(stack, _redacted), do: Enum.map(stack, &redact/1)
+
+    defp post_entries([], _mode), do: []
+    defp post_entries(stack, mode), do: [post: middleware_entries(stack, mode)]
+
+    defp redact({module, :call, [[]]}) when is_atom(module), do: module
+    defp redact({module, :call, [_opts]}) when is_atom(module), do: {module, :redacted}
+    defp redact({:fn, fun}) when is_function(fun), do: :fn
+    defp redact(_other), do: :redacted
+
+    defp unruntime(stack) when is_list(stack), do: Enum.map(stack, &unruntime/1)
+    defp unruntime({module, :call, [[]]}) when is_atom(module), do: module
+    defp unruntime({module, :call, [opts]}) when is_atom(module), do: {module, opts}
+    defp unruntime({:fn, fun}) when is_function(fun), do: fun
+  end
 end

--- a/lib/tesla/client.ex
+++ b/lib/tesla/client.ex
@@ -187,12 +187,17 @@ defmodule Tesla.Client do
   defimpl Inspect do
     import Inspect.Algebra
 
+    # Renders from the public user-form (`adapter/1`, `middleware/1`) rather
+    # than the runtime stack, so this stays correct if the internal
+    # representation changes.
     def inspect(%Tesla.Client{} = client, opts) do
       mode = Application.get_env(:tesla, :inspect, :redacted)
 
       fields =
-        [adapter: adapter_entry(client, mode), middleware: middleware_entries(client.pre, mode)] ++
-          post_entries(client.post, mode)
+        [
+          adapter: render(Tesla.Client.adapter(client), mode),
+          middleware: render_stack(Tesla.Client.middleware(client), mode)
+        ] ++ post_entries(client, mode)
 
       container_doc("#Tesla.Client<", fields, ">", opts, &field_doc/2,
         separator: ",",
@@ -203,24 +208,16 @@ defmodule Tesla.Client do
     defp field_doc({key, value}, opts),
       do: concat([Atom.to_string(key), ": ", to_doc(value, opts)])
 
-    defp adapter_entry(%{adapter: nil}, _mode), do: nil
-    defp adapter_entry(client, :full), do: Tesla.Client.adapter(client)
-    defp adapter_entry(%{adapter: adapter}, _redacted), do: redact(adapter)
+    defp post_entries(%Tesla.Client{post: []}, _mode), do: []
 
-    defp middleware_entries(stack, :full), do: unruntime(stack)
-    defp middleware_entries(stack, _redacted), do: Enum.map(stack, &redact/1)
+    defp post_entries(%Tesla.Client{post: post}, mode),
+      do: [post: render_stack(Tesla.Client.middleware(%Tesla.Client{pre: post}), mode)]
 
-    defp post_entries([], _mode), do: []
-    defp post_entries(stack, mode), do: [post: middleware_entries(stack, mode)]
+    defp render_stack(entries, mode), do: Enum.map(entries, &render(&1, mode))
 
-    defp redact({module, :call, [[]]}) when is_atom(module), do: module
-    defp redact({module, :call, [_opts]}) when is_atom(module), do: {module, :redacted}
-    defp redact({:fn, fun}) when is_function(fun), do: :fn
-    defp redact(_other), do: :redacted
-
-    defp unruntime(stack) when is_list(stack), do: Enum.map(stack, &unruntime/1)
-    defp unruntime({module, :call, [[]]}) when is_atom(module), do: module
-    defp unruntime({module, :call, [opts]}) when is_atom(module), do: {module, opts}
-    defp unruntime({:fn, fun}) when is_function(fun), do: fun
+    defp render(entry, :full), do: entry
+    defp render({module, _opts}, _redacted) when is_atom(module), do: {module, :redacted}
+    defp render(module, _redacted) when is_atom(module), do: module
+    defp render(fun, _redacted) when is_function(fun), do: :fn
   end
 end

--- a/test/tesla/client_test.exs
+++ b/test/tesla/client_test.exs
@@ -340,9 +340,10 @@ defmodule Tesla.ClientTest do
       try do
         fun.()
       after
-        if previous,
-          do: Application.put_env(:tesla, :inspect, previous),
-          else: Application.delete_env(:tesla, :inspect)
+        case previous do
+          nil -> Application.delete_env(:tesla, :inspect)
+          value -> Application.put_env(:tesla, :inspect, value)
+        end
       end
     end
 

--- a/test/tesla/client_test.exs
+++ b/test/tesla/client_test.exs
@@ -317,4 +317,86 @@ defmodule Tesla.ClientTest do
       assert middlewares == Client.middleware(client)
     end
   end
+
+  describe "Inspect" do
+    @secret "Bearer s3cret-token"
+
+    defp secret_client do
+      Tesla.client(
+        [
+          {Tesla.Middleware.BaseUrl, "https://api.example.com"},
+          {Tesla.Middleware.Headers, [{"authorization", @secret}]},
+          Tesla.Middleware.JSON,
+          fn env, next -> Tesla.run(env, next) end
+        ],
+        {Tesla.Adapter.Httpc, [recv_timeout: 30_000]}
+      )
+    end
+
+    defp with_inspect_mode(mode, fun) do
+      previous = Application.get_env(:tesla, :inspect)
+      Application.put_env(:tesla, :inspect, mode)
+
+      try do
+        fun.()
+      after
+        if previous,
+          do: Application.put_env(:tesla, :inspect, previous),
+          else: Application.delete_env(:tesla, :inspect)
+      end
+    end
+
+    test "redacts middleware and adapter options by default, keeping module names" do
+      printed = inspect(secret_client())
+
+      refute printed =~ @secret
+      refute printed =~ "api.example.com"
+      refute printed =~ "recv_timeout"
+      assert printed =~ "#Tesla.Client<"
+      assert printed =~ "{Tesla.Middleware.BaseUrl, :redacted}"
+      assert printed =~ "{Tesla.Middleware.Headers, :redacted}"
+      assert printed =~ "Tesla.Middleware.JSON"
+      assert printed =~ ":fn"
+      assert printed =~ "adapter: {Tesla.Adapter.Httpc, :redacted}"
+    end
+
+    test "an env that embeds the client does not print the client's secrets" do
+      client = Tesla.client([{Tesla.Middleware.Headers, [{"authorization", @secret}]}])
+
+      env = %Tesla.Env{
+        method: :get,
+        url: "https://api.example.com/",
+        status: 500,
+        __client__: client
+      }
+
+      printed = inspect(env)
+
+      refute printed =~ @secret
+      assert printed =~ "__client__: #Tesla.Client<"
+    end
+
+    test "config :tesla, inspect: :full shows the options in their original form" do
+      with_inspect_mode(:full, fn ->
+        printed = inspect(secret_client())
+
+        assert printed =~ @secret
+        assert printed =~ ~s({Tesla.Middleware.BaseUrl, "https://api.example.com"})
+        assert printed =~ "adapter: {Tesla.Adapter.Httpc, [recv_timeout: 30000]}"
+      end)
+    end
+
+    test "renders an empty client" do
+      assert inspect(%Tesla.Client{}) == "#Tesla.Client<adapter: nil, middleware: []>"
+    end
+
+    test "shows post middleware only when present" do
+      client = %Tesla.Client{
+        secret_client()
+        | post: [{Tesla.Middleware.Logger, :call, [[level: :debug]]}]
+      }
+
+      assert inspect(client) =~ "post: [{Tesla.Middleware.Logger, :redacted}]"
+    end
+  end
 end


### PR DESCRIPTION
## Problem

A `%Tesla.Client{}` carries every middleware together with its options, and a `%Tesla.Env{}` embeds the client as `__client__`. Both use the default `Inspect`, so this:

```elixir
client = Tesla.client([{Tesla.Middleware.Headers, [{"authorization", "Bearer s3cret"}]}])
{:ok, env} = Tesla.get(client, "/users")
Logger.error("request failed: #{inspect(env)}")
```

writes `Bearer s3cret` to the log. The same applies to an API key in `Tesla.Middleware.Query`, credentials in a custom middleware, or adapter options. The `Logger.error("...#{inspect(env)}")` pattern is common in error handling, so this tends to surface as a credential in a production log aggregator rather than in a debugging session. We found it that way in a service that wraps a third-party API client built on Tesla: the provider API key appeared in the logs on every non-2xx response.

## Change

An `Inspect` implementation for `Tesla.Client` that shows middleware and adapter **modules** but redacts their **options** by default:

```elixir
iex> client = Tesla.client([{Tesla.Middleware.Headers, [{"authorization", "Bearer s3cret"}]}, Tesla.Middleware.JSON])
iex> inspect(client)
"#Tesla.Client<adapter: nil, middleware: [{Tesla.Middleware.Headers, :redacted}, Tesla.Middleware.JSON]>"
```

- Middleware with options render as `{Module, :redacted}`; middleware without options render as the bare module; function middleware/adapters render as `:fn`.
- `post` middleware is shown only when present.
- Because `__client__` is rendered through this implementation, `inspect(env)` no longer prints the client's secrets either.
- Opt back in to the full rendering for debugging with `config :tesla, inspect: :full`. This follows the existing `Application.get_env(:tesla, ...)` convention used for the adapter and the Logger middleware.
- `Tesla.Client.middleware/1` and `Tesla.Client.adapter/1` are unchanged and remain the programmatic way to read a client's configuration.

Docs: a `@moduledoc` for `Tesla.Client` (it had none) and a short "Inspecting a client" section in `guides/explanations/0.client.md`.

## Why redact by default rather than opt in

`inspect/1` output is not a stable API and nothing in Tesla parses it. The leak is silent and lands in the place people look least (production logs), so the safer default seems right, with the previous rendering one config line away. Happy to flip it to opt-in if you'd prefer to keep current behaviour as the default.

## Not covered here

Request headers on the env itself (`env.headers`) still print when an env is inspected before or after a request, since they are legitimately part of the env. Redacting those is a bigger behavioural question (which headers, and whether `Tesla.Middleware.Logger`'s `:filter_headers` should be shared with it), so I've kept this PR to the client, which is where the configuration secrets live.

## Tests

`test/tesla/client_test.exs` gains an `Inspect` describe block: defaults redact header values, base URL and adapter options while keeping module names; an env embedding the client does not print the client's secrets; `inspect: :full` restores the original forms; empty client; `post` middleware. Doctests in the new moduledoc run via the existing `doctest Tesla.Client`.

```
mix test test/tesla/client_test.exs   9 doctests, 39 tests, 0 failures
mix test (non-adapter suites)         15 doctests, 700 tests, 0 failures
mix format --check-formatted          clean
```